### PR TITLE
Silence warning about GCS credentials

### DIFF
--- a/data_process/convert_wb2_to_makani_input.py
+++ b/data_process/convert_wb2_to_makani_input.py
@@ -27,7 +27,7 @@ import xarray as xr
 # MPI
 from mpi4py import MPI
 
-from .wb2_helpers import surface_variables, atmospheric_variables, split_convert_channel_names, DistributedProgressBar
+from .wb2_helpers import surface_variables, atmospheric_variables, split_convert_channel_names, DistributedProgressBar, gcs_storage_options
 
 
 def convert(input_file: str, output_dir: str, metadata_file: str, years: List[int],
@@ -99,13 +99,7 @@ def convert(input_file: str, output_dir: str, metadata_file: str, years: List[in
     atmospheric_channel_names, atmospheric_channel_names_wb2, surface_channel_names, surface_channel_names_wb2, atmospheric_levels = split_convert_channel_names(channel_names)
 
     # open cloud dataset
-    if input_file.startswith(("gs://", "gcs://")):
-        # Allow configuration of GCS authentication via environment variable.
-        # If GCS_TOKEN is unset, rely on the default gcsfs/xarray authentication behavior.
-        gcs_token = os.getenv("GCS_TOKEN", "anon")
-        storage_options = {"token": gcs_token} if gcs_token is not None else {}
-    else:
-        storage_options = {}
+    storage_options = gcs_storage_options() if input_file.startswith(("gs://", "gcs://")) else {}
     wb2_data = xr.open_dataset(input_file, engine="zarr", storage_options=storage_options)
 
     # check total number of entries:

--- a/data_process/generate_wb2_climatology.py
+++ b/data_process/generate_wb2_climatology.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 
 from mpi4py import MPI
 
-from .wb2_helpers import split_convert_channel_names
+from .wb2_helpers import split_convert_channel_names, gcs_storage_options
 
 
 def generate_wb2_climatology(metadata_file: str, input_climatology: str, mask_output_file: str, climatology_output_file: str,
@@ -83,13 +83,7 @@ def generate_wb2_climatology(metadata_file: str, input_climatology: str, mask_ou
     atmospheric_channel_names, atmospheric_channel_names_wb2, surface_channel_names, surface_channel_names_wb2, atmospheric_levels = split_convert_channel_names(channel_names)
     
     # open zarr file and load the above_ground mask:
-    if input_climatology.startswith(("gs://", "gcs://")):
-        # Allow configuration of GCS authentication via environment variable.
-        # If GCS_TOKEN is unset, rely on the default gcsfs/xarray authentication behavior.
-        gcs_token = os.getenv("GCS_TOKEN", "anon")
-        storage_options = {"token": gcs_token} if gcs_token is not None else {}
-    else:
-        storage_options = {}
+    storage_options = gcs_storage_options() if input_climatology.startswith(("gs://", "gcs://")) else {}
     clim = xr.open_zarr(input_climatology, storage_options=storage_options)
 
     # above ground data, only relevant levels

--- a/data_process/wb2_helpers.py
+++ b/data_process/wb2_helpers.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from makani.utils.features import get_channel_groups
 
+
 # variable translation
 surface_variables = {
     "u10m" : "10m_u_component_of_wind",
@@ -45,8 +46,19 @@ atmospheric_variables = {
     "q": "specific_humidity",
 }
 
+
+def gcs_storage_options():
+    """Return gcsfs storage options with anonymous access token if no ADC found."""
+    try:
+        import google.auth
+        google.auth.default()
+        return {}
+    except Exception:
+        return {"token": "anon"}
+
+
 def split_convert_channel_names(makani_channel_names):
-    
+
     # split in surface and atmospheric channels
     atmospheric_channel_indices, surface_channel_indices, _, atmospheric_levels = get_channel_groups(makani_channel_names)
 
@@ -55,11 +67,11 @@ def split_convert_channel_names(makani_channel_names):
     pat = re.compile(r"^(.*?)\d{1,}$")
     atmospheric_channel_names = sorted(list(set([pat.match(c).groups()[0] for c in atmospheric_channel_names])))
     atmospheric_channel_names_wb2 = [atmospheric_variables[c] for c in atmospheric_channel_names]
-    
+
     # surface
     surface_channel_names = sorted([makani_channel_names[k] for k in surface_channel_indices])
     surface_channel_names_wb2 = [surface_variables[c] for c in surface_channel_names]
-    
+
     # levels
     atmospheric_levels = sorted(list(atmospheric_levels))
 


### PR DESCRIPTION
Small PR to silence warnings about missing GCS credentials. In addition to silencing warnings when no credentials are present, I have found that on Brev/GCP machines with default credentials, this is actually required to be able to pull WB2 data.