### PR TITLE
Update imports for cross-version PNM compatibility

### DIFF
--- a/makani/models/networks/fourcastnet3.py
+++ b/makani/models/networks/fourcastnet3.py
@@ -41,7 +41,7 @@ from makani.utils import comm
 # for annotation of models
 from dataclasses import dataclass
 import physicsnemo
-from physicsnemo.models.meta import ModelMetaData
+from physicsnemo import ModelMetaData
 
 # heuristic for finding theta_cutoff
 def _compute_cutoff_radius(nlat, kernel_shape, basis_type):

--- a/makani/models/networks/sfnonet.py
+++ b/makani/models/networks/sfnonet.py
@@ -46,7 +46,7 @@ from makani.mpu.layer_norm import DistributedInstanceNorm2d, DistributedLayerNor
 # for annotation of models
 from dataclasses import dataclass
 import physicsnemo
-from physicsnemo.models.meta import ModelMetaData
+from physicsnemo import ModelMetaData
 
 
 class SpectralFilterLayer(nn.Module):


### PR DESCRIPTION
Updates the `ModelMetaData` import to work in either physicsnemo<2.0.0 or physicsnemo>=2.0.0. This should allow us to support FCN3 and SFNO in earth2studio with no conflicts. Model tests pass locally for me in either PNM version.

I also tried running the distributed tests but they failed with errors relating to torch-harmonics typing of the autograd functions. I believe it's totally unrelated to PNM, maybe those tests need updating?
```
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft1_0 - TypeError: fft_rfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft1_1 - TypeError: fft_rfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft2_3_0 - TypeError: fft_rfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft2_3_1 - TypeError: fft_rfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft2_3_2 - TypeError: fft_rfft2(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_fft2_3_3 - TypeError: fft_rfft2(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft1_0 - TypeError: fft_irfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft1_1 - TypeError: fft_irfft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_azimuth
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft2_3_0 - TypeError: fft_ifft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_polar
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft2_3_1 - TypeError: fft_ifft(): argument 'input' (position 1) must be Tensor, not distributed_transpose_polar
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft2_3_2 - TypeError: fft_ifft2(): argument 'input' (position 1) must be Tensor, not distributed_transpose_polar
FAILED tests/distributed/tests_distributed_fft.py::TestDistributedRealFFT::test_distributed_ifft2_3_3 - TypeError: fft_ifft2(): argument 'input' (position 1) must be Tensor, not distributed_transpose_polar
```