### PR TITLE
Fix data_process scripts: import, progressbar init and bounds

### DIFF
--- a/data_process/convert_wb2_to_makani_input.py
+++ b/data_process/convert_wb2_to_makani_input.py
@@ -28,7 +28,8 @@ import xarray as xr
 # MPI
 from mpi4py import MPI
 
-from wb2_helpers import split_convert_channel_names, DistributedProgressBar, gcs_storage_options
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from data_process.wb2_helpers import split_convert_channel_names, DistributedProgressBar, gcs_storage_options
 
 
 def convert(input_file: str, output_dir: str, metadata_file: str, years: List[int],

--- a/data_process/convert_wb2_to_makani_input.py
+++ b/data_process/convert_wb2_to_makani_input.py
@@ -28,7 +28,7 @@ import xarray as xr
 # MPI
 from mpi4py import MPI
 
-from .wb2_helpers import split_convert_channel_names, DistributedProgressBar, gcs_storage_options
+from wb2_helpers import split_convert_channel_names, DistributedProgressBar, gcs_storage_options
 
 
 def convert(input_file: str, output_dir: str, metadata_file: str, years: List[int],

--- a/data_process/wb2_helpers.py
+++ b/data_process/wb2_helpers.py
@@ -95,6 +95,7 @@ class DistributedProgressBar(object):
         if self.comm.Get_rank() == 0:
             # set up pbar
             self.pbar = progressbar.ProgressBar(maxval=num_entries)
+            self.pbar.start()
         self.reset()
 
     def __del__(self):
@@ -125,4 +126,4 @@ class DistributedProgressBar(object):
     def update_progress(self):
         if self.comm.Get_rank() == 0:
             count = self.get_counter()
-            self.pbar.update(count)
+            self.pbar.update(min(count, self.pbar.maxval))


### PR DESCRIPTION
- Use absolute import for wb2_helpers in convert_wb2_to_makani_input.py since the documented invocation is direct script execution (python script.py), not module execution (python -m), which breaks relative imports.

- Call progressbar.start() before update() as required by progressbar2 API.

- Clamp progress count to maxval to prevent ValueError in distributed settings where aggregated count can momentarily exceed the total.