### PR TITLE
Tkurth/improved state handling

### DIFF
--- a/makani/models/noise.py
+++ b/makani/models/noise.py
@@ -81,8 +81,40 @@ class BaseNoiseS2(nn.Module):
         # generator objects:
         self.set_rng(seed=seed)
 
-        # store the noise state: initialize to None
-        self.register_buffer("state", torch.zeros((batch_size, self.num_time_steps, self.num_channels, self.lmax_local, self.mmax_local, 2), dtype=torch.float32), persistent=False)
+        # allocate the state buffer via the centralized helper; subclasses customize the
+        # per-batch shape by overriding _state_shape_suffix.
+        self._ensure_state(batch_size, device=torch.device("cpu"), dtype=torch.float32)
+
+    @property
+    def _state_shape_suffix(self):
+        """
+        Shape of the state buffer beyond the batch dim. Subclasses override this to
+        customize the layout (e.g. DummyNoiseS2 stores state in spatial, not spectral, form).
+        """
+        return (self.num_time_steps, self.num_channels, self.lmax_local, self.mmax_local, 2)
+
+    def _ensure_state(self, batch_size, device=None, dtype=None):
+        """
+        Single source of truth for (re)allocating ``self.state``.
+
+        This is the only method that (re-)registers the state buffer. Calling it with
+        the same shape as the current state is a no-op; calling it with a different
+        batch size re-registers the buffer so buffer semantics (``.to(device)``,
+        ``state_dict`` membership via ``_buffers``, etc.) are preserved rather than
+        relying on the ``__setattr__`` hook.
+        """
+        if device is None:
+            device = self.state.device if ("state" in self._buffers) else torch.device("cpu")
+        if dtype is None:
+            dtype = self.state.dtype if ("state" in self._buffers) else torch.float32
+
+        target_shape = (batch_size,) + tuple(self._state_shape_suffix)
+        if ("state" not in self._buffers) or (tuple(self.state.shape) != target_shape):
+            self.register_buffer(
+                "state",
+                torch.zeros(target_shape, dtype=dtype, device=device),
+                persistent=False,
+            )
 
     def is_stateful(self):
         raise NotImplementedError("is_stateful method not implemented for this noise class")
@@ -96,23 +128,19 @@ class BaseNoiseS2(nn.Module):
 
     # Resets the internal state. Can be used to change the batch size if required.
     def reset(self, batch_size=None):
-        if self.state is not None:
-
-            if batch_size is not None:
-                self.state = torch.zeros(batch_size, self.num_time_steps, self.num_channels, self.lmax_local, self.mmax_local, 2, dtype=self.state.dtype, device=self.state.device)
-
-            with torch.no_grad():
-                self.state.fill_(0.0)
+        if batch_size is not None:
+            self._ensure_state(batch_size)
+        with torch.no_grad():
+            self.state.zero_()
 
     # this routine generates a noise sample for a single time step and updates the state accordingly, by appending the last time step
     def update(self, replace_state=False, batch_size=None):
-        # Update should always create a new state, so
-        # we don't need to check for replace_state
-        # create single occurence
+
+        if batch_size is not None:
+            self._ensure_state(batch_size)
+
         with torch.no_grad():
-            if batch_size is None:
-                batch_size = self.state.shape[0]
-            newstate = torch.empty((batch_size, self.num_time_steps, self.num_channels, self.lmax_local, self.mmax_local, 2), dtype=self.state.dtype, device=self.state.device)
+            newstate = torch.empty_like(self.state)
             if self.state.is_cuda:
                 newstate.normal_(mean=0.0, std=1.0, generator=self.rng_gpu)
             else:
@@ -121,10 +149,7 @@ class BaseNoiseS2(nn.Module):
             if self.reflect:
                 newstate = -newstate
 
-            if newstate.shape == self.state.shape:
-                self.state.copy_(newstate)
-            else:
-                self.state = newstate
+            self.state.copy_(newstate)
 
         return
 
@@ -148,6 +173,22 @@ class BaseNoiseS2(nn.Module):
         return self.state.detach().clone()
 
     def set_tensor_state(self, newstate):
+        # Validate the state layout (everything beyond the batch dim) matches this
+        # noise module's expected suffix BEFORE touching `self.state`. Only the batch
+        # dim may differ — it is auto-resized via `_ensure_state`. Any other
+        # difference raises `ValueError` up-front with a useful message instead of
+        # silently mutating the state into a bad shape and failing at `copy_()`.
+        expected_suffix = tuple(self._state_shape_suffix)
+        actual_suffix = tuple(newstate.shape[1:]) if newstate.dim() >= 1 else tuple(newstate.shape)
+        if actual_suffix != expected_suffix:
+            raise ValueError(
+                f"set_tensor_state: shape mismatch beyond batch dim. "
+                f"Expected suffix {expected_suffix}, got {actual_suffix} "
+                f"(full newstate.shape={tuple(newstate.shape)}, "
+                f"current state.shape={tuple(self.state.shape)})."
+            )
+        if tuple(newstate.shape) != tuple(self.state.shape):
+            self._ensure_state(newstate.shape[0])
         with torch.no_grad():
             self.state.copy_(newstate)
         return
@@ -368,8 +409,7 @@ class DiffusionNoiseS2(BaseNoiseS2):
             self.register_buffer("phi", phi, persistent=False)
             self.register_buffer("sigma_l", sigma_l, persistent=False)
 
-        # store the noise state: initialize to None
-        self.register_buffer("state", torch.zeros((batch_size, self.num_time_steps, self.num_channels, self.lmax_local, self.mmax_local, 2), dtype=torch.float32), persistent=False)
+        # state buffer is already allocated by BaseNoiseS2.__init__ via _ensure_state
 
         # if num_time_steps > 1, we need the toeplitz matrix for the discounts:
         #            [    1,     0,   0, 0]
@@ -397,14 +437,20 @@ class DiffusionNoiseS2(BaseNoiseS2):
     # this routine generates a noise sample for a single time step and updates the state accordingly, by appending the last time step
     @override
     def update(self, replace_state=False, batch_size=None):
+        if batch_size is not None:
+            self._ensure_state(batch_size)
 
-        # create single occurence
         with torch.no_grad():
             with amp.autocast(device_type=self.state.device.type, enabled=False):
-                nsteps = self.num_time_steps if replace_state else 1
-                if batch_size is None:
-                    batch_size = self.state.shape[0]
-                eta_l = torch.empty((batch_size, nsteps, self.num_channels, self.lmax_local, self.mmax_local, 2), dtype=torch.float32, device=self.state.device)
+                # draw either the full T-step history (replace) or a single step (AR)
+                if replace_state:
+                    eta_l = torch.empty_like(self.state)
+                else:
+                    B = self.state.shape[0]
+                    eta_l = torch.empty(
+                        (B, 1, self.num_channels, self.lmax_local, self.mmax_local, 2),
+                        dtype=self.state.dtype, device=self.state.device,
+                    )
                 if self.state.is_cuda:
                     eta_l.normal_(mean=0.0, std=1.0, generator=self.rng_gpu)
                 else:
@@ -421,8 +467,8 @@ class DiffusionNoiseS2(BaseNoiseS2):
                     # update previous state
                     if self.num_time_steps > 1:
                         last_state = self.state[:, -1, ...].unsqueeze(1)
-                        newstate = self.phi * last_state + eta_l
-                        newstate = torch.cat([self.state[:, 1:, ...], newstate], dim=1)
+                        newstep = self.phi * last_state + eta_l
+                        newstate = torch.cat([self.state[:, 1:, ...], newstep], dim=1)
                     else:
                         newstate = self.phi * self.state + eta_l
                 else:
@@ -433,11 +479,8 @@ class DiffusionNoiseS2(BaseNoiseS2):
                     if self.num_time_steps > 1:
                         newstate = torch.einsum("ctr,brclmu->btclmu", self.discount, newstate).contiguous()
 
-                # update the state
-                if newstate.shape == self.state.shape:
-                    self.state.copy_(newstate)
-                else:
-                    self.state = newstate
+                # shape matches self.state after _ensure_state above
+                self.state.copy_(newstate)
 
         return
 
@@ -521,8 +564,9 @@ class DummyNoiseS2(BaseNoiseS2):
         self.mode = mode
 
         # BaseNoiseS2.__init__ sets up nlat/nlon, comm splits, rng_cpu/rng_gpu, and
-        # registers a spectral state buffer. We replace the state buffer below with
-        # a spatial one of the correct shape.
+        # allocates the state buffer via _ensure_state. The shape is picked up through
+        # our override of _state_shape_suffix below, which gives a spatial (H, W)
+        # layout instead of the spectral (L, M, 2) default.
         super().__init__(
             img_shape=img_shape,
             batch_size=batch_size,
@@ -531,42 +575,22 @@ class DummyNoiseS2(BaseNoiseS2):
             seed=seed,
         )
 
-        # Replace the spectral state buffer (lmax, mmax, 2) with a spatial one (H, W).
-        self.register_buffer(
-            "state",
-            torch.zeros(
-                (batch_size, self.num_time_steps, self.num_channels, self.nlat_local, self.nlon_local),
-                dtype=torch.float32,
-            ),
-            persistent=False,
-        )
+    @property
+    def _state_shape_suffix(self):
+        # spatial (H, W) rather than spectral (L, M, 2)
+        return (self.num_time_steps, self.num_channels, self.nlat_local, self.nlon_local)
 
     @override
     def is_stateful(self):
         return False
 
     @override
-    def reset(self, batch_size=None):
-        if self.state is not None:
-            if batch_size is not None:
-                self.state = torch.zeros(
-                    batch_size, self.num_time_steps, self.num_channels,
-                    self.nlat_local, self.nlon_local,
-                    dtype=self.state.dtype, device=self.state.device,
-                )
-            with torch.no_grad():
-                self.state.fill_(0.0)
-
-    @override
     def update(self, replace_state=False, batch_size=None):
+        if batch_size is not None:
+            self._ensure_state(batch_size)
 
         with torch.no_grad():
-            if batch_size is None:
-                batch_size = self.state.shape[0]
-            newstate = torch.empty(
-                (batch_size, self.num_time_steps, self.num_channels, self.nlat_local, self.nlon_local),
-                dtype=self.state.dtype, device=self.state.device,
-            )
+            newstate = torch.empty_like(self.state)
 
             if self.mode == "constant_zero":
                 newstate.zero_()
@@ -576,10 +600,7 @@ class DummyNoiseS2(BaseNoiseS2):
                 else:
                     newstate.normal_(mean=0.0, std=1.0, generator=self.rng_cpu)
 
-            if newstate.shape == self.state.shape:
-                self.state.copy_(newstate)
-            else:
-                self.state = newstate
+            self.state.copy_(newstate)
 
         return
 

--- a/makani/models/preprocessor.py
+++ b/makani/models/preprocessor.py
@@ -181,6 +181,12 @@ class Preprocessor2D(nn.Module):
     def expand_history(self, x, nhist):
         if x.dim() == 4:
             b_, ct_, h_, w_ = x.shape
+            if ct_ % nhist != 0:
+                raise ValueError(
+                    f"expand_history: channel dim {ct_} is not divisible by nhist={nhist}. "
+                    f"The flattened-history input may not match the preprocessor's expected "
+                    f"n_history={self.n_history} (so ct_ should be a multiple of n_history+1={nhist})."
+                )
             x = torch.reshape(x, (b_, nhist, ct_ // nhist, h_, w_))
         return x
 
@@ -243,6 +249,16 @@ class Preprocessor2D(nn.Module):
         # x-dimension
         xdim = x.dim()
 
+        # Batch alignment between input and cached unpredicted features.
+        # If these diverge, the `cat` below would fail with a cryptic message —
+        # raise up-front with context about the likely cause.
+        if x.shape[0] != xc.shape[0]:
+            raise ValueError(
+                f"_append_channels: batch mismatch between input ({x.shape[0]}) and "
+                f"cached unpredicted features ({xc.shape[0]}). "
+                f"Did you cache xz/yz at a different batch size than the current forward?"
+            )
+
         # expand history
         x = self.expand_history(x, self.n_history + 1)
         xc = self.expand_history(xc, self.n_history + 1)
@@ -250,6 +266,13 @@ class Preprocessor2D(nn.Module):
         # this routine also adds noise every time a channel gets appended
         if hasattr(self, "input_noise"):
             n = self.input_noise()
+            if n.shape[0] != x.shape[0]:
+                raise ValueError(
+                    f"_append_channels: batch mismatch between input_noise state "
+                    f"({n.shape[0]}) and input ({x.shape[0]}). "
+                    f"Did you call update_internal_state(batch_size=...) at a different "
+                    f"batch than the current forward pass?"
+                )
             if self.input_noise_mode == "concatenate":
                 xc = torch.cat([xc, n], dim=2)
             elif self.input_noise_mode == "perturb":
@@ -371,27 +394,33 @@ class Preprocessor2D(nn.Module):
 
         return x
 
+    def _ensure_cached(self, name: str, tensor):
+        """
+        Centralized rebind for the cached unpredicted-feature attributes.
+
+        - tensor is None: the cached attribute is cleared to None.
+        - current is None or has a different shape: store a fresh clone.
+        - shapes match: in-place ``copy_`` to reuse the existing memory.
+
+        These are plain attributes (not registered buffers): they are per-step scratch
+        populated from dataloader output on-device, and should not appear in ``state_dict``.
+        """
+        current = getattr(self, name)
+        if tensor is None:
+            setattr(self, name, None)
+            return
+        if (current is not None) and (current.shape == tensor.shape):
+            current.copy_(tensor)
+        else:
+            setattr(self, name, tensor.clone())
+
     def cache_unpredicted_features(self, x, y, xz=None, yz=None):
         if self.training:
-            if (self.unpredicted_inp_train is not None) and (xz is not None) and (self.unpredicted_inp_train.shape == xz.shape):
-                self.unpredicted_inp_train.copy_(xz)
-            else:
-                self.unpredicted_inp_train = xz.clone() if xz is not None else None
-
-            if (self.unpredicted_tar_train is not None) and (yz is not None) and (self.unpredicted_tar_train.shape == yz.shape):
-                self.unpredicted_tar_train.copy_(yz)
-            else:
-                self.unpredicted_tar_train = yz.clone() if yz is not None else None
+            self._ensure_cached("unpredicted_inp_train", xz)
+            self._ensure_cached("unpredicted_tar_train", yz)
         else:
-            if (self.unpredicted_inp_eval is not None) and (xz is not None) and (self.unpredicted_inp_eval.shape == xz.shape):
-                self.unpredicted_inp_eval.copy_(xz)
-            else:
-                self.unpredicted_inp_eval = xz.clone() if xz is not None else None
-
-            if (self.unpredicted_tar_eval is not None) and (yz is not None) and (self.unpredicted_tar_eval.shape == yz.shape):
-                self.unpredicted_tar_eval.copy_(yz)
-            else:
-                self.unpredicted_tar_eval = yz.clone() if yz is not None else None
+            self._ensure_cached("unpredicted_inp_eval", xz)
+            self._ensure_cached("unpredicted_tar_eval", yz)
 
         return x, y
 

--- a/makani/models/preprocessor.py
+++ b/makani/models/preprocessor.py
@@ -343,9 +343,36 @@ class Preprocessor2D(nn.Module):
 
         return
 
+    def _check_history_stats(self, x, caller: str):
+        """
+        Controlled-fail validation for history normalization paths.
+
+        - Raises RuntimeError if stats haven't been computed yet (caller forgot
+          history_compute_stats before normalize/denormalize).
+        - Raises ValueError if the input batch doesn't match the stats batch,
+          which in the mean/exponential modes is the only shape dim that isn't a
+          broadcast singleton. Common cause: stats were computed on one batch and
+          normalize/denormalize is being invoked on a differently-sized input
+          without a fresh history_compute_stats call.
+        """
+        if self.history_mean is None or self.history_std is None:
+            raise RuntimeError(
+                f"{caller}: history_mean / history_std are None. "
+                f"Call history_compute_stats(x) before {caller} (mode='{self.history_normalization_mode}')."
+            )
+        stats_batch = self.history_mean.shape[0]
+        if stats_batch != x.shape[0]:
+            raise ValueError(
+                f"{caller}: batch mismatch between input ({x.shape[0]}) and cached "
+                f"history stats ({stats_batch}). Did you forget to call "
+                f"history_compute_stats on the current input before {caller}?"
+            )
+
     def history_normalize(self, x, target=False):
         if self.history_normalization_mode in ["none", "timediff"]:
             return x
+
+        self._check_history_stats(x, caller="history_normalize")
 
         xdim = x.dim()
         if xdim == 5:
@@ -371,8 +398,7 @@ class Preprocessor2D(nn.Module):
         if self.history_normalization_mode in ["none", "timediff"]:
             return xn
 
-        assert self.history_mean is not None
-        assert self.history_std is not None
+        self._check_history_stats(xn, caller="history_denormalize")
 
         xndim = xn.dim()
         if xndim == 5:

--- a/makani/models/stochastic_interpolant.py
+++ b/makani/models/stochastic_interpolant.py
@@ -356,7 +356,13 @@ class StochasticInterpolantWrapper(nn.Module):
         return x
 
     def forward(self, inp, tar=None, n_samples=1, n_steps=1):
-        self.preprocessor.update_internal_state(replace_state=True)
+        # Keep both noise sources sized to the current input batch so callers that
+        # fold an ensemble dim into the batch (e.g. stochastic_trainer.validate_one_epoch)
+        # can hand us a (B*E, ...) input without any state-resize plumbing of their own.
+        # Drawing a fresh stationary state here also means the very first noise read
+        # inside _forward_train / _forward_eval sees a non-trivial sample.
+        self.preprocessor.update_internal_state(replace_state=True, batch_size=inp.shape[0])
+        self.noise_module.update(replace_state=True, batch_size=inp.shape[0])
         if self.training:
             return self._forward_train(inp, tar, n_samples=n_samples)
         else:

--- a/makani/utils/dataloaders/dali_es_helper_2d.py
+++ b/makani/utils/dataloaders/dali_es_helper_2d.py
@@ -210,6 +210,21 @@ class GeneralES(object):
         else:
             self.indices_select = self.indices_full.copy()
 
+        # Data is read per-year from a single file, so the full (n_history,
+        # n_future) window must sit inside one year.  Drop any index whose
+        # window would cross a year boundary; otherwise __call__ would have
+        # to clamp and silently return duplicate samples.
+        year_offsets_arr = np.asarray(self.year_offsets)
+        n_samples_year_arr = np.asarray(self.n_samples_year)
+        year_idx = np.searchsorted(year_offsets_arr, self.indices_select, side="right") - 1
+        local_idx = self.indices_select - year_offsets_arr[year_idx]
+        year_lengths = n_samples_year_arr[year_idx]
+        window_ok = (
+            (local_idx >= self.dt * self.n_history) &
+            (local_idx + self.dt * (self.n_future + 1) <= year_lengths - 1)
+        )
+        self.indices_select = self.indices_select[window_ok]
+
     def _reorder_channels(self, inp, tar):
         # reorder data if requested:
 	# inp
@@ -630,10 +645,6 @@ class GeneralES(object):
         # determine local and sample idx
         sample_idx = self.index_permutation[cycle_sample_idx]
         local_idx, year_idx = self._get_local_year_index_from_global_index(sample_idx)
-
-        # if we are not at least self.dt*n_history timesteps into the prediction
-        local_idx = max(local_idx, self.dt * self.n_history)
-        local_idx = min(local_idx, self.n_samples_year[year_idx] - self.dt * (self.n_future + 1) - 1)
 
         if self.files[year_idx] is None:
 

--- a/makani/utils/dataloaders/data_loader_dummy.py
+++ b/makani/utils/dataloaders/data_loader_dummy.py
@@ -36,6 +36,19 @@ from .data_helpers import get_lat_lon_grid
 
 
 class DummyLoader(object):
+    """Synthetic dataloader for model-perf benchmarking.
+
+    Unlike conventional dataloaders, ``DummyLoader`` pre-allocates its output
+    tensors on the device passed via the ``device`` kwarg and returns the same
+    tensors on every iteration. This is intentional — for benchmarking model
+    throughput, it avoids the per-batch CPU→device transfer cost that would
+    otherwise dominate the timing. Pass ``device=torch.device("cpu")`` for
+    testing or for a more conventional dataloader-like behavior.
+
+    For multi-GPU runs the caller is responsible for passing the rank-specific
+    device (e.g. ``cuda:<local_rank>``); the loader does not infer it.
+    """
+
     def __init__(self,
                  location: str,
                  batch_size: int,
@@ -96,12 +109,7 @@ class DummyLoader(object):
 
         self._get_files_stats()
 
-        # set lat_lon
-        if self.lat_lon is None:
-            latitude, longitude = get_lat_lon_grid(self.img_shape)
-            self.lat_lon = (latitude.tolist(), longitude.tolist())
-
-        # get local lat lon
+        # get local lat lon (overrides the read_anchor-based slice from _get_files_stats)
         self.lat_lon_local = (self.lat_lon[0][self.crop_anchor[0] : self.crop_anchor[0] + self.crop_shape[0]], self.lat_lon[1][self.crop_anchor[1] : self.crop_anchor[1] + self.crop_shape[1]])
 
         # zenith angle yes or no?
@@ -109,12 +117,12 @@ class DummyLoader(object):
         if self.add_zenith:
             self.zen_dummy = torch.zeros((self.batch_size, self.n_history + 1, 1, self.return_shape[0], self.return_shape[1]), dtype=torch.float32, device=self.device)
 
-        # grid types
+        # grid types (lat_lon_local may be a list if auto-created; coerce to tensor)
         self.grid_converter = GridConverter(
             data_grid_type,
             model_grid_type,
-            torch.deg2rad(self.lat_lon_local[0]).to(torch.float32),
-            torch.deg2rad(self.lat_lon_local[1]).to(torch.float32),
+            torch.deg2rad(torch.as_tensor(self.lat_lon_local[0])).to(torch.float32),
+            torch.deg2rad(torch.as_tensor(self.lat_lon_local[1])).to(torch.float32),
         )
 
     def _get_files_stats(self):
@@ -205,6 +213,12 @@ class DummyLoader(object):
         self.img_shape_x_resampled = self.img_shape_resampled[0]
         self.img_shape_y_resampled = self.img_shape_resampled[1]
 
+        # auto-create lat/lon if the caller didn't supply them
+        # (matches the pattern used by GeneralES and GeneralConcatES)
+        if self.lat_lon is None:
+            latitude, longitude = get_lat_lon_grid(self.img_shape)
+            self.lat_lon = (latitude.tolist(), longitude.tolist())
+
         # lat lon coords
         self.lat_lon_local = (self.lat_lon[0][self.read_anchor[0] : self.read_anchor[0] + self.read_shape[0]], self.lat_lon[1][self.read_anchor[1] : self.read_anchor[1] + self.read_shape[1]])
 
@@ -220,8 +234,7 @@ class DummyLoader(object):
         logging.info(f"Including {self.dhours*self.dt*self.n_history} hours of past history in training at a frequency of {self.dhours*self.dt} hours")
         logging.info("WARNING: using dummy data")
 
-        # create tensors for dummy data
-        self.device = torch.device(f"cuda:{comm.get_local_rank()}")
+        # create tensors for dummy data on the device passed at construction time
         self.inp = torch.zeros((self.batch_size, self.n_history + 1, self.n_in_channels, self.return_shape[0], self.return_shape[1]), dtype=torch.float32, device=self.device)
         self.tar = torch.zeros(
             (self.batch_size, self.n_future + 1, self.n_out_channels_local, self.return_shape[0], self.return_shape[1]), dtype=torch.float32, device=self.device

--- a/makani/utils/functions.py
+++ b/makani/utils/functions.py
@@ -22,3 +22,24 @@ def relative_error(tensor1, tensor2):
 # this computes an absolute error compatible with torch.allclose or np.allclose
 def absolute_error(tensor1, tensor2):
     return torch.max(torch.abs(tensor1-tensor2))
+
+
+def expand_ensemble(x: torch.Tensor, ensemble_size: int) -> torch.Tensor:
+    """
+    Replicate each element of ``x`` along a new ensemble dim, then flatten that dim
+    into the batch dim: ``(B, ...) -> (B*E, ...)``.
+
+    Layout is batch-major: the E consecutive entries at positions ``b*E .. b*E+E-1``
+    all correspond to the original batch element ``x[b]``. This pairs with a
+    symmetric ``pred_flat.reshape(B, E, ...)`` on the model output so a single forward
+    on the folded batch produces independent ensemble samples per input.
+
+    ``ensemble_size <= 1`` returns ``x`` unchanged (no allocation).
+    """
+    if ensemble_size <= 1:
+        return x
+    return (
+        x.unsqueeze(1)
+         .repeat_interleave(ensemble_size, dim=1)
+         .reshape(x.shape[0] * ensemble_size, *x.shape[1:])
+    )

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -573,10 +573,7 @@ class Inferencer(Driver):
                         self.preprocessor.update_internal_state(replace_state=True, batch_size=inp.shape[0])
 
                         if rollout_buffer is not None:
-                            if E > 1:
-                                inpt_viz = inp.reshape(B, E, *inp.shape[1:])
-                            else:
-                                inpt_viz = inp.unsqueeze(1)
+                            inpt_viz = inp.reshape(B, E, *inp.shape[1:])
                             rollout_buffer.update(inpt_viz, tinp[:, 0], idt=idte)
 
                     else:
@@ -603,10 +600,7 @@ class Inferencer(Driver):
                             inp = self.preprocessor.append_history(inp, pred_flat, 0, update_state=True)
 
                             # reshape back to (B, E, ...) for downstream metrics / loss / buffers
-                            if E > 1:
-                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
-                            else:
-                                pred = pred_flat.unsqueeze(1)
+                            pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
                             # set weight to None here, since I am not sure what to do for spectral components
                             # in spectral CRPS

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -26,6 +26,7 @@ import torch.utils.data as tud
 
 from makani.utils.driver import Driver
 from makani.utils import LossHandler, MetricsHandler
+from makani.utils.functions import expand_ensemble
 from makani.utils.dataloader import get_dataloader
 from makani.utils.dataloaders.data_loader_multifiles import MultifilesDataset
 from makani.utils.dataloaders.data_helpers import get_date_from_timestamp, get_data_normalization, get_climatology
@@ -564,15 +565,9 @@ class Inferencer(Driver):
                         inp_raw = self.preprocessor.flatten_history(inp_raw)
                         B = inp_raw.shape[0]
 
-                        if E > 1:
-                            inp = inp_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp_raw.shape[1:])
-                            if inpz_raw is not None:
-                                inpz = inpz_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inpz_raw.shape[1:])
-                            else:
-                                inpz = None
-                        else:
-                            inp = inp_raw
-                            inpz = inpz_raw
+                        # fold the ensemble dim into the batch dim (no-op when E==1)
+                        inp = expand_ensemble(inp_raw, E)
+                        inpz = expand_ensemble(inpz_raw, E) if inpz_raw is not None else None
 
                         # reset noise state at the folded batch for this episode
                         self.preprocessor.update_internal_state(replace_state=True, batch_size=inp.shape[0])
@@ -594,10 +589,7 @@ class Inferencer(Driver):
                         targ = self.preprocessor.flatten_history(tar)
 
                         # expand target-side zenith to the folded batch for caching
-                        if tarz_raw is not None and E > 1:
-                            tarz = tarz_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *tarz_raw.shape[1:])
-                        else:
-                            tarz = tarz_raw
+                        tarz = expand_ensemble(tarz_raw, E) if tarz_raw is not None else None
 
                         # set unpredicted features at (B*E, ...) shape to match the folded-batch inp
                         self.preprocessor.cache_unpredicted_features(None, None, inpz, tarz)

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -442,14 +442,6 @@ class Inferencer(Driver):
 
         return logs
 
-    def _initialize_noise_states(self, seed_offset=666):
-        noise_states = []
-        for ide in range(self.params.local_ensemble_size):
-            member_seed = seed_offset + self.preprocessor.get_base_seed(default=333) * ide
-            self.preprocessor.set_rng(seed=member_seed, reset=True)
-            noise_states.append(self.preprocessor.get_internal_state(tensor=True))
-        return noise_states
-
     def _inference_indexlist(
         self,
         indices: Union[List[int], torch.Tensor],
@@ -512,9 +504,12 @@ class Inferencer(Driver):
             climatology_iterator = iter(self.climatology_dataloader)
 
         # create loader for the full epoch
-        noise_states = self._initialize_noise_states()
-        inptlist = None
+        inp = None        # folded-batch input carried across rollout steps, shape (B*E, C', H, W)
+        inpz = None       # input zenith expanded to (B*E, ...) if add_zenith
+        tinp = None       # input timestamp (unexpanded, shape (B, ...)) kept for date logging / rollout buffer
+        B = None          # unexpanded batch size captured at episode start
         idt = 0
+        E = self.params.local_ensemble_size
         with torch.inference_mode():
             with torch.no_grad():
                 for token in tqdm(subset_dataloader, desc="Inference progress", disable=not self.log_to_screen):
@@ -527,7 +522,7 @@ class Inferencer(Driver):
                         torch.cuda.nvtx.range_push(f"inference step {idt}, rollout step {idte}")
 
                     # move input to GPU
-                    gtoken = map(lambda x: x.to(self.device), token)
+                    gtoken = list(map(lambda x: x.to(self.device), token))
 
                     # get mask
                     if self.mask_dataset is not None:
@@ -552,78 +547,75 @@ class Inferencer(Driver):
                         clims = None
 
                     if idte == 0:
-                        # use the input
+                        # episode start: a new initial condition.
+                        # The ensemble dim is folded into the batch dim for the whole rollout
+                        # (shape (B*E, ...) going into the model). Noise state is reset once
+                        # here and then evolves via AR updates during the rollout.
                         if self.params.add_zenith:
-                            inp, inpz, tinp = gtoken
+                            inp_raw, inpz_raw, tinp = gtoken
                         else:
-                            inp, tinp = gtoken
-                            inpz = None
+                            inp_raw, tinp = gtoken
+                            inpz_raw = None
 
                         dates = date_fn(tinp.flatten().detach().cpu()).tolist()
                         datestring = ", ".join([d.strftime("%Y-%m-%dT%H:%M:%S") for d in dates])
                         print(f"inferencing dates: {datestring}")
 
-                        inp = self.preprocessor.flatten_history(inp)
+                        inp_raw = self.preprocessor.flatten_history(inp_raw)
+                        B = inp_raw.shape[0]
 
-                        # set the batch size
+                        if E > 1:
+                            inp = inp_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp_raw.shape[1:])
+                            if inpz_raw is not None:
+                                inpz = inpz_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inpz_raw.shape[1:])
+                            else:
+                                inpz = None
+                        else:
+                            inp = inp_raw
+                            inpz = inpz_raw
+
+                        # reset noise state at the folded batch for this episode
                         self.preprocessor.update_internal_state(replace_state=True, batch_size=inp.shape[0])
 
-                        # reset noise states and input list
-                        noise_states = self._initialize_noise_states(seed_offset=idt)
-                        inptlist = [inp.clone() for _ in range(self.params.local_ensemble_size)]
-
                         if rollout_buffer is not None:
-                            inpt = torch.stack(inptlist, dim=1)
-                            rollout_buffer.update(inpt, tinp[:, 0], idt=idte)
+                            if E > 1:
+                                inpt_viz = inp.reshape(B, E, *inp.shape[1:])
+                            else:
+                                inpt_viz = inp.unsqueeze(1)
+                            rollout_buffer.update(inpt_viz, tinp[:, 0], idt=idte)
 
                     else:
-                        # use this as target
+                        # rollout step
                         if self.params.add_zenith:
-                            tar, tarz, ttar = gtoken
+                            tar, tarz_raw, ttar = gtoken
                         else:
                             tar, ttar = gtoken
-                            tarz = None
+                            tarz_raw = None
                         targ = self.preprocessor.flatten_history(tar)
 
-                        # set unpredicted
+                        # expand target-side zenith to the folded batch for caching
+                        if tarz_raw is not None and E > 1:
+                            tarz = tarz_raw.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *tarz_raw.shape[1:])
+                        else:
+                            tarz = tarz_raw
+
+                        # set unpredicted features at (B*E, ...) shape to match the folded-batch inp
                         self.preprocessor.cache_unpredicted_features(None, None, inpz, tarz)
 
-                        # do predictions
-                        predlist = []
                         with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
-                            for e in range(self.params.local_ensemble_size):
+                            # single forward on the folded batch; noise does an AR update
+                            # (replace_state=False) before being consumed this step
+                            pred_flat = self.model(inp, update_state=True, replace_state=False)
 
-                                if torch.cuda.is_available() and (self.params.local_ensemble_size > 1):
-                                    torch.cuda.nvtx.range_push(f"ensemble step {e}")
+                            # advance the input history / unpredicted features once per step
+                            inp = self.preprocessor.append_history(inp, pred_flat, 0, update_state=True)
 
-                                # retrieve input
-                                inpt = inptlist[e]
+                            # reshape back to (B, E, ...) for downstream metrics / loss / buffers
+                            if E > 1:
+                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
+                            else:
+                                pred = pred_flat.unsqueeze(1)
 
-                                # restore noise state
-                                if (self.params.local_ensemble_size > 1):
-                                    self.preprocessor.set_internal_state(noise_states[e])
-
-                                    # forward pass: never replace state since we do that manually
-                                    pred = self.model(inpt, update_state=(idte!=0), replace_state=False)
-
-                                    # store new state
-                                    noise_states[e] = self.preprocessor.get_internal_state(tensor=True)
-                                else:
-                                    # forward pass: replace state if this is the first step of the rollout
-                                    pred = self.model(inpt, update_state=True, replace_state=(idte==0))
-
-                                # concatenate predictions
-                                predlist.append(pred)
-
-                                # append input to prediction and get the new unpredicted features. idt is 0 here as there is always only one target
-                                last_member = e == self.params.local_ensemble_size - 1
-                                inptlist[e] = self.preprocessor.append_history(inpt, pred, 0, update_state=last_member)
-
-                                if torch.cuda.is_available() and (self.params.local_ensemble_size > 1):
-                                    torch.cuda.nvtx.range_pop()
-
-                            # concatenate
-                            pred = torch.stack(predlist, dim=1)
                             # set weight to None here, since I am not sure what to do for spectral components
                             # in spectral CRPS
                             loss = self.loss_obj(pred, targ, None)
@@ -631,7 +623,7 @@ class Inferencer(Driver):
                             if rollout_buffer is not None:
                                 rollout_buffer.update(pred, ttar[:, 0], idt=idte)
 
-                        # reset zenith angles
+                        # swap zenith/timestamp for the next rollout step
                         inpz = tarz
                         tinp = ttar
 

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -465,6 +465,7 @@ class EnsembleTrainer(Trainer):
 
         pred_flat = self.model_train(inp_flat, update_state=False)
 
+        # unflatten
         pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
         loss = self.loss_obj(pred, tar, inp=inp)
@@ -693,7 +694,7 @@ class EnsembleTrainer(Trainer):
                             # reshape back to (B, E, ...) for the loss
                             pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
-                            loss = self.loss_obj(pred, targ)
+                            loss = self.loss_obj(pred, targ, None)
 
                             # log the loss
                             progress_bar.set_postfix({"loss": loss.item()})

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -443,17 +443,35 @@ class EnsembleTrainer(Trainer):
         return
 
     def _ensemble_step(self, inp: torch.Tensor, tar: torch.Tensor):
-        predlist = []
-        for _ in range(self.params.local_ensemble_size):
-            # forward pass
-            pred = self.model_train(inp)
-            # store prediction
-            predlist.append(pred)
+        """
+        Single forward on a folded batch of size (B*E, ...).
 
-        # stack predictions along new dim (ensemble dim):
-        pred = torch.stack(predlist, dim=1)
-        # compute loss
-        loss = self.loss_obj(pred, tar, inp=inp)
+        The ensemble dim is carried explicitly as dim 1 through unsqueeze+repeat_interleave,
+        then flattened into dim 0 just for the model forward; the prediction reshapes back
+        to (B, E, ...) for the loss. Noise is drawn once at the folded batch so each
+        (batch, ensemble member) pair sees an independent sample.
+        """
+        E = self.params.local_ensemble_size
+        B = inp.shape[0]
+
+        if E > 1:
+            # (B, C, H, W) -> (B, 1, C, H, W) -> (B, E, C, H, W) -> (B*E, C, H, W)
+            inp_flat = inp.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp.shape[1:])
+        else:
+            inp_flat = inp
+
+        # pre-adjust the preprocessor's noise state to the folded batch; the model is then
+        # called with update_state=False so it consumes this fresh state directly.
+        self.preprocessor.update_internal_state(replace_state=True, batch_size=inp_flat.shape[0])
+
+        pred_flat = self.model_train(inp_flat, update_state=False)
+
+        if E > 1:
+            pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
+        else:
+            pred = pred_flat.unsqueeze(1)
+
+        loss = self.loss_obj(pred, tar)
 
         return pred, loss
 
@@ -480,8 +498,20 @@ class EnsembleTrainer(Trainer):
 
             torch.cuda.nvtx.range_push(f"train step {train_steps}")
 
-            # map to device
-            gdata = map(lambda x: x.to(self.device), data)
+            # map to device; materialize to list so we can expand zenith features
+            gdata = [x.to(self.device) for x in data]
+
+            # When training with local_ensemble_size > 1 we fold the ensemble dim into the
+            # batch dim for a single forward pass. The cached unpredicted features (xz, yz)
+            # must therefore also carry an ensemble-expanded batch so shapes line up inside
+            # the preprocessor. x is expanded inside _ensemble_step (to preserve `inp.shape[0]`
+            # semantics below); y stays at its original batch since the loss expects (B, E, ...)
+            # pred vs (B, ...) target.
+            E = self.params.local_ensemble_size
+            if E > 1 and len(gdata) == 4:
+                B_xz = gdata[2].shape[0]
+                gdata[2] = gdata[2].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[2].shape[1:])
+                gdata[3] = gdata[3].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[3].shape[1:])
 
             # do preprocessing
             inp, tar = self.preprocessor.cache_unpredicted_features(*gdata)
@@ -585,13 +615,6 @@ class EnsembleTrainer(Trainer):
 
         return train_time, total_data_gb, logs
 
-    def _initialize_noise_states(self):
-        noise_states = []
-        for _ in range(self.params.local_ensemble_size):
-            self.preprocessor.update_internal_state(replace_state=True)
-            noise_states.append(self.preprocessor.get_internal_state(tensor=True))
-        return noise_states
-
     def validate_one_epoch(self, epoch, profiler=None):
         # set to eval
         self._set_eval()
@@ -625,21 +648,35 @@ class EnsembleTrainer(Trainer):
                     if torch.cuda.is_available():
                         torch.cuda.nvtx.range_push(f"eval step {eval_steps}")
 
-                    # map to gpu
-                    gdata = map(lambda x: x.to(self.device), data)
+                    # map to gpu; materialize to list so we can expand zenith features
+                    gdata = [x.to(self.device) for x in data]
+
+                    # When local_ensemble_size > 1, fold the ensemble dim into the batch dim
+                    # for a single forward pass per rollout step. The zenith features (xz, yz)
+                    # must be expanded so they line up with the folded-batch input; the target
+                    # (y) stays at the original batch — the loss expects (B, E, ...) pred against
+                    # (B, ...) target.
+                    E = self.params.local_ensemble_size
+                    if E > 1 and len(gdata) == 4:
+                        B_xz = gdata[2].shape[0]
+                        gdata[2] = gdata[2].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[2].shape[1:])
+                        gdata[3] = gdata[3].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[3].shape[1:])
 
                     # preprocess
                     inp, tar = self.preprocessor.cache_unpredicted_features(*gdata)
                     inp = self.preprocessor.flatten_history(inp)
 
-                    # split list of targets
+                    B = inp.shape[0]
+
+                    # expand the input batch to (B*E, ...) for the folded-batch forward
+                    if E > 1:
+                        inp = inp.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp.shape[1:])
+
+                    # split list of targets (stays at batch B)
                     tarlist = torch.split(tar, 1, dim=1)
 
-                    # do autoregression for each ensemble member individually
-                    # do the rollout
-                    # initialize the noise states with random seeds:
-                    noise_states = self._initialize_noise_states()
-                    inptlist = [inp.clone() for _ in range(self.params.local_ensemble_size)]
+                    # draw a fresh stationary noise state at the folded batch for this episode
+                    self.preprocessor.update_internal_state(replace_state=True, batch_size=inp.shape[0])
 
                     # loop over lead times
                     for idt, targ in enumerate(tarlist):
@@ -647,38 +684,25 @@ class EnsembleTrainer(Trainer):
                         # flatten history of the target
                         targ = self.preprocessor.flatten_history(targ)
 
-                        # FW pass
-                        predlist = []
-
                         with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
-                            # loop over local ensemble members
-                            for e in range(self.params.local_ensemble_size):
-                                # retrieve input
-                                inpt = inptlist[e]
+                            # single forward on the folded batch: at idt==0 the noise state was
+                            # just drawn fresh, so skip the stepper's internal update; for
+                            # subsequent steps run the standard AR update.
+                            pred_flat = self.model_eval(
+                                inp,
+                                update_state=(idt != 0),
+                                replace_state=False,
+                            )
 
-                                # this is different, depending on local ensemble size
-                                if self.params.local_ensemble_size > 1:
-                                    # recover correct state
-                                    self.preprocessor.set_internal_state(noise_states[e])
+                            # advance the input history / unpredicted features once per step
+                            inp = self.preprocessor.append_history(inp, pred_flat, idt, update_state=True)
 
-                                    # forward pass: never replace state since we do that manually
-                                    pred = self.model_eval(inpt, update_state=(idt!=0), replace_state=False)
+                            # reshape back to (B, E, ...) for the loss
+                            if E > 1:
+                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
+                            else:
+                                pred = pred_flat.unsqueeze(1)
 
-                                    # store new state
-                                    noise_states[e] = self.preprocessor.get_internal_state(tensor=True)
-                                else:
-                                    # forward pass: replace state if this is the first step of the rollout
-                                    pred = self.model_eval(inpt, update_state=True, replace_state=(idt==0))
-
-                                # concatenate predictions
-                                predlist.append(pred)
-
-                                # append input to prediction
-                                last_member = e == self.params.local_ensemble_size - 1
-                                inptlist[e] = self.preprocessor.append_history(inpt, pred, idt, update_state=last_member)
-
-                            # concatenate
-                            pred = torch.stack(predlist, dim=1)
                             loss = self.loss_obj(pred, targ)
 
                             # log the loss

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -32,6 +32,7 @@ from makani.utils.profiling import Timer
 
 # makani depenedencies
 from makani.utils import LossHandler, MetricsHandler
+from makani.utils.functions import expand_ensemble
 from makani.utils.driver import Driver
 from makani.utils.training import Trainer
 from makani.utils.dataloader import get_dataloader
@@ -454,11 +455,9 @@ class EnsembleTrainer(Trainer):
         E = self.params.local_ensemble_size
         B = inp.shape[0]
 
-        if E > 1:
-            # (B, C, H, W) -> (B, 1, C, H, W) -> (B, E, C, H, W) -> (B*E, C, H, W)
-            inp_flat = inp.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp.shape[1:])
-        else:
-            inp_flat = inp
+        # (B, C, H, W) -> (B*E, C, H, W) with ensemble dim folded into batch
+        # (E==1 short-circuits inside expand_ensemble, no allocation)
+        inp_flat = expand_ensemble(inp, E)
 
         # pre-adjust the preprocessor's noise state to the folded batch; the model is then
         # called with update_state=False so it consumes this fresh state directly.
@@ -508,10 +507,9 @@ class EnsembleTrainer(Trainer):
             # semantics below); y stays at its original batch since the loss expects (B, E, ...)
             # pred vs (B, ...) target.
             E = self.params.local_ensemble_size
-            if E > 1 and len(gdata) == 4:
-                B_xz = gdata[2].shape[0]
-                gdata[2] = gdata[2].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[2].shape[1:])
-                gdata[3] = gdata[3].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[3].shape[1:])
+            if len(gdata) == 4:
+                gdata[2] = expand_ensemble(gdata[2], E)
+                gdata[3] = expand_ensemble(gdata[3], E)
 
             # do preprocessing
             inp, tar = self.preprocessor.cache_unpredicted_features(*gdata)
@@ -657,10 +655,9 @@ class EnsembleTrainer(Trainer):
                     # (y) stays at the original batch — the loss expects (B, E, ...) pred against
                     # (B, ...) target.
                     E = self.params.local_ensemble_size
-                    if E > 1 and len(gdata) == 4:
-                        B_xz = gdata[2].shape[0]
-                        gdata[2] = gdata[2].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[2].shape[1:])
-                        gdata[3] = gdata[3].unsqueeze(1).repeat_interleave(E, dim=1).reshape(B_xz * E, *gdata[3].shape[1:])
+                    if len(gdata) == 4:
+                        gdata[2] = expand_ensemble(gdata[2], E)
+                        gdata[3] = expand_ensemble(gdata[3], E)
 
                     # preprocess
                     inp, tar = self.preprocessor.cache_unpredicted_features(*gdata)
@@ -669,8 +666,7 @@ class EnsembleTrainer(Trainer):
                     B = inp.shape[0]
 
                     # expand the input batch to (B*E, ...) for the folded-batch forward
-                    if E > 1:
-                        inp = inp.unsqueeze(1).repeat_interleave(E, dim=1).reshape(B * E, *inp.shape[1:])
+                    inp = expand_ensemble(inp, E)
 
                     # split list of targets (stays at batch B)
                     tarlist = torch.split(tar, 1, dim=1)

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -465,10 +465,7 @@ class EnsembleTrainer(Trainer):
 
         pred_flat = self.model_train(inp_flat, update_state=False)
 
-        if E > 1:
-            pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
-        else:
-            pred = pred_flat.unsqueeze(1)
+        pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
         loss = self.loss_obj(pred, tar, inp=inp)
 
@@ -694,10 +691,7 @@ class EnsembleTrainer(Trainer):
                             inp = self.preprocessor.append_history(inp, pred_flat, idt, update_state=True)
 
                             # reshape back to (B, E, ...) for the loss
-                            if E > 1:
-                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
-                            else:
-                                pred = pred_flat.unsqueeze(1)
+                            pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
                             loss = self.loss_obj(pred, targ)
 

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -470,7 +470,7 @@ class EnsembleTrainer(Trainer):
         else:
             pred = pred_flat.unsqueeze(1)
 
-        loss = self.loss_obj(pred, tar)
+        loss = self.loss_obj(pred, tar, inp=inp)
 
         return pred, loss
 

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -619,10 +619,7 @@ class StochasticTrainer(Driver):
                             inp = self.preprocessor.append_history(inp, pred_flat, idt, update_state=True)
 
                             # reshape back to (B, E, ...) for the loss and downstream buffers
-                            if E > 1:
-                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
-                            else:
-                                pred = pred_flat.unsqueeze(1)
+                            pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
 
                             loss = self.loss_obj(pred, targ)
 

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -29,6 +29,7 @@ import wandb
 
 # makani depenedencies
 from makani.utils import LossHandler, MetricsHandler
+from makani.utils.functions import expand_ensemble
 from makani.utils.driver import Driver
 from makani.utils.dataloader import get_dataloader
 from makani.utils.dataloaders.data_helpers import get_climatology
@@ -579,40 +580,50 @@ class StochasticTrainer(Driver):
                 for data in progress_bar:
                     eval_steps += 1
 
-                    # map to gpu
-                    gdata = map(lambda x: x.to(self.device), data)
+                    # map to gpu; materialize to list so we can expand zenith features
+                    gdata = [x.to(self.device) for x in data]
+
+                    # When local_ensemble_size > 1, fold the ensemble dim into the batch
+                    # dim for a single forward per rollout step. xz / yz (zenith features)
+                    # must be expanded to (B*E, ...) so the preprocessor's cache lines up
+                    # with the folded-batch input; tar stays at the original batch — the
+                    # loss expects (B, E, ...) pred vs (B, ...) target.
+                    E = self.params.local_ensemble_size
+                    if len(gdata) == 4:
+                        gdata[2] = expand_ensemble(gdata[2], E)
+                        gdata[3] = expand_ensemble(gdata[3], E)
 
                     # preprocess
                     inp, tar = self.preprocessor.cache_unpredicted_features(*gdata)
                     inp = self.preprocessor.flatten_history(inp)
 
-                    # split list of targets
+                    B = inp.shape[0]
+
+                    # expand the input batch to (B*E, ...) for the folded-batch forward
+                    inp = expand_ensemble(inp, E)
+
+                    # split list of targets (stays at batch B)
                     tarlist = torch.split(tar, 1, dim=1)
 
-                    # make sure the input has the correct shape
-                    # inpt = inp.unsqueeze(1).repeat(1, self.params.local_ensemble_size, 1, 1, 1)
-                    # do we need to clone here?
-                    inptlist = [inp.clone() for _ in range(self.params.local_ensemble_size)]
                     for idt, targ in enumerate(tarlist):
                         # flatten history of the target
                         targ = self.preprocessor.flatten_history(targ)
 
-                        # FW pass
-                        predlist = []
                         with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
-                            for ic in range(self.params.local_ensemble_size):
-                                # retrieve input
-                                inpt = inptlist[ic]
+                            # single forward on the folded batch; StochasticInterpolant.forward
+                            # handles the batch-resize of both the preprocessor's input_noise
+                            # and its own noise_module internally.
+                            pred_flat = self.model_eval(inp, n_steps=self.params.stochastic_interpolation_steps)
 
-                                # forward pass
-                                pred = self.model_eval(inpt, n_steps=self.params.stochastic_interpolation_steps)
-                                predlist.append(pred)
+                            # advance the input history / unpredicted features once per step
+                            inp = self.preprocessor.append_history(inp, pred_flat, idt, update_state=True)
 
-                                # append input to prediction
-                                inptlist[ic] = self.preprocessor.append_history(inpt, pred, idt, update_state=(ic == 0))
+                            # reshape back to (B, E, ...) for the loss and downstream buffers
+                            if E > 1:
+                                pred = pred_flat.reshape(B, E, *pred_flat.shape[1:])
+                            else:
+                                pred = pred_flat.unsqueeze(1)
 
-                            # concatenate
-                            pred = torch.stack(predlist, dim=1)
                             loss = self.loss_obj(pred, targ)
 
                         # TODO: move all of this into the visualization handler

--- a/tests/test_dali_helpers.py
+++ b/tests/test_dali_helpers.py
@@ -69,10 +69,6 @@ _DHOURS     = DHOURS
 _YEARS      = TRAIN_YEARS
 _N_TOTAL    = len(_YEARS) * _N_PER_YEAR
 
-# Default config: n_history=0, n_future=0, dt=1, truncate_old=False
-# samples_end = N_TOTAL - dt*(n_future+1) = N_TOTAL - 1
-_N_VALID = _N_TOTAL - 1
-
 # Boundary timestamp = exactly sample 24 of the first training year.
 # lookback_hours = DHOURS*(n_future+1) = DHOURS*1, so the exclusion window
 # is [sample_24_time - DHOURS, sample_24_time), which contains sample 23.
@@ -81,7 +77,6 @@ _BOUNDARY_DT = (
     + dt.timedelta(hours=24 * _DHOURS)   # sample 24
 )
 _BOUNDARY_TS = _BOUNDARY_DT.isoformat()
-_N_VALID_WITH_BOUNDARY = _N_VALID - 1   # sample 23 excluded
 
 
 # ---------------------------------------------------------------------------
@@ -226,7 +221,25 @@ class _BaseESTests:
     Subclasses must implement:
         _make(**overrides)             → ES backed by standard random dataset
         _make_distinctive(**overrides) → ES backed by distinctive-channel dataset
+        _expected_n_valid(dt, n_history, n_future)
+                                       → number of usable samples for the
+                                         given window config.  Differs between
+                                         backends because GeneralES drops
+                                         windows that cross year boundaries
+                                         while GeneralConcatES does not.
     """
+
+    def _expected_n_valid(self, dt, n_history, n_future):
+        raise NotImplementedError
+
+    @property
+    def expected_n_valid(self):
+        return self._expected_n_valid(dt=1, n_history=0, n_future=0)
+
+    @property
+    def expected_n_valid_with_boundary(self):
+        # the boundary-list fixture excludes exactly one extra sample
+        return self.expected_n_valid - 1
 
     def _call0(self, es):
         """Call es at the very first sample of epoch 0."""
@@ -503,7 +516,7 @@ class _BaseESTests:
 
     def test_n_samples_total(self):
         es = self._make()
-        self.assertEqual(es.n_samples_total, _N_VALID)
+        self.assertEqual(es.n_samples_total, self.expected_n_valid)
 
     def test_shuffle_epoch_cycle(self):
         """
@@ -579,6 +592,109 @@ class _BaseESTests:
         with self.subTest(desc="complete coverage"):
             self.assertEqual(set(loaded_ts), expected_ts)
 
+    def test_shuffle_multi_cycle_coverage_and_ordering(self):
+        """
+        Two consecutive cycles must
+          1. each independently cover every valid sample exactly once, and
+          2. use different permutations (cycle seed is base_seed + cycle_idx).
+        """
+        N_SAMPLES          = 50
+        EPOCH_LEN          = 10
+        N_EPOCHS_PER_CYCLE = N_SAMPLES // EPOCH_LEN   # 5
+        N_CYCLES           = 2
+
+        es = self._make(
+            train=True,
+            max_samples=N_SAMPLES + 1,       # samples_end = (N+1) - 1 = N
+            samples_per_epoch=EPOCH_LEN,
+            batch_size=1,
+            return_timestamp=True,
+        )
+
+        per_cycle_ts = []
+        for cycle in range(N_CYCLES):
+            cycle_ts = []
+            for epoch_in_cycle in range(N_EPOCHS_PER_CYCLE):
+                epoch_idx = cycle * N_EPOCHS_PER_CYCLE + epoch_in_cycle
+                for step in range(EPOCH_LEN):
+                    result = es(_SampleInfo(
+                        idx_in_epoch=step,
+                        epoch_idx=epoch_idx,
+                        iteration=step,
+                    ))
+                    cycle_ts.append(_ts_to_posix(result[2][0]))
+            per_cycle_ts.append(cycle_ts)
+
+        expected = {_ts_to_posix(ts) for ts in es.timestamps[es.indices_select]}
+
+        for c, ts_list in enumerate(per_cycle_ts):
+            with self.subTest(desc=f"cycle {c} full coverage"):
+                self.assertEqual(set(ts_list), expected)
+            with self.subTest(desc=f"cycle {c} no intra-cycle repeats"):
+                self.assertEqual(len(ts_list), len(set(ts_list)))
+
+        with self.subTest(desc="cycles use different permutations"):
+            # same sample set, different ordering
+            self.assertNotEqual(per_cycle_ts[0], per_cycle_ts[1])
+
+    def test_shuffle_epoch_not_divisible_by_cycle(self):
+        """
+        Virtual-epoch size does not divide cycle size.  An epoch then
+        spans a cycle boundary mid-epoch; the permutation regenerates
+        partway through and cycle_sample_idx wraps to 0 on the next call.
+
+        Walk 8 epochs of 7 steps = 56 samples, against a 50-sample cycle:
+          - the first 50 samples form cycle 0 (full coverage, no repeats),
+          - the remaining 6 are the start of cycle 1 (distinct permutation).
+        """
+        N_SAMPLES = 50
+        EPOCH_LEN = 7                    # 50 % 7 != 0
+        N_EPOCHS  = 8                    # 56 total steps
+
+        es = self._make(
+            train=True,
+            max_samples=N_SAMPLES + 1,
+            samples_per_epoch=EPOCH_LEN,
+            batch_size=1,
+            return_timestamp=True,
+        )
+        self.assertEqual(es.n_samples_total,     N_SAMPLES)
+        self.assertEqual(es.num_steps_per_epoch, EPOCH_LEN)
+
+        all_ts = []
+        for epoch_idx in range(N_EPOCHS):
+            for step in range(EPOCH_LEN):
+                result = es(_SampleInfo(
+                    idx_in_epoch=step,
+                    epoch_idx=epoch_idx,
+                    iteration=step,
+                ))
+                all_ts.append(_ts_to_posix(result[2][0]))
+
+        expected = {_ts_to_posix(ts) for ts in es.timestamps[es.indices_select]}
+
+        # cycle 0 = first N_SAMPLES calls → full coverage, no repeats
+        cycle0 = all_ts[:N_SAMPLES]
+        with self.subTest(desc="cycle 0 full coverage"):
+            self.assertEqual(set(cycle0), expected)
+        with self.subTest(desc="cycle 0 no repeats"):
+            self.assertEqual(len(cycle0), len(set(cycle0)))
+
+        # cycle 1 prefix = remaining calls → subset of expected, no repeats
+        cycle1_prefix = all_ts[N_SAMPLES:]
+        expected_prefix_len = N_EPOCHS * EPOCH_LEN - N_SAMPLES
+        with self.subTest(desc="cycle 1 prefix length"):
+            self.assertEqual(len(cycle1_prefix), expected_prefix_len)
+        with self.subTest(desc="cycle 1 prefix is a valid subset"):
+            self.assertTrue(set(cycle1_prefix).issubset(expected))
+        with self.subTest(desc="cycle 1 prefix no repeats"):
+            self.assertEqual(len(cycle1_prefix), len(set(cycle1_prefix)))
+
+        # the two permutations must differ: cycle 1's start cannot match
+        # cycle 0's start element-by-element
+        with self.subTest(desc="distinct permutations across boundary"):
+            self.assertNotEqual(cycle1_prefix, cycle0[:expected_prefix_len])
+
     # ---- 13. timestamp boundary list ------------------------------------
 
     def test_timestamp_boundary_excludes_one_sample(self):
@@ -588,12 +704,52 @@ class _BaseESTests:
         """
         es_plain    = self._make()
         es_boundary = self._make(timestamp_boundary_list=[_BOUNDARY_TS])
-        self.assertEqual(es_plain.n_samples_total,    _N_VALID)
-        self.assertEqual(es_boundary.n_samples_total, _N_VALID_WITH_BOUNDARY)
+        self.assertEqual(es_plain.n_samples_total,    self.expected_n_valid)
+        self.assertEqual(es_boundary.n_samples_total, self.expected_n_valid_with_boundary)
 
     def test_empty_boundary_list_unchanged(self):
         es = self._make(timestamp_boundary_list=[])
-        self.assertEqual(es.n_samples_total, _N_VALID)
+        self.assertEqual(es.n_samples_total, self.expected_n_valid)
+
+    # ---- 14. window exclusion across (dt, n_history, n_future) ----------
+
+    def test_window_exclusion_various_settings(self):
+        """
+        Vary dt, n_history, and n_future.  For every combination
+          1. n_samples_total must match the backend-specific formula
+             (dir-based drops the window per year; concat drops it once),
+          2. walking the full non-shuffled epoch must yield unique samples
+             (no silent per-year clamp).
+        """
+        configs = [
+            # (dt, n_history, n_future)
+            (1, 0, 0),
+            (1, 0, 3),
+            (1, 2, 0),
+            (1, 1, 2),
+            (2, 0, 0),
+            (2, 1, 2),
+            (3, 0, 5),
+        ]
+        for dt_, nh, nf in configs:
+            with self.subTest(dt=dt_, n_history=nh, n_future=nf):
+                es = self._make(dt=dt_, n_history=nh, n_future=nf)
+
+                self.assertEqual(
+                    es.n_samples_total,
+                    self._expected_n_valid(dt_, nh, nf),
+                )
+
+                fps = set()
+                for step in range(es.num_steps_per_epoch):
+                    inp, _tar = es(_SampleInfo(
+                        idx_in_epoch=step, epoch_idx=0, iteration=step,
+                    ))
+                    # inp has shape (n_history+1, C, H, W); the last (t=0)
+                    # frame is unique per sample_idx and is cheaper to hash
+                    # than the full window.
+                    fps.add(inp[nh].tobytes())
+                self.assertEqual(len(fps), es.num_steps_per_epoch)
 
 
 # ===========================================================================
@@ -606,6 +762,11 @@ class TestGeneralES(_BaseESTests, unittest.TestCase):
     The main dataset is created by init_dataset() from testutils, which
     produces the same two-year training layout used by the other dataloader tests.
     """
+
+    def _expected_n_valid(self, dt, n_history, n_future):
+        # window must sit inside one year
+        window = dt * (n_history + n_future + 1)
+        return sum(max(0, _N_PER_YEAR - window) for _ in range(len(_YEARS)))
 
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -638,6 +799,12 @@ class TestGeneralES(_BaseESTests, unittest.TestCase):
 
 class TestGeneralConcatES(_BaseESTests, unittest.TestCase):
     """Tests for GeneralConcatES (single concatenated HDF5 file)."""
+
+    def _expected_n_valid(self, dt, n_history, n_future):
+        # single contiguous file: samples_start=dt*n_history, samples_end
+        # trims dt*(n_future+1) off the global tail
+        window = dt * (n_history + n_future + 1)
+        return max(0, _N_TOTAL - window)
 
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -583,5 +583,85 @@ class TestDataLoader(unittest.TestCase):
             self.assertNotEqual(fps_ep0, fps_ep1)
 
 
+class TestDummyLoader(unittest.TestCase):
+    """Smoke tests for the synthetic DummyLoader. CPU-friendly — no DALI, no HDF5 fixture."""
+
+    def setUp(self):
+        disable_tf32()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.batch_size = 2
+        self.img_shape = (32, 64)
+        self.in_channels = list(range(5))
+        self.out_channels = list(range(5))
+
+    def _make_loader(self, **overrides):
+        from makani.utils.dataloaders.data_loader_dummy import DummyLoader
+        kwargs = dict(
+            location="/nonexistent",
+            device=self.device,
+            batch_size=self.batch_size,
+            dt=1,
+            dhours=6,
+            in_channels=self.in_channels,
+            out_channels=self.out_channels,
+            img_shape=self.img_shape,
+            n_samples_per_epoch=4,
+        )
+        kwargs.update(overrides)
+        return DummyLoader(**kwargs)
+
+    def test_basic_iteration_shapes_and_dtype(self):
+        loader = self._make_loader()
+        self.assertEqual(len(loader), 4)
+        batches = list(loader)
+        self.assertEqual(len(batches), 4)
+        for inp, tar in batches:
+            self.assertEqual(tuple(inp.shape), (self.batch_size, 1, len(self.in_channels), *self.img_shape))
+            self.assertEqual(tuple(tar.shape), (self.batch_size, 1, len(self.out_channels), *self.img_shape))
+            self.assertEqual(inp.dtype, torch.float32)
+            self.assertEqual(tar.dtype, torch.float32)
+
+    def test_history_and_future_dimensions(self):
+        loader = self._make_loader(n_history=2, n_future=3)
+        inp, tar = next(iter(loader))
+        self.assertEqual(inp.shape[1], 3)   # n_history + 1
+        self.assertEqual(tar.shape[1], 4)   # n_future  + 1
+
+    def test_add_zenith_appends_zenith_tensors(self):
+        loader = self._make_loader(add_zenith=True)
+        batch = next(iter(loader))
+        self.assertEqual(len(batch), 4)     # inp, tar, inp_zen, tar_zen
+        _, _, inp_zen, _ = batch
+        self.assertEqual(tuple(inp_zen.shape), (self.batch_size, 1, 1, *self.img_shape))
+
+    def test_return_timestamp_appends_time_tensors(self):
+        loader = self._make_loader(return_timestamp=True)
+        batch = next(iter(loader))
+        self.assertEqual(len(batch), 4)     # inp, tar, inp_time, tar_time
+        _, _, inp_time, _ = batch
+        self.assertEqual(tuple(inp_time.shape), (self.batch_size, 1))
+        self.assertEqual(inp_time.dtype, torch.float64)
+
+    def test_return_target_false_yields_input_only(self):
+        loader = self._make_loader(return_target=False)
+        batch = next(iter(loader))
+        self.assertEqual(len(batch), 1)     # inp only
+
+    def test_subsampling_factor_reduces_spatial_shape(self):
+        loader = self._make_loader(subsampling_factor=2)
+        inp, _ = next(iter(loader))
+        self.assertEqual(tuple(inp.shape[-2:]), (self.img_shape[0] // 2, self.img_shape[1] // 2))
+
+    def test_normalization_helpers_return_neutral_stats(self):
+        loader = self._make_loader()
+        in_bias, in_scale = loader.get_input_normalization()
+        out_bias, out_scale = loader.get_output_normalization()
+        self.assertEqual(in_bias.shape, (1, len(self.in_channels), 1, 1))
+        self.assertTrue((in_bias == 0).all())
+        self.assertTrue((in_scale == 1).all())
+        self.assertTrue((out_bias == 0).all())
+        self.assertTrue((out_scale == 1).all())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -497,5 +497,91 @@ class TestDataLoader(unittest.TestCase):
             if idt > self.num_steps:
                 break
 
+    @unittest.skipUnless(_have_dali, "nvidia.dali is not installed")
+    def test_dali_temporal_window_across_year_boundary_no_duplicates(self):
+        """
+        DALI path, eval mode on the 2-year training set with n_future > 0.
+
+        Invariant: a full non-shuffled epoch must yield distinct samples.
+        The per-year clamp in GeneralES.__call__ silently maps indices near
+        a year boundary to the same frame, which would show up here as
+        duplicate input tensors.  If this test fails, it is flagging exactly
+        that boundary handling.
+        """
+        params = copy.deepcopy(self.params)
+        params.multifiles = False
+        params.valid_autoreg_steps = 3   # n_future=3 in eval mode
+        params.batch_size = 1
+
+        loader, _, _ = get_dataloader(
+            params, params.train_data_path, mode="eval", device=self.device,
+        )
+
+        fingerprints = []
+        for token in loader:
+            inp = token[0]
+            for b in range(inp.shape[0]):
+                fingerprints.append(inp[b].cpu().numpy().tobytes())
+
+        unique = len(set(fingerprints))
+        total  = len(fingerprints)
+        self.assertEqual(
+            unique, total,
+            f"{total - unique} duplicate samples in a non-shuffled DALI epoch "
+            f"(total={total}, unique={unique}).",
+        )
+
+    @unittest.skipUnless(_have_dali, "nvidia.dali is not installed")
+    def test_dali_multi_epoch_reset_state(self):
+        """
+        DALI path, train mode on the 2-year training set.
+
+        Drives the pipeline through two full back-to-back epochs via
+        auto_reset, then a third epoch after an explicit reset_pipeline().
+        Checks
+          - each epoch fully iterates without raising,
+          - each epoch yields distinct samples (no intra-epoch duplicates),
+          - the two shuffled epochs use different permutations (seed is
+            base_seed + cycle_epoch_idx; if the DALI/ES epoch counter got
+            stuck the two epochs would match).
+        """
+        params = copy.deepcopy(self.params)
+        params.multifiles = False
+        params.batch_size = 1
+        params.n_train_samples = 20          # keep the test fast
+        params.n_future = 0
+
+        loader, _, _ = get_dataloader(
+            params, params.train_data_path, mode="train", device=self.device,
+        )
+
+        def _collect_epoch():
+            fps = []
+            for token in loader:
+                inp = token[0]
+                for b in range(inp.shape[0]):
+                    fps.append(inp[b].cpu().numpy().tobytes())
+            return fps
+
+        # auto_reset handles the first-to-second transition
+        fps_ep0 = _collect_epoch()
+        fps_ep1 = _collect_epoch()
+
+        # explicit reset_pipeline() should also produce a valid epoch
+        loader.reset_pipeline()
+        fps_ep2 = _collect_epoch()
+
+        for ep_idx, fps in enumerate((fps_ep0, fps_ep1, fps_ep2)):
+            with self.subTest(desc=f"epoch {ep_idx} non-empty"):
+                self.assertGreater(len(fps), 0)
+            with self.subTest(desc=f"no intra-epoch duplicates in epoch {ep_idx}"):
+                self.assertEqual(len(fps), len(set(fps)))
+
+        # auto_reset must advance the shuffle seed: two consecutive epochs
+        # cannot produce identical orderings.
+        with self.subTest(desc="auto_reset advances shuffle state"):
+            self.assertNotEqual(fps_ep0, fps_ep1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -687,6 +687,54 @@ class TestDiffusionNoiseS2(unittest.TestCase):
                         "reset(batch_size=N) should produce an all-zero state")
 
     # -----------------------------------------------------------------------
+    # Pattern-4 state handling invariants
+    # -----------------------------------------------------------------------
+    def test_state_remains_registered_buffer_after_resize(self):
+        """After a batch-changing update, `state` is still a registered buffer (not a plain
+        attribute) and therefore still moves with `.to(device)`. Guards against a future
+        regression to the raw `self.state = ...` rebind pattern.
+        """
+        noise = self._make_noise()
+        new_B = self.B + 3
+        noise.update(replace_state=True, batch_size=new_B)
+
+        buffer_names = {name for name, _ in noise.named_buffers()}
+        self.assertIn("state", buffer_names,
+                      "state must remain a registered buffer after resize")
+        self.assertEqual(noise.state.shape[0], new_B)
+
+        if torch.cuda.is_available():
+            moved = noise.to(torch.device("cuda"))
+            self.assertEqual(moved.state.device.type, "cuda",
+                             ".to(cuda) must move the state buffer after a resize")
+
+    def test_ensure_state_is_idempotent_on_same_batch(self):
+        """`_ensure_state` with the current batch size is a no-op: the underlying
+        buffer is reused (same data_ptr), not re-registered.
+        """
+        noise = self._make_noise()
+        before_ptr = noise.state.data_ptr()
+        noise._ensure_state(noise.state.shape[0])
+        after_ptr = noise.state.data_ptr()
+        self.assertEqual(before_ptr, after_ptr,
+                         "_ensure_state on the same batch size must not rebind the buffer")
+
+    def test_set_tensor_state_raises_on_shape_suffix_mismatch(self):
+        """`set_tensor_state` must reject any non-batch shape mismatch up-front with a
+        clear ValueError, and must NOT mutate `state` before raising.
+        """
+        noise = self._make_noise()
+        original_shape = tuple(noise.state.shape)
+        # perturb one of the suffix dims (channel count); batch dim may match
+        bad_shape = list(noise.state.shape)
+        bad_shape[2] = bad_shape[2] + 1   # wrong C
+        bad = torch.zeros(tuple(bad_shape), dtype=noise.state.dtype, device=noise.state.device)
+        with self.assertRaises(ValueError):
+            noise.set_tensor_state(bad)
+        self.assertEqual(tuple(noise.state.shape), original_shape,
+                         "state must not be mutated when set_tensor_state raises")
+
+    # -----------------------------------------------------------------------
     # Per-channel kT / lambd lists — noise.py lines 305-319
     # -----------------------------------------------------------------------
     def test_per_channel_kT_list(self):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1095,6 +1095,56 @@ class TestPreprocessor2DBasic(unittest.TestCase):
         self.assertTrue(compare_tensors("history_normalize cpu vs gpu", xn_cpu, xn_gpu,
                                         atol=1e-5, rtol=1e-4, verbose=verbose))
 
+    # -----------------------------------------------------------------------
+    # Hardening: controlled-fail shape / batch checks
+    # -----------------------------------------------------------------------
+
+    def test_expand_history_raises_on_non_divisible_channels(self):
+        """expand_history raises ValueError when the channel dim isn't divisible by nhist."""
+        params = get_default_parameters()
+        params.n_history = 2  # nhist = 3
+        pp = Preprocessor2D(params)
+        # channels = 5, not divisible by 3
+        x_bad = torch.randn(self.B, 5, self.H, self.W)
+        with self.assertRaises(ValueError) as cm:
+            pp.expand_history(x_bad, nhist=pp.n_history + 1)
+        self.assertIn("not divisible", str(cm.exception))
+
+    def test_append_channels_raises_on_input_cache_batch_mismatch(self):
+        """_append_channels raises ValueError when input and cached xz have different batch sizes."""
+        self.pp.train()
+        # cache xz/yz at the preprocessor's configured batch
+        x_cache = self._rand(self.B, self.C, self.H, self.W)
+        xz = self._rand(self.B, 1, 1, self.H, self.W)
+        yz = self._rand(self.B, 1, 1, self.H, self.W)
+        self.pp.cache_unpredicted_features(x_cache, x_cache, xz=xz, yz=yz)
+        # now pass an input with a DIFFERENT batch size
+        x_mismatch = self._rand(self.B + 1, self.C, self.H, self.W)
+        with self.assertRaises(ValueError) as cm:
+            self.pp.append_unpredicted_features(x_mismatch, target=False)
+        self.assertIn("batch mismatch", str(cm.exception))
+        self.assertIn("cached unpredicted features", str(cm.exception))
+
+    def test_append_channels_raises_on_noise_state_batch_mismatch(self):
+        """_append_channels raises ValueError when input_noise state and input batch disagree."""
+        params = get_default_parameters()
+        params.input_noise = {"type": "dummy", "mode": "concatenate", "n_channels": 1}
+        pp = Preprocessor2D(params)
+        pp.train()
+        # cache xz at batch B and pass input at batch B so the first check passes;
+        # bump noise state to a different batch to hit the second (noise) check.
+        x = self._rand(self.B, self.C, self.H, self.W)
+        xz = self._rand(self.B, 1, 1, self.H, self.W)
+        yz = self._rand(self.B, 1, 1, self.H, self.W)
+        pp.cache_unpredicted_features(x, x, xz=xz, yz=yz)
+        pp.update_internal_state(replace_state=True, batch_size=self.B + 2)
+
+        with self.assertRaises(ValueError) as cm:
+            pp.append_unpredicted_features(x, target=False)
+        msg = str(cm.exception)
+        self.assertIn("batch mismatch", msg)
+        self.assertIn("input_noise state", msg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This branch will contain some major refactoring of preprocessor.py and noise.py. Those two rely on some states with implicitly assumptions and for some features implement order contracts. This MR will clean up all of this because it can lead to semantic problems and data corruption if not aware.

- rewrites noise.py and preprocessor.py to not accidentally hold on to dead references
- folds local ensemble dimension into batch dimension for forward pass, simplifies a lot of the noise handling
- added more data loader tests related to number of samples in epochs and cycles.
- added external source fix for split file DALI loader which silently duplicated samples. Invalid samples are excluded from the file list now

Do not merge before https://github.com/NVIDIA/makani/pull/77 