### PR TITLE
Add backwards compatibility with sinusoidal grid frequencies

### DIFF
--- a/makani/models/preprocessor_helpers.py
+++ b/makani/models/preprocessor_helpers.py
@@ -97,12 +97,19 @@ def get_static_features(params):
             if gridtype == "sinusoidal":
                 num_freq = params.get("grid_num_frequencies", 1)
 
+                add_cos = params.get("add_cos_to_grid", True)
                 singrid = None
                 for freq in range(1, num_freq + 1):
                     if singrid is None:
-                        singrid = [torch.sin(grid), torch.cos(grid)]
+                        if add_cos:
+                            singrid =[torch.sin(grid), torch.cos(grid)]
+                        else:
+                            singrid = [torch.sin(grid)]
                     else:
-                        singrid = singrid + [torch.sin(freq * grid), torch.cos(freq * grid)]
+                        if add_cos:
+                            singrid = singrid + [torch.sin(freq * grid), torch.cos(freq * grid)]
+                        else:
+                            singrid = singrid + [torch.sin(freq * grid)]
 
                 static_features = torch.cat(singrid, dim=-3)
             else:


### PR DESCRIPTION
Preparing for makani v0.2 lead to the following change in the preprocessor utilities that add sinusoidal grid frequencies:

it went from

```python
singrid = None
for freq in range(1, num_freq + 1):
    if singrid is None:
        singrid = torch.sin(grid)
    else:
        singrid = torch.cat([singrid, torch.sin(freq * grid)], dim=1)

static_features = singrid
```

to

```python
singrid = None
for freq in range(1, num_freq + 1):
    if singrid is None:
        singrid = [torch.sin(grid), torch.cos(grid)]
    else:
        singrid = singrid + [torch.sin(freq * grid), torch.cos(freq * grid)]
static_features = torch.cat(singrid, dim=-3)
```

This present MR allows users to set `params.add_cos_to_grid = False` for backwards compatibility (True is the default, so any present user needs not make any change).