### PR TITLE
Fix syntax error in climatology script

### DIFF
--- a/data_process/generate_wb2_climatology.py
+++ b/data_process/generate_wb2_climatology.py
@@ -264,7 +264,7 @@ def generate_wb2_climatology(metadata_file: str, input_climatology: str, mask_ou
 
 
 def main(args):
-    generate_wb2_climatology(args.metadata_file, args.input_climatology, args.mask_output_file, args.climatology_output_file, verbose=args.verbose))
+    generate_wb2_climatology(args.metadata_file, args.input_climatology, args.mask_output_file, args.climatology_output_file, verbose=args.verbose)
 
     return
 


### PR DESCRIPTION
Fix a syntax error in the script for converting WeatherBench2 climatology to makani HDF5 format.