### PR TITLE
Fixing and updating classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 classifiers = [
-    "Development Status :: Alpha",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Mainly its the development status which is not a valid classifier, can potentially cause install issues if the install attempts to build wheel meta data.

https://pypi.org/classifiers/