### PR TITLE
Tkurth/gds readiness

### DIFF
--- a/makani/utils/inference/rollout_buffer.py
+++ b/makani/utils/inference/rollout_buffer.py
@@ -432,12 +432,6 @@ class RolloutBuffer(DataBuffer):
                 tarr,
                 dest_sel=batch_range,
             )
-            # advance the file pointer BEFORE zero_buffers — zero_buffers now
-            # resets buffer_offset, so we must capture it here while still valid.
-            self.file_offset += self.buffer_offset
-
-        # reset buffers (also resets buffer_offset)
-        self.zero_buffers()
 
         return
 

--- a/makani/utils/inference/rollout_buffer.py
+++ b/makani/utils/inference/rollout_buffer.py
@@ -34,6 +34,22 @@ import torch_harmonics as th
 import torch_harmonics.distributed as thd
 
 
+def _barrier(device):
+    """
+    Synchronize across ranks if a process group is initialized.
+
+    Wraps ``dist.barrier`` with two safety guards: it's a no-op when no
+    process group has been initialized, and it only passes ``device_ids``
+    on CUDA (``device.index`` is ``None`` for CPU and would make
+    ``dist.barrier(device_ids=[None])`` raise).
+    """
+    if not dist.is_initialized():
+        return
+    device_ids = [device.index] if device.type == "cuda" else None
+    dist.barrier(device_ids=device_ids)
+
+
+
 class DataBuffer(object, metaclass=ABCMeta):
     r"""
     DataBuffer class used as base class for online data analysis
@@ -268,19 +284,28 @@ class RolloutBuffer(DataBuffer):
 
     def zero_buffers(self):
         """
-        set buffers to zero
+        Reset all buffer state to a fresh post-construction state. Zeros the
+        data tensors AND resets ``buffer_offset`` so callers may invoke this
+        mid-rollout without leaving a stale offset pointing into newly-zeroed
+        slots.
+
+        This mirrors ``MeanStdBuffer.zero_buffers`` (which also resets its
+        offset analog ``num_samples_tracked``) for consistency.
         """
 
         with torch.no_grad():
             self.timestamp_data_cpu.fill_(0.0)
             self.rollout_data_cpu.fill_(0.0)
+        self.buffer_offset = 0
 
         return
 
     def _flush_to_disk(self):
 
-        # wait for everything to complete
-        torch.cuda.synchronize(device=self.device)
+        # wait for everything to complete (CUDA only — synchronize is a CUDA-specific
+        # primitive and would raise on CPU-only builds).
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(device=self.device)
 
         if self.file_handle is not None:
             # batch ranges in file
@@ -306,13 +331,12 @@ class RolloutBuffer(DataBuffer):
                 self.timestamp_buffer_disk[batch_range] = tarr[batch_range_buffer, ...]
             self.rollout_buffer_disk[batch_range, :, ens_range, :, lat_range, lon_range] = self.rollout_data_cpu.numpy()[batch_range_buffer, ...]
 
-        # reset buffers
-        self.zero_buffers()
-
-        # reset pointers
-        if self.file_handle is not None:
+            # advance the file pointer BEFORE zero_buffers — zero_buffers now
+            # resets buffer_offset, so we must capture it here while still valid.
             self.file_offset += self.buffer_offset
-        self.buffer_offset = 0
+
+        # reset buffers (also resets buffer_offset)
+        self.zero_buffers()
 
         return
 
@@ -344,18 +368,22 @@ class RolloutBuffer(DataBuffer):
 
     def finalize(self):
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
-        # write outstanding copies to disk
-        self._flush_to_disk()
+        # Flush only when there's an output file. ``_flush_to_disk`` doubles as
+        # a destructive reset: in the no-file path it just zeros the buffer.
+        # Calling it here without a file would silently destroy the in-memory
+        # data the caller may want to read.
+        if self.file_handle is not None:
+            self._flush_to_disk()
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
-        # close output file
+        # Close the output file and null the handle so a subsequent finalize()
+        # or __del__ doesn't try to operate on an already-closed h5py object.
         if self.file_handle is not None:
             self.file_handle.close()
+            self.file_handle = None
 
         return
 
@@ -592,8 +620,7 @@ class TemporalAverageBuffer(MeanStdBuffer):
         # close file
         file_handle.close()
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return
 
@@ -614,8 +641,7 @@ class TemporalAverageBuffer(MeanStdBuffer):
 
     def finalize(self):
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         # compute common mean
         self._aggregate_stats("data")
@@ -627,8 +653,7 @@ class TemporalAverageBuffer(MeanStdBuffer):
         if self.output_file is not None:
             self._write_output_data(mean.cpu().numpy(), std.cpu().numpy())
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return
 
@@ -760,8 +785,7 @@ class SpectrumAverageBuffer(MeanStdBuffer):
 
     def finalize(self):
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         # compute common mean
         self._aggregate_stats("batch")
@@ -773,8 +797,7 @@ class SpectrumAverageBuffer(MeanStdBuffer):
         if self.output_file is not None:
             self._write_output_data(mean.cpu().numpy(), std.cpu().numpy())
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return
 
@@ -843,8 +866,7 @@ class SpectrumAverageBuffer(MeanStdBuffer):
         # close file
         file_handle.close()
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return
 
@@ -990,8 +1012,7 @@ class ZonalSpectrumAverageBuffer(MeanStdBuffer):
 
     def finalize(self):
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         # compute common mean
         self._aggregate_stats("batch")
@@ -1003,8 +1024,7 @@ class ZonalSpectrumAverageBuffer(MeanStdBuffer):
         if self.output_file is not None:
             self._write_output_data(mean.cpu().numpy(), std.cpu().numpy())
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return
 
@@ -1083,7 +1103,6 @@ class ZonalSpectrumAverageBuffer(MeanStdBuffer):
         # close file
         file_handle.close()
 
-        if dist.is_initialized():
-            dist.barrier(device_ids=[self.device.index])
+        _barrier(self.device)
 
         return

--- a/makani/utils/inference/rollout_buffer.py
+++ b/makani/utils/inference/rollout_buffer.py
@@ -150,8 +150,19 @@ class RolloutBuffer(DataBuffer):
         List of channels to be recorded
     output_file: str, optional
         Outputfile to write to
-    output_memory_buffer_size: int
+    output_memory_buffer_size: int, optional
         Number of samples to cache in memory before writing to disk
+    streaming_mode: bool, optional
+        When ``True``, every ``update()`` call writes directly to disk and no
+        in-memory rollout buffer is allocated. Requires ``output_file`` to be
+        set. Default is ``False``.
+    buffer_device: str or torch.device, optional
+        Device on which the in-memory rollout buffer is allocated. Defaults
+        to ``torch.device("cpu")``, which uses pinned memory when ``device``
+        is CUDA. Pass a CUDA device to keep the buffer GPU-resident and
+        avoid GPU→CPU transfers on every ``update()``; the buffer is copied
+        to host once at flush time. Ignored when ``streaming_mode`` is
+        ``True``.
     """
 
     def __init__(
@@ -172,8 +183,23 @@ class RolloutBuffer(DataBuffer):
         output_channels: List[str] = [],
         output_file: Optional[str] = None,
         output_memory_buffer_size: Optional[int] = None,
+        streaming_mode: bool = False,
+        buffer_device: Union[str, torch.device] = torch.device("cpu"),
     ):
         super().__init__(num_rollout_steps, rollout_dt, channel_names, device, scale, bias, output_channels, output_file)
+
+        # streaming mode has no in-memory fallback — every update writes to disk.
+        if streaming_mode and output_file is None:
+            raise ValueError(
+                "streaming_mode=True requires output_file to be set; "
+                "there is no in-memory buffer in streaming mode."
+            )
+        self.streaming_mode = streaming_mode
+
+        # resolve buffer device (mirrors DataBuffer's str→torch.device coercion).
+        # CUDA buffers avoid GPU→CPU transfers per update() call but pay one
+        # bulk copy at flush time.
+        self.buffer_device = torch.device(buffer_device) if isinstance(buffer_device, str) else buffer_device
 
         # store additional members
         self.img_shape = img_shape
@@ -200,11 +226,18 @@ class RolloutBuffer(DataBuffer):
             self.num_samples_offsets = [0, self.num_samples]
         self.num_samples_total = self.num_samples_offsets[-1]
 
-        # rollout buffer on CPU has dimensions initial_conditions x num_rollout_steps x ensemble_size x num_channels x nlat x nlon
-        pin_memory = self.device.type == "cuda"
-        local_buffer_size = (self.num_buffered_samples, self.num_rollout_steps + 1, self.ensemble_size, self.num_channels, *self.local_shape)
-        self.rollout_data_cpu = torch.zeros(local_buffer_size, dtype=torch.float32, device="cpu", pin_memory=pin_memory)
-        self.timestamp_data_cpu = torch.zeros((self.num_buffered_samples), dtype=torch.float64, device="cpu", pin_memory=pin_memory)
+        # rollout buffer dimensions: initial_conditions x num_rollout_steps x ensemble_size x num_channels x nlat x nlon
+        if self.streaming_mode:
+            # No in-memory buffer; each update() flushes to disk directly.
+            self.rollout_data = None
+            self.timestamp_data = None
+        else:
+            # pin_memory only applies to CPU buffers, and is only useful when the
+            # compute device is CUDA (it accelerates async H2D/D2H transfers).
+            pin_memory = (self.buffer_device.type == "cpu") and (self.device.type == "cuda")
+            local_buffer_size = (self.num_buffered_samples, self.num_rollout_steps + 1, self.ensemble_size, self.num_channels, *self.local_shape)
+            self.rollout_data = torch.zeros(local_buffer_size, dtype=torch.float32, device=self.buffer_device, pin_memory=pin_memory)
+            self.timestamp_data = torch.zeros((self.num_buffered_samples), dtype=torch.float64, device=self.buffer_device, pin_memory=pin_memory)
 
         # open output_file
         self.file_handle = None
@@ -277,8 +310,12 @@ class RolloutBuffer(DataBuffer):
 
     # close the output file
     def __del__(self):
-        if self.file_handle is not None:
-            self.file_handle.close()
+        # ``__del__`` may run after a partial-init failure (e.g. constructor
+        # validation raised before ``self.file_handle`` was assigned). Use
+        # getattr so a missing attribute doesn't shadow the original error.
+        file_handle = getattr(self, "file_handle", None)
+        if file_handle is not None:
+            file_handle.close()
             self.file_handle = None
         return
 
@@ -291,23 +328,29 @@ class RolloutBuffer(DataBuffer):
 
         This mirrors ``MeanStdBuffer.zero_buffers`` (which also resets its
         offset analog ``num_samples_tracked``) for consistency.
+
+        In streaming mode there are no in-memory buffers, so this is a no-op.
         """
 
+        if self.streaming_mode:
+            return
+
         with torch.no_grad():
-            self.timestamp_data_cpu.fill_(0.0)
-            self.rollout_data_cpu.fill_(0.0)
+            self.timestamp_data.fill_(0.0)
+            self.rollout_data.fill_(0.0)
         self.buffer_offset = 0
 
         return
 
-    def _flush_to_disk(self):
+    def _flush_buffer_to_disk(self):
+        """Write the accumulated in-memory buffer to disk (non-streaming mode)."""
 
         # wait for everything to complete (CUDA only — synchronize is a CUDA-specific
         # primitive and would raise on CPU-only builds).
         if self.device.type == "cuda":
             torch.cuda.synchronize(device=self.device)
 
-        if self.file_handle is not None:
+        if (self.file_handle is not None) and (self.buffer_offset > 0):
             # batch ranges in file
             batch_start_file = self.file_offset
             # the buffer offset represents the current filling level of the local buffer
@@ -325,11 +368,26 @@ class RolloutBuffer(DataBuffer):
             lat_range = slice(self.local_offset[0], self.local_offset[0] + self.local_shape[0])
             lon_range = slice(self.local_offset[1], self.local_offset[1] + self.local_shape[1])
 
+            # bring buffer to host if it lives on a non-CPU device
+            rollout_src = self.rollout_data if self.buffer_device.type == "cpu" else self.rollout_data.cpu()
+            timestamp_src = self.timestamp_data if self.buffer_device.type == "cpu" else self.timestamp_data.cpu()
+
+            # write_direct requires C-contiguous source arrays
+            rollout_arr = np.ascontiguousarray(rollout_src.numpy())
+            timestamp_arr = np.ascontiguousarray(timestamp_src.numpy())
+
             # concurrent writing
             if (comm.get_rank("model") == 0) and (comm.get_rank("ensemble") == 0):
-                tarr = self.timestamp_data_cpu.numpy()
-                self.timestamp_buffer_disk[batch_range] = tarr[batch_range_buffer, ...]
-            self.rollout_buffer_disk[batch_range, :, ens_range, :, lat_range, lon_range] = self.rollout_data_cpu.numpy()[batch_range_buffer, ...]
+                self.timestamp_buffer_disk.write_direct(
+                    timestamp_arr,
+                    source_sel=batch_range_buffer,
+                    dest_sel=batch_range,
+                )
+            self.rollout_buffer_disk.write_direct(
+                rollout_arr,
+                source_sel=np.s_[batch_range_buffer, ...],
+                dest_sel=np.s_[batch_range, :, ens_range, :, lat_range, lon_range],
+            )
 
             # advance the file pointer BEFORE zero_buffers — zero_buffers now
             # resets buffer_offset, so we must capture it here while still valid.
@@ -340,6 +398,43 @@ class RolloutBuffer(DataBuffer):
 
         return
 
+    def _write_to_disk(self, tstamps, predp, idt):
+        """Write a single (batch, leadtime) slice straight to disk (streaming mode)."""
+
+        if self.file_handle is None:
+            return
+
+        current_batch_size = predp.shape[0]
+
+        # batch range in file (uses current file_offset, advanced after the last leadtime)
+        batch_range = slice(self.file_offset, self.file_offset + current_batch_size)
+
+        # ensemble range
+        ens_start = self.ensemble_size * comm.get_rank("ensemble")
+        ens_range = slice(ens_start, ens_start + self.ensemble_size)
+
+        # spatial range
+        lat_range = slice(self.local_offset[0], self.local_offset[0] + self.local_shape[0])
+        lon_range = slice(self.local_offset[1], self.local_offset[1] + self.local_shape[1])
+
+        # bring data to host for h5py write; ensure C-contiguity for write_direct
+        predp_arr = np.ascontiguousarray(predp.detach().cpu().numpy())
+
+        self.rollout_buffer_disk.write_direct(
+            predp_arr,
+            dest_sel=np.s_[batch_range, idt, ens_range, :, lat_range, lon_range],
+        )
+
+        # write timestamps once per IC (on the first leadtime), single-writer
+        if (idt == 0) and (comm.get_rank("model") == 0) and (comm.get_rank("ensemble") == 0):
+            tarr = np.ascontiguousarray(tstamps.detach().cpu().numpy())
+            self.timestamp_buffer_disk.write_direct(
+                tarr,
+                dest_sel=batch_range,
+            )
+
+        return
+
     def update(self, pred, tstamps, idt):
         """update local buffers"""
 
@@ -347,22 +442,29 @@ class RolloutBuffer(DataBuffer):
         current_batch_size = pred.shape[0]
 
         # check if we can buffer the next element or if we need to flush now
-        if (idt == 0) and (self.buffer_offset + current_batch_size > self.num_buffered_samples):
-            self._flush_to_disk()
+        # (only meaningful in non-streaming mode — streaming has no buffer to fill)
+        if (not self.streaming_mode) and (idt == 0) and (self.buffer_offset + current_batch_size > self.num_buffered_samples):
+            self._flush_buffer_to_disk()
 
         with torch.no_grad():
             predp = self.scale * pred[..., self.channel_mask, :, :] + self.bias
 
-            batch_start = self.buffer_offset
-            batch_end = batch_start + current_batch_size
+            if self.streaming_mode:
+                self._write_to_disk(tstamps, predp, idt)
+                # advance file pointer when this IC's last leadtime is done
+                if (idt + 1) == (self.num_rollout_steps + 1):
+                    self.file_offset += current_batch_size
+            else:
+                batch_start = self.buffer_offset
+                batch_end = batch_start + current_batch_size
 
-            if idt == 0:
-                self.timestamp_data_cpu[batch_start:batch_end].copy_(tstamps, non_blocking=True)
-            self.rollout_data_cpu[batch_start:batch_end, idt].copy_(predp, non_blocking=True)
+                if idt == 0:
+                    self.timestamp_data[batch_start:batch_end].copy_(tstamps, non_blocking=True)
+                self.rollout_data[batch_start:batch_end, idt].copy_(predp, non_blocking=True)
 
-            # increase buffer pointer if the next one is a new IC
-            if (idt + 1) == (self.num_rollout_steps + 1):
-                self.buffer_offset += current_batch_size
+                # increase buffer pointer if the next one is a new IC
+                if (idt + 1) == (self.num_rollout_steps + 1):
+                    self.buffer_offset += current_batch_size
 
         return
 
@@ -370,12 +472,14 @@ class RolloutBuffer(DataBuffer):
 
         _barrier(self.device)
 
-        # Flush only when there's an output file. ``_flush_to_disk`` doubles as
-        # a destructive reset: in the no-file path it just zeros the buffer.
-        # Calling it here without a file would silently destroy the in-memory
-        # data the caller may want to read.
-        if self.file_handle is not None:
-            self._flush_to_disk()
+        # Flush remaining buffered data when there's both a file to write to and
+        # an in-memory buffer to flush. ``_flush_buffer_to_disk`` doubles as a
+        # destructive reset; in the no-file path it just zeros the buffer.
+        # Calling it here without a file would silently destroy in-memory data
+        # the caller may want to read. In streaming mode there's nothing to
+        # flush — every ``update()`` already wrote directly to disk.
+        if (not self.streaming_mode) and (self.file_handle is not None):
+            self._flush_buffer_to_disk()
 
         _barrier(self.device)
 

--- a/tests/test_rollout_buffers.py
+++ b/tests/test_rollout_buffers.py
@@ -23,7 +23,7 @@ import torch
 import h5py as h5
 from typing import Optional
 
-from makani.utils.inference.rollout_buffer import MeanStdBuffer, TemporalAverageBuffer
+from makani.utils.inference.rollout_buffer import MeanStdBuffer, RolloutBuffer, TemporalAverageBuffer
 from makani.utils.dataloaders.data_helpers import get_lat_lon_grid
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -72,9 +72,17 @@ def init_dataset_params(
     return params
 
 
-class TestRolloutBuffers(unittest.TestCase):
+class TestTemporalAverageBufferIntegration(unittest.TestCase):
     """
-    Test class for TemporalAverageBuffer using dataset initialization from test_dataloader.py
+    End-to-end test for ``TemporalAverageBuffer``: feeds real HDF5 data through
+    the buffer (update + finalize), writes the output, reads it back, and
+    compares against numpy-computed mean/std. Complements
+    ``TestTemporalAverageBufferUnit`` (in-memory, no I/O) below.
+
+    Named ``Integration`` rather than ``...Buffers`` (plural) — the prior name
+    misleadingly suggested coverage of all rollout-buffer classes when in fact
+    only ``TemporalAverageBuffer`` is exercised here. The actual ``RolloutBuffer``
+    data-dump class has its own ``TestRolloutBuffer`` (singular) elsewhere.
     """
 
     @classmethod
@@ -529,6 +537,635 @@ class TestTemporalAverageBufferUnit(unittest.TestCase):
 
         # finalize is in-place math + (no-op write) — should not raise
         buf.finalize()
+
+
+class TestRolloutBuffer(unittest.TestCase):
+    """
+    In-memory unit tests for ``RolloutBuffer`` — the data-dump buffer used to
+    record forecast tensors during inference rollouts. None of these tests
+    write to disk (``output_file=None``), so they exercise the pure logic of
+    update/flush/zero in isolation:
+
+      * update() routing into (sample, step, ensemble, channel, lat, lon)
+      * buffer_offset advance only on rollout completion
+      * scale*x + bias projection
+      * channel_mask channel selection
+      * timestamp-only-at-idt=0
+      * zero_buffers() data reset
+      * auto-flush on buffer-overflow at idt=0
+      * output_memory_buffer_size defaults and clamping
+
+    The auto-flush test requires CUDA because ``_flush_to_disk`` calls
+    ``torch.cuda.synchronize`` unconditionally; it's skipped on CPU-only hosts.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # CPU is fine for everything except _flush_to_disk; per-test guards
+        # skip that single case if CUDA isn't available.
+        cls.device = torch.device("cpu")
+
+    @staticmethod
+    def _make_buffer(
+        *,
+        num_samples=4,
+        batch_size=2,
+        num_rollout_steps=1,
+        ensemble_size=1,
+        img_shape=(2, 2),
+        channel_names=("a",),
+        output_channels=("a",),
+        scale=None,
+        bias=None,
+        output_memory_buffer_size=None,
+        device=None,
+    ):
+        if device is None:
+            device = torch.device("cpu")
+        H, W = img_shape
+        return RolloutBuffer(
+            num_samples=num_samples,
+            batch_size=batch_size,
+            num_rollout_steps=num_rollout_steps,
+            rollout_dt=1,
+            ensemble_size=ensemble_size,
+            img_shape=(H, W),
+            local_shape=(H, W),
+            local_offset=(0, 0),
+            channel_names=list(channel_names),
+            lat_lon=(list(range(H)), list(range(W))),
+            device=device,
+            scale=scale,
+            bias=bias,
+            output_channels=list(output_channels),
+            output_file=None,
+            output_memory_buffer_size=output_memory_buffer_size,
+        )
+
+    def test_update_writes_to_correct_slot(self, verbose=False):
+        # Channel mask should select 'a' (idx 0) and 'c' (idx 2), drop 'b' (idx 1).
+        # Verify the slot at (sample=0:2, step=0, ensemble=:, channel=:, lat=:, lon=:)
+        # holds the projected per-channel constants.
+        buf = self._make_buffer(
+            num_samples=4,
+            batch_size=2,
+            num_rollout_steps=1,
+            ensemble_size=2,
+            img_shape=(4, 6),
+            channel_names=("a", "b", "c"),
+            output_channels=("a", "c"),
+        )
+
+        pred = torch.zeros(2, 2, 3, 4, 6)
+        pred[..., 0, :, :] = 1.0   # 'a'
+        pred[..., 1, :, :] = 2.0   # 'b' (NOT in output_channels, must be dropped)
+        pred[..., 2, :, :] = 3.0   # 'c'
+        tstamps = torch.tensor([100.0, 200.0])
+
+        buf.update(pred, tstamps, idt=0)
+
+        # Expected output shape (2 samples, 2 ensemble, 2 channels, 4 lat, 6 lon)
+        with self.subTest(desc="channel a values"):
+            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0, :, 0, :, :] == 1.0))
+        with self.subTest(desc="channel c values"):
+            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0, :, 1, :, :] == 3.0))
+        with self.subTest(desc="other slots untouched"):
+            # step 1 should still be zero (we only updated idt=0)
+            self.assertTrue(torch.all(buf.rollout_data_cpu[:, 1, :, :, :, :] == 0.0))
+
+    def test_buffer_offset_advances_only_on_rollout_completion(self, verbose=False):
+        # buffer_offset increments only when idt+1 == num_rollout_steps+1
+        # (i.e., the final step of an IC's rollout). This is the trickiest
+        # invariant — getting it wrong silently corrupts the recorded slots.
+        num_rollout_steps = 3
+        batch_size = 2
+        buf = self._make_buffer(
+            num_samples=4,
+            batch_size=batch_size,
+            num_rollout_steps=num_rollout_steps,
+        )
+
+        pred = torch.zeros(batch_size, 1, 1, 2, 2)
+        tstamps = torch.tensor([0.0, 1.0])
+
+        with self.subTest(desc="initial offset"):
+            self.assertEqual(buf.buffer_offset, 0)
+
+        # Steps 0..R-1: buffer_offset must NOT advance.
+        for idt in range(num_rollout_steps):
+            buf.update(pred, tstamps, idt=idt)
+            with self.subTest(desc=f"idt={idt} (intermediate)"):
+                self.assertEqual(buf.buffer_offset, 0)
+
+        # Final step (idt == num_rollout_steps): buffer_offset advances by batch_size.
+        buf.update(pred, tstamps, idt=num_rollout_steps)
+        with self.subTest(desc="post-final-step offset"):
+            self.assertEqual(buf.buffer_offset, batch_size)
+
+    def test_multi_step_rollout_fills_slots_in_order(self, verbose=False):
+        # Each step writes a known constant; verify slot[idt] == idt afterwards.
+        num_rollout_steps = 3
+        buf = self._make_buffer(
+            num_samples=1,
+            batch_size=1,
+            num_rollout_steps=num_rollout_steps,
+        )
+
+        for idt in range(num_rollout_steps + 1):
+            pred = torch.full((1, 1, 1, 2, 2), float(idt))
+            buf.update(pred, torch.tensor([42.0]), idt=idt)
+
+        for idt in range(num_rollout_steps + 1):
+            with self.subTest(desc=f"slot {idt}"):
+                slot = buf.rollout_data_cpu[0, idt]
+                self.assertTrue(torch.all(slot == float(idt)))
+
+    def test_scale_and_bias_applied(self, verbose=False):
+        # With constant input ones, output per channel should equal scale*1 + bias.
+        scale = torch.tensor([2.0, 3.0])
+        bias = torch.tensor([1.0, -1.0])
+        buf = self._make_buffer(
+            num_samples=1,
+            batch_size=1,
+            num_rollout_steps=0,
+            ensemble_size=1,
+            channel_names=("a", "b"),
+            output_channels=("a", "b"),
+            scale=scale,
+            bias=bias,
+        )
+
+        pred = torch.ones(1, 1, 2, 2, 2)
+        buf.update(pred, torch.tensor([0.0]), idt=0)
+
+        with self.subTest(desc="ch a = 2*1 + 1"):
+            self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0, :, 0, :, :] == 3.0))
+        with self.subTest(desc="ch b = 3*1 - 1"):
+            self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0, :, 1, :, :] == 2.0))
+
+    def test_default_scale_and_bias_are_identity(self, verbose=False):
+        # When scale and bias are None, DataBuffer fills them with ones/zeros so
+        # the projection is the identity. Verify input passes through unchanged.
+        buf = self._make_buffer(num_samples=1, batch_size=1, num_rollout_steps=0)
+
+        pred = torch.full((1, 1, 1, 2, 2), 7.5)
+        buf.update(pred, torch.tensor([0.0]), idt=0)
+
+        self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0] == 7.5))
+
+    def test_timestamps_recorded_only_at_idt_zero(self, verbose=False):
+        # Timestamps for a given IC should be captured at idt=0 and NOT
+        # overwritten by subsequent rollout steps that pass different values.
+        buf = self._make_buffer(
+            num_samples=1, batch_size=1, num_rollout_steps=2,
+        )
+
+        pred = torch.zeros(1, 1, 1, 2, 2)
+
+        buf.update(pred, torch.tensor([100.0]), idt=0)
+        with self.subTest(desc="recorded at idt=0"):
+            self.assertEqual(buf.timestamp_data_cpu[0].item(), 100.0)
+
+        # Pass a different tstamp at later steps — it should be ignored.
+        buf.update(pred, torch.tensor([999.0]), idt=1)
+        buf.update(pred, torch.tensor([777.0]), idt=2)
+        with self.subTest(desc="not overwritten by idt>0"):
+            self.assertEqual(buf.timestamp_data_cpu[0].item(), 100.0)
+
+    def test_zero_buffers_resets_all_state(self, verbose=False):
+        # zero_buffers() is fully self-contained: zeros data tensors AND
+        # resets buffer_offset, so it's safe to call mid-rollout (puts the
+        # buffer back into a fresh post-construction state). Mirrors
+        # MeanStdBuffer.zero_buffers's contract for the offset analog.
+        buf = self._make_buffer(num_samples=2, batch_size=1, num_rollout_steps=0)
+
+        pred = torch.full((1, 1, 1, 2, 2), 5.0)
+        buf.update(pred, torch.tensor([100.0]), idt=0)   # finishes rollout (R=0)
+
+        with self.subTest(desc="pre-zero state"):
+            self.assertEqual(buf.buffer_offset, 1)
+            self.assertNotEqual(buf.rollout_data_cpu.abs().sum().item(), 0.0)
+            self.assertNotEqual(buf.timestamp_data_cpu.abs().sum().item(), 0.0)
+
+        buf.zero_buffers()
+
+        with self.subTest(desc="data zeroed"):
+            self.assertEqual(buf.rollout_data_cpu.abs().sum().item(), 0.0)
+            self.assertEqual(buf.timestamp_data_cpu.abs().sum().item(), 0.0)
+        with self.subTest(desc="offset reset"):
+            self.assertEqual(buf.buffer_offset, 0)
+
+    def test_auto_flush_on_buffer_overflow(self, verbose=False):
+        # Buffer holds 2 ICs (output_memory_buffer_size=2), batch_size=2,
+        # rollout_steps=0 (one timestep per IC). The first batch fills the
+        # buffer; the second batch's idt=0 must trigger _flush_to_disk before
+        # writing, leaving the buffer holding only the second batch's data.
+        # _flush_to_disk's cuda.synchronize is now device-guarded, so this
+        # test runs on either CPU or CUDA.
+        buf = self._make_buffer(
+            num_samples=4,
+            batch_size=2,
+            num_rollout_steps=0,
+            output_memory_buffer_size=2,
+            device=self.device,
+        )
+
+        pred1 = torch.full((2, 1, 1, 2, 2), 1.0, device=self.device)
+        buf.update(pred1, torch.tensor([1.0, 2.0]), idt=0)
+        with self.subTest(desc="buffer full after first batch"):
+            self.assertEqual(buf.buffer_offset, 2)
+
+        # Second batch at idt=0: pre-flush condition (offset+B > capacity) holds.
+        # The implementation auto-flushes, then writes the new batch into a
+        # freshly-zeroed buffer.
+        pred2 = torch.full((2, 1, 1, 2, 2), 9.0, device=self.device)
+        buf.update(pred2, torch.tensor([3.0, 4.0]), idt=0)
+
+        with self.subTest(desc="buffer holds second batch only"):
+            self.assertEqual(buf.buffer_offset, 2)
+            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0] == 9.0))
+
+    def test_output_memory_buffer_size_defaults_to_num_samples(self, verbose=False):
+        # output_memory_buffer_size=None means "buffer the entire run in memory".
+        buf = self._make_buffer(
+            num_samples=10,
+            batch_size=2,
+            output_memory_buffer_size=None,
+        )
+        self.assertEqual(buf.num_buffered_samples, 10)
+
+    def test_output_memory_buffer_size_clamping(self, verbose=False):
+        # The buffer size is clamped to [batch_size, num_samples] inclusive.
+        # Below the floor: clamped up to batch_size (otherwise update() with a
+        # full batch would never fit).
+        with self.subTest(desc="clamps below batch_size"):
+            buf = self._make_buffer(
+                num_samples=10, batch_size=4,
+                output_memory_buffer_size=2,    # below floor
+            )
+            self.assertEqual(buf.num_buffered_samples, 4)
+
+        # Above the ceiling: clamped down to num_samples (no point in
+        # over-allocating).
+        with self.subTest(desc="clamps above num_samples"):
+            buf = self._make_buffer(
+                num_samples=10, batch_size=2,
+                output_memory_buffer_size=100,  # above ceiling
+            )
+            self.assertEqual(buf.num_buffered_samples, 10)
+
+
+class TestRolloutBufferIO(unittest.TestCase):
+    """
+    End-to-end round-trip tests for ``RolloutBuffer``'s HDF5 output path.
+
+    These tests drive only the public API: construct with ``output_file``,
+    call ``update()`` per (batch, idt), then ``finalize()``. They verify
+    correctness by **reading the resulting HDF5 file** rather than by
+    inspecting the buffer's in-memory state. This keeps the tests valid
+    under a future streaming write-path (e.g. GDS-backed) that may bypass
+    the in-memory buffer entirely.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.device("cpu")
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_buffer(
+        self,
+        *,
+        output_file,
+        num_samples=4,
+        batch_size=2,
+        num_rollout_steps=1,
+        rollout_dt=6,
+        ensemble_size=1,
+        img_shape=(2, 4),
+        channel_names=("a", "b"),
+        output_channels=None,
+        scale=None,
+        bias=None,
+        output_memory_buffer_size=None,
+        lat_lon=None,
+    ):
+        if output_channels is None:
+            output_channels = list(channel_names)
+        if lat_lon is None:
+            H, W = img_shape
+            # synthetic lat/lon so we can verify file content
+            lat_lon = (
+                [float(90 - 180.0 * i / max(H - 1, 1)) for i in range(H)],
+                [float(360.0 * j / W) for j in range(W)],
+            )
+        H, W = img_shape
+        return RolloutBuffer(
+            num_samples=num_samples,
+            batch_size=batch_size,
+            num_rollout_steps=num_rollout_steps,
+            rollout_dt=rollout_dt,
+            ensemble_size=ensemble_size,
+            img_shape=(H, W),
+            local_shape=(H, W),
+            local_offset=(0, 0),
+            channel_names=list(channel_names),
+            lat_lon=lat_lon,
+            device=self.device,
+            scale=scale,
+            bias=bias,
+            output_channels=list(output_channels),
+            output_file=output_file,
+            output_memory_buffer_size=output_memory_buffer_size,
+        )
+
+    def _drive_full_rollout(self, buf, *, ic_data_per_batch, tstamps_per_batch):
+        """Feed multiple batches through update() with the canonical step ordering.
+
+        ``ic_data_per_batch[b]`` shape: (batch_size, num_rollout_steps+1,
+        ensemble_size, num_channels, H, W). For each batch and each timestep,
+        we extract the corresponding step slice and call update().
+        """
+        R_plus_1 = ic_data_per_batch[0].shape[1]
+        for batch_idx, (batch, tstamps) in enumerate(zip(ic_data_per_batch, tstamps_per_batch)):
+            for idt in range(R_plus_1):
+                buf.update(batch[:, idt], tstamps, idt=idt)
+
+    def test_dataset_shape_and_dtype(self, verbose=False):
+        # Verify the output HDF5 ``fields`` dataset has the expected
+        # (num_samples, R+1, ensemble_size, num_channels, H, W) shape and
+        # float32 dtype. This is the contract every consumer relies on.
+        out_path = os.path.join(self.tmpdir, "structure.h5")
+        num_samples = 4
+        num_rollout_steps = 2
+        ensemble_size = 3
+        img_shape = (4, 6)
+        output_channels = ["a", "c"]
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=num_samples,
+            batch_size=2,
+            num_rollout_steps=num_rollout_steps,
+            ensemble_size=ensemble_size,
+            img_shape=img_shape,
+            channel_names=("a", "b", "c"),
+            output_channels=output_channels,
+        )
+
+        # Feed enough zero data to fill all ICs through full rollouts.
+        zero_batches = [
+            torch.zeros(2, num_rollout_steps + 1, ensemble_size, 3, *img_shape)
+            for _ in range(2)   # 2 batches × 2 ICs each = 4 ICs total
+        ]
+        tstamps = [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])]
+        self._drive_full_rollout(buf, ic_data_per_batch=zero_batches, tstamps_per_batch=tstamps)
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            with self.subTest(desc="dataset shape"):
+                self.assertEqual(
+                    f["fields"].shape,
+                    (num_samples, num_rollout_steps + 1, ensemble_size, len(output_channels), *img_shape),
+                )
+            with self.subTest(desc="dataset dtype"):
+                self.assertEqual(f["fields"].dtype, np.float32)
+            with self.subTest(desc="dim labels"):
+                self.assertEqual(f["fields"].dims[0].label, "Timestamp in UTC time zone")
+                self.assertEqual(f["fields"].dims[1].label, "Lead time relative to timestamp")
+                self.assertEqual(f["fields"].dims[2].label, "Ensemble index")
+                self.assertEqual(f["fields"].dims[3].label, "Channel name")
+                self.assertEqual(f["fields"].dims[4].label, "Latitude in degrees")
+                self.assertEqual(f["fields"].dims[5].label, "Longitude in degrees")
+
+    def test_round_trip_single_flush(self, verbose=False):
+        # Whole run fits in a single in-memory buffer (no auto-flush).
+        # Per-IC data is a unique constant so we can verify routing into
+        # (sample, step, ensemble, channel, lat, lon) slots after readback.
+        out_path = os.path.join(self.tmpdir, "single_flush.h5")
+        num_samples = 4
+        R = 2
+        E = 1
+        H, W = 2, 4
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=num_samples, batch_size=2,
+            num_rollout_steps=R, ensemble_size=E,
+            img_shape=(H, W), channel_names=("a",),
+        )
+
+        # batch 0: ICs 0, 1; batch 1: ICs 2, 3
+        # data[ic, idt, e, c, h, w] = ic * 10 + idt
+        batches = []
+        for b in range(2):
+            arr = torch.zeros(2, R + 1, E, 1, H, W)
+            for i in range(2):
+                ic = b * 2 + i
+                for idt in range(R + 1):
+                    arr[i, idt, ...] = float(ic * 10 + idt)
+            batches.append(arr)
+        tstamps = [torch.tensor([100.0, 200.0]), torch.tensor([300.0, 400.0])]
+
+        self._drive_full_rollout(buf, ic_data_per_batch=batches, tstamps_per_batch=tstamps)
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            data = f["fields"][...]
+            ts = f["timestamp"][...]
+
+        for ic in range(num_samples):
+            for idt in range(R + 1):
+                with self.subTest(desc=f"ic={ic} idt={idt}"):
+                    self.assertTrue(
+                        np.all(data[ic, idt] == float(ic * 10 + idt)),
+                        msg=f"slot (ic={ic}, idt={idt}) has wrong content",
+                    )
+        with self.subTest(desc="timestamps"):
+            self.assertTrue(np.array_equal(ts, np.array([100.0, 200.0, 300.0, 400.0], dtype=np.float64)))
+
+    def test_round_trip_with_auto_flush(self, verbose=False):
+        # ``output_memory_buffer_size`` < ``num_samples`` forces at least one
+        # mid-run flush. Verify the full file still contains every IC at the
+        # right (sample, step, ...) coordinates — i.e. the auto-flush bookkeeping
+        # for ``file_offset`` is correct.
+        out_path = os.path.join(self.tmpdir, "auto_flush.h5")
+        num_samples = 6
+        R = 1
+        H, W = 2, 3
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=num_samples, batch_size=2,
+            num_rollout_steps=R, ensemble_size=1,
+            img_shape=(H, W), channel_names=("a",),
+            output_memory_buffer_size=2,   # forces auto-flush every batch
+        )
+
+        # 3 batches × 2 ICs each = 6 ICs. Same encoding as single-flush case.
+        batches = []
+        for b in range(3):
+            arr = torch.zeros(2, R + 1, 1, 1, H, W)
+            for i in range(2):
+                ic = b * 2 + i
+                for idt in range(R + 1):
+                    arr[i, idt, ...] = float(ic * 10 + idt)
+            batches.append(arr)
+        tstamps = [torch.tensor([float(b * 2), float(b * 2 + 1)]) for b in range(3)]
+
+        self._drive_full_rollout(buf, ic_data_per_batch=batches, tstamps_per_batch=tstamps)
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            data = f["fields"][...]
+            ts = f["timestamp"][...]
+
+        with self.subTest(desc="all ICs present"):
+            for ic in range(num_samples):
+                for idt in range(R + 1):
+                    self.assertTrue(
+                        np.all(data[ic, idt] == float(ic * 10 + idt)),
+                        msg=f"after auto-flush: slot (ic={ic}, idt={idt}) corrupt",
+                    )
+        with self.subTest(desc="timestamps in correct order across flushes"):
+            self.assertTrue(np.array_equal(ts, np.arange(num_samples, dtype=np.float64)))
+
+    def test_dim_scales_attached_and_correct(self, verbose=False):
+        # The fields dataset has 5 named dim scales: timestamp, lead_time,
+        # channel, lat, lon. Verify each resolves and contains the expected
+        # values (channels and lat/lon set unconditionally; timestamp populated
+        # via update() calls; lead_time computed from rollout_dt).
+        out_path = os.path.join(self.tmpdir, "scales.h5")
+        H, W = 3, 5
+        rollout_dt = 6
+        R = 2
+        channel_names = ("a", "b")
+        output_channels = ["a", "b"]
+        lat = [60.0, 0.0, -60.0]
+        lon = [0.0, 72.0, 144.0, 216.0, 288.0]
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=2, batch_size=2,
+            num_rollout_steps=R, rollout_dt=rollout_dt,
+            ensemble_size=1, img_shape=(H, W),
+            channel_names=channel_names, output_channels=output_channels,
+            lat_lon=(lat, lon),
+        )
+
+        zero_batch = torch.zeros(2, R + 1, 1, 2, H, W)
+        self._drive_full_rollout(
+            buf,
+            ic_data_per_batch=[zero_batch],
+            tstamps_per_batch=[torch.tensor([1234.0, 5678.0])],
+        )
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            dset = f["fields"]
+            with self.subTest(desc="timestamp scale on dim 0"):
+                self.assertTrue(np.array_equal(dset.dims[0]["timestamp"][...], [1234.0, 5678.0]))
+            with self.subTest(desc="lead_time scale on dim 1"):
+                expected_lt = np.arange(0, (R + 1) * rollout_dt, rollout_dt, dtype=np.float64)
+                self.assertTrue(np.array_equal(dset.dims[1]["lead_time"][...], expected_lt))
+            with self.subTest(desc="channel scale on dim 3"):
+                names = [c.decode() for c in dset.dims[3]["channel"][...].tolist()]
+                self.assertEqual(names, output_channels)
+            with self.subTest(desc="lat scale on dim 4"):
+                self.assertTrue(np.allclose(dset.dims[4]["lat"][...], np.array(lat, dtype=np.float32)))
+            with self.subTest(desc="lon scale on dim 5"):
+                self.assertTrue(np.allclose(dset.dims[5]["lon"][...], np.array(lon, dtype=np.float32)))
+
+    def test_scale_and_bias_propagated_to_file(self, verbose=False):
+        # Constant input (ones) with non-trivial scale + bias should land in
+        # the file as scale*1 + bias per channel.
+        out_path = os.path.join(self.tmpdir, "scale_bias.h5")
+        scale = torch.tensor([2.0, 0.5])
+        bias = torch.tensor([1.0, -1.0])
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=2, batch_size=2,
+            num_rollout_steps=0, ensemble_size=1,
+            img_shape=(2, 2),
+            channel_names=("a", "b"), output_channels=["a", "b"],
+            scale=scale, bias=bias,
+        )
+
+        ones = torch.ones(2, 1, 1, 2, 2, 2)   # (batch, R+1, E, C, H, W)
+        self._drive_full_rollout(buf, ic_data_per_batch=[ones], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            data = f["fields"][...]   # (2, 1, 1, 2, 2, 2)
+
+        with self.subTest(desc="channel a = 2*1 + 1 = 3"):
+            self.assertTrue(np.all(data[:, :, :, 0, :, :] == 3.0))
+        with self.subTest(desc="channel b = 0.5*1 + (-1) = -0.5"):
+            self.assertTrue(np.all(data[:, :, :, 1, :, :] == -0.5))
+
+    def test_channel_mask_subset_written(self, verbose=False):
+        # full input has 3 channels (a, b, c); output_channels = (a, c).
+        # The file should have only 2 channels and they should be a/c values.
+        out_path = os.path.join(self.tmpdir, "mask.h5")
+
+        buf = self._make_buffer(
+            output_file=out_path,
+            num_samples=2, batch_size=2,
+            num_rollout_steps=0, ensemble_size=1,
+            img_shape=(2, 2),
+            channel_names=("a", "b", "c"), output_channels=["a", "c"],
+        )
+
+        # full pred has 3 channels; values 100/200/300 per channel
+        pred = torch.zeros(2, 1, 1, 3, 2, 2)
+        pred[..., 0, :, :] = 100.0   # a → kept
+        pred[..., 1, :, :] = 200.0   # b → dropped
+        pred[..., 2, :, :] = 300.0   # c → kept
+
+        self._drive_full_rollout(buf, ic_data_per_batch=[pred], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+        buf.finalize()
+
+        with h5.File(out_path, "r") as f:
+            data = f["fields"][...]
+            channel_names = [c.decode() for c in f["channel"][...].tolist()]
+
+        with self.subTest(desc="only 2 channels in file"):
+            self.assertEqual(data.shape[3], 2)
+            self.assertEqual(channel_names, ["a", "c"])
+        with self.subTest(desc="channel 'a' kept its value"):
+            self.assertTrue(np.all(data[:, :, :, 0, :, :] == 100.0))
+        with self.subTest(desc="channel 'c' kept its value"):
+            self.assertTrue(np.all(data[:, :, :, 1, :, :] == 300.0))
+
+    def test_finalize_idempotent(self, verbose=False):
+        # finalize() must be safe to call more than once. The recent fix
+        # (file_handle = None after close) makes the second call a no-op
+        # rather than an h5py error.
+        out_path = os.path.join(self.tmpdir, "idempotent.h5")
+        buf = self._make_buffer(output_file=out_path)
+
+        zero = torch.zeros(2, 2, 1, 2, 2, 4)
+        self._drive_full_rollout(buf, ic_data_per_batch=[zero], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+
+        buf.finalize()
+        with self.subTest(desc="file_handle nulled after first finalize"):
+            self.assertIsNone(buf.file_handle)
+
+        # Second finalize should not raise.
+        try:
+            buf.finalize()
+        except Exception as e:
+            self.fail(f"second finalize() raised: {e!r}")
+
+        # File on disk is unaffected and still readable.
+        with h5.File(out_path, "r") as f:
+            self.assertEqual(f["fields"].shape, (4, 2, 1, 2, 2, 4))
 
 
 if __name__ == "__main__":

--- a/tests/test_rollout_buffers.py
+++ b/tests/test_rollout_buffers.py
@@ -555,14 +555,13 @@ class TestRolloutBuffer(unittest.TestCase):
       * auto-flush on buffer-overflow at idt=0
       * output_memory_buffer_size defaults and clamping
 
-    The auto-flush test requires CUDA because ``_flush_to_disk`` calls
-    ``torch.cuda.synchronize`` unconditionally; it's skipped on CPU-only hosts.
+    Runs on CPU end-to-end: ``_flush_buffer_to_disk``'s
+    ``torch.cuda.synchronize`` is now device-guarded, so the auto-flush test
+    no longer requires CUDA.
     """
 
     @classmethod
     def setUpClass(cls):
-        # CPU is fine for everything except _flush_to_disk; per-test guards
-        # skip that single case if CUDA isn't available.
         cls.device = torch.device("cpu")
 
     @staticmethod
@@ -626,12 +625,12 @@ class TestRolloutBuffer(unittest.TestCase):
 
         # Expected output shape (2 samples, 2 ensemble, 2 channels, 4 lat, 6 lon)
         with self.subTest(desc="channel a values"):
-            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0, :, 0, :, :] == 1.0))
+            self.assertTrue(torch.all(buf.rollout_data[0:2, 0, :, 0, :, :] == 1.0))
         with self.subTest(desc="channel c values"):
-            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0, :, 1, :, :] == 3.0))
+            self.assertTrue(torch.all(buf.rollout_data[0:2, 0, :, 1, :, :] == 3.0))
         with self.subTest(desc="other slots untouched"):
             # step 1 should still be zero (we only updated idt=0)
-            self.assertTrue(torch.all(buf.rollout_data_cpu[:, 1, :, :, :, :] == 0.0))
+            self.assertTrue(torch.all(buf.rollout_data[:, 1, :, :, :, :] == 0.0))
 
     def test_buffer_offset_advances_only_on_rollout_completion(self, verbose=False):
         # buffer_offset increments only when idt+1 == num_rollout_steps+1
@@ -677,7 +676,7 @@ class TestRolloutBuffer(unittest.TestCase):
 
         for idt in range(num_rollout_steps + 1):
             with self.subTest(desc=f"slot {idt}"):
-                slot = buf.rollout_data_cpu[0, idt]
+                slot = buf.rollout_data[0, idt]
                 self.assertTrue(torch.all(slot == float(idt)))
 
     def test_scale_and_bias_applied(self, verbose=False):
@@ -699,9 +698,9 @@ class TestRolloutBuffer(unittest.TestCase):
         buf.update(pred, torch.tensor([0.0]), idt=0)
 
         with self.subTest(desc="ch a = 2*1 + 1"):
-            self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0, :, 0, :, :] == 3.0))
+            self.assertTrue(torch.all(buf.rollout_data[0, 0, :, 0, :, :] == 3.0))
         with self.subTest(desc="ch b = 3*1 - 1"):
-            self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0, :, 1, :, :] == 2.0))
+            self.assertTrue(torch.all(buf.rollout_data[0, 0, :, 1, :, :] == 2.0))
 
     def test_default_scale_and_bias_are_identity(self, verbose=False):
         # When scale and bias are None, DataBuffer fills them with ones/zeros so
@@ -711,7 +710,7 @@ class TestRolloutBuffer(unittest.TestCase):
         pred = torch.full((1, 1, 1, 2, 2), 7.5)
         buf.update(pred, torch.tensor([0.0]), idt=0)
 
-        self.assertTrue(torch.all(buf.rollout_data_cpu[0, 0] == 7.5))
+        self.assertTrue(torch.all(buf.rollout_data[0, 0] == 7.5))
 
     def test_timestamps_recorded_only_at_idt_zero(self, verbose=False):
         # Timestamps for a given IC should be captured at idt=0 and NOT
@@ -724,13 +723,13 @@ class TestRolloutBuffer(unittest.TestCase):
 
         buf.update(pred, torch.tensor([100.0]), idt=0)
         with self.subTest(desc="recorded at idt=0"):
-            self.assertEqual(buf.timestamp_data_cpu[0].item(), 100.0)
+            self.assertEqual(buf.timestamp_data[0].item(), 100.0)
 
         # Pass a different tstamp at later steps — it should be ignored.
         buf.update(pred, torch.tensor([999.0]), idt=1)
         buf.update(pred, torch.tensor([777.0]), idt=2)
         with self.subTest(desc="not overwritten by idt>0"):
-            self.assertEqual(buf.timestamp_data_cpu[0].item(), 100.0)
+            self.assertEqual(buf.timestamp_data[0].item(), 100.0)
 
     def test_zero_buffers_resets_all_state(self, verbose=False):
         # zero_buffers() is fully self-contained: zeros data tensors AND
@@ -744,23 +743,23 @@ class TestRolloutBuffer(unittest.TestCase):
 
         with self.subTest(desc="pre-zero state"):
             self.assertEqual(buf.buffer_offset, 1)
-            self.assertNotEqual(buf.rollout_data_cpu.abs().sum().item(), 0.0)
-            self.assertNotEqual(buf.timestamp_data_cpu.abs().sum().item(), 0.0)
+            self.assertNotEqual(buf.rollout_data.abs().sum().item(), 0.0)
+            self.assertNotEqual(buf.timestamp_data.abs().sum().item(), 0.0)
 
         buf.zero_buffers()
 
         with self.subTest(desc="data zeroed"):
-            self.assertEqual(buf.rollout_data_cpu.abs().sum().item(), 0.0)
-            self.assertEqual(buf.timestamp_data_cpu.abs().sum().item(), 0.0)
+            self.assertEqual(buf.rollout_data.abs().sum().item(), 0.0)
+            self.assertEqual(buf.timestamp_data.abs().sum().item(), 0.0)
         with self.subTest(desc="offset reset"):
             self.assertEqual(buf.buffer_offset, 0)
 
     def test_auto_flush_on_buffer_overflow(self, verbose=False):
         # Buffer holds 2 ICs (output_memory_buffer_size=2), batch_size=2,
         # rollout_steps=0 (one timestep per IC). The first batch fills the
-        # buffer; the second batch's idt=0 must trigger _flush_to_disk before
+        # buffer; the second batch's idt=0 must trigger _flush_buffer_to_disk before
         # writing, leaving the buffer holding only the second batch's data.
-        # _flush_to_disk's cuda.synchronize is now device-guarded, so this
+        # _flush_buffer_to_disk's cuda.synchronize is now device-guarded, so this
         # test runs on either CPU or CUDA.
         buf = self._make_buffer(
             num_samples=4,
@@ -783,7 +782,7 @@ class TestRolloutBuffer(unittest.TestCase):
 
         with self.subTest(desc="buffer holds second batch only"):
             self.assertEqual(buf.buffer_offset, 2)
-            self.assertTrue(torch.all(buf.rollout_data_cpu[0:2, 0] == 9.0))
+            self.assertTrue(torch.all(buf.rollout_data[0:2, 0] == 9.0))
 
     def test_output_memory_buffer_size_defaults_to_num_samples(self, verbose=False):
         # output_memory_buffer_size=None means "buffer the entire run in memory".
@@ -1166,6 +1165,302 @@ class TestRolloutBufferIO(unittest.TestCase):
         # File on disk is unaffected and still readable.
         with h5.File(out_path, "r") as f:
             self.assertEqual(f["fields"].shape, (4, 2, 1, 2, 2, 4))
+
+
+class TestRolloutBufferStreaming(unittest.TestCase):
+    """
+    Tests for ``RolloutBuffer``'s streaming mode and ``buffer_device``
+    parameter.
+
+    Streaming mode skips the in-memory buffer entirely and writes directly to
+    HDF5 on every ``update()``. ``buffer_device`` controls where the
+    in-memory buffer (when present) lives — defaulting to CPU but allowing a
+    GPU-resident buffer to avoid GPU→CPU traffic on every update.
+
+    These tests reuse the public-API-only style of ``TestRolloutBufferIO``:
+    construction → ``update()`` → ``finalize()`` → readback. We assert on
+    file content (the contract) rather than internal state where possible.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.device("cpu")
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_buffer(
+        self,
+        *,
+        output_file,
+        num_samples=4,
+        batch_size=2,
+        num_rollout_steps=1,
+        rollout_dt=6,
+        ensemble_size=1,
+        img_shape=(2, 4),
+        channel_names=("a", "b"),
+        output_channels=None,
+        scale=None,
+        bias=None,
+        output_memory_buffer_size=None,
+        streaming_mode=False,
+        buffer_device=torch.device("cpu"),
+    ):
+        if output_channels is None:
+            output_channels = list(channel_names)
+        H, W = img_shape
+        lat_lon = (
+            [float(90 - 180.0 * i / max(H - 1, 1)) for i in range(H)],
+            [float(360.0 * j / W) for j in range(W)],
+        )
+        return RolloutBuffer(
+            num_samples=num_samples,
+            batch_size=batch_size,
+            num_rollout_steps=num_rollout_steps,
+            rollout_dt=rollout_dt,
+            ensemble_size=ensemble_size,
+            img_shape=(H, W),
+            local_shape=(H, W),
+            local_offset=(0, 0),
+            channel_names=list(channel_names),
+            lat_lon=lat_lon,
+            device=self.device,
+            scale=scale,
+            bias=bias,
+            output_channels=list(output_channels),
+            output_file=output_file,
+            output_memory_buffer_size=output_memory_buffer_size,
+            streaming_mode=streaming_mode,
+            buffer_device=buffer_device,
+        )
+
+    def _drive_full_rollout(self, buf, *, ic_data_per_batch, tstamps_per_batch):
+        R_plus_1 = ic_data_per_batch[0].shape[1]
+        for batch, tstamps in zip(ic_data_per_batch, tstamps_per_batch):
+            for idt in range(R_plus_1):
+                buf.update(batch[:, idt], tstamps, idt=idt)
+
+    def test_streaming_without_output_file_raises(self, verbose=False):
+        # Streaming mode has no in-memory fallback — every update writes
+        # directly to disk, so output_file is mandatory.
+        with self.assertRaises(ValueError):
+            self._make_buffer(output_file=None, streaming_mode=True)
+
+    def test_streaming_skips_in_memory_buffer_allocation(self, verbose=False):
+        # Streaming mode must NOT allocate the (potentially huge) rollout
+        # tensors. ``rollout_data`` and ``timestamp_data`` are None.
+        out_path = os.path.join(self.tmpdir, "no_buf.h5")
+        buf = self._make_buffer(output_file=out_path, streaming_mode=True)
+        with self.subTest(desc="rollout_data is None"):
+            self.assertIsNone(buf.rollout_data)
+        with self.subTest(desc="timestamp_data is None"):
+            self.assertIsNone(buf.timestamp_data)
+        # Drive a no-op rollout so finalize() doesn't trip on an empty file.
+        zero = torch.zeros(2, 2, 1, 2, 2, 4)
+        self._drive_full_rollout(buf, ic_data_per_batch=[zero], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+        buf.finalize()
+
+    def test_streaming_round_trip_matches_buffered(self, verbose=False):
+        # The same input, fed through streaming-mode and buffered-mode buffers,
+        # must produce byte-identical output files. This is the strongest
+        # correctness check: it pins down that streaming hits the same disk
+        # coordinates as the bulk-flush path.
+        num_samples = 6
+        R = 1
+        H, W = 2, 3
+        img_shape = (H, W)
+
+        # build identical inputs
+        batches = []
+        for b in range(3):
+            arr = torch.zeros(2, R + 1, 1, 1, H, W)
+            for i in range(2):
+                ic = b * 2 + i
+                for idt in range(R + 1):
+                    arr[i, idt, ...] = float(ic * 10 + idt)
+            batches.append(arr)
+        tstamps = [torch.tensor([float(b * 2), float(b * 2 + 1)]) for b in range(3)]
+
+        out_streaming = os.path.join(self.tmpdir, "streaming.h5")
+        out_buffered = os.path.join(self.tmpdir, "buffered.h5")
+
+        for path, streaming in [(out_streaming, True), (out_buffered, False)]:
+            buf = self._make_buffer(
+                output_file=path,
+                num_samples=num_samples, batch_size=2,
+                num_rollout_steps=R, ensemble_size=1,
+                img_shape=img_shape, channel_names=("a",),
+                streaming_mode=streaming,
+            )
+            self._drive_full_rollout(buf, ic_data_per_batch=batches, tstamps_per_batch=tstamps)
+            buf.finalize()
+
+        with h5.File(out_streaming, "r") as f_s, h5.File(out_buffered, "r") as f_b:
+            with self.subTest(desc="fields match buffered mode"):
+                self.assertTrue(np.array_equal(f_s["fields"][...], f_b["fields"][...]))
+            with self.subTest(desc="timestamps match buffered mode"):
+                self.assertTrue(np.array_equal(f_s["timestamp"][...], f_b["timestamp"][...]))
+
+    def test_streaming_zero_buffers_is_noop(self, verbose=False):
+        # Without buffers, zero_buffers() must not raise (and must not touch
+        # the file_offset bookkeeping that streaming depends on).
+        out_path = os.path.join(self.tmpdir, "zero_noop.h5")
+        buf = self._make_buffer(output_file=out_path, streaming_mode=True)
+
+        # advance file_offset via a full IC rollout
+        zero = torch.zeros(2, 2, 1, 2, 2, 4)
+        self._drive_full_rollout(buf, ic_data_per_batch=[zero], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+        offset_before = buf.file_offset
+
+        buf.zero_buffers()
+        with self.subTest(desc="no exception"):
+            pass
+        with self.subTest(desc="file_offset preserved"):
+            self.assertEqual(buf.file_offset, offset_before)
+        buf.finalize()
+
+    def test_streaming_finalize_idempotent(self, verbose=False):
+        # finalize() in streaming mode must close the file once and be safe
+        # to call again. Mirrors test_finalize_idempotent for the buffered path.
+        out_path = os.path.join(self.tmpdir, "stream_idempotent.h5")
+        buf = self._make_buffer(output_file=out_path, streaming_mode=True)
+
+        zero = torch.zeros(2, 2, 1, 2, 2, 4)
+        self._drive_full_rollout(buf, ic_data_per_batch=[zero], tstamps_per_batch=[torch.tensor([0.0, 1.0])])
+
+        buf.finalize()
+        with self.subTest(desc="file_handle nulled after first finalize"):
+            self.assertIsNone(buf.file_handle)
+
+        try:
+            buf.finalize()
+        except Exception as e:
+            self.fail(f"second finalize() raised: {e!r}")
+
+    def test_buffer_device_string_resolves_to_torch_device(self, verbose=False):
+        # Passing a string device name should resolve to a torch.device on
+        # ``buffer_device``, matching how ``device`` is handled.
+        buf = self._make_buffer(output_file=None, buffer_device="cpu")
+        self.assertIsInstance(buf.buffer_device, torch.device)
+        self.assertEqual(buf.buffer_device.type, "cpu")
+
+    def test_buffer_device_default_is_cpu(self, verbose=False):
+        # Constructed without ``buffer_device`` the buffer must land on CPU,
+        # preserving pre-port behavior for callers that don't opt in to
+        # GPU-resident buffers. Construct ``RolloutBuffer`` directly (bypassing
+        # the helper) so this test pins the actual signature default.
+        H, W = 2, 4
+        lat_lon = (
+            [float(90 - 180.0 * i / max(H - 1, 1)) for i in range(H)],
+            [float(360.0 * j / W) for j in range(W)],
+        )
+        buf = RolloutBuffer(
+            num_samples=4,
+            batch_size=2,
+            num_rollout_steps=1,
+            rollout_dt=6,
+            ensemble_size=1,
+            img_shape=(H, W),
+            local_shape=(H, W),
+            local_offset=(0, 0),
+            channel_names=["a", "b"],
+            lat_lon=lat_lon,
+            device=self.device,
+            output_channels=["a", "b"],
+            output_file=None,
+        )
+        self.assertEqual(buf.buffer_device.type, "cpu")
+        self.assertEqual(buf.rollout_data.device.type, "cpu")
+        self.assertEqual(buf.timestamp_data.device.type, "cpu")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for GPU-resident buffer test")
+    def test_buffer_device_cuda_keeps_buffer_on_gpu(self, verbose=False):
+        # When buffer_device is CUDA, the buffer tensors must live on GPU and
+        # pin_memory must be False (pinning only applies to host memory).
+        cuda_dev = torch.device("cuda:0")
+        buf = self._make_buffer(output_file=None, buffer_device=cuda_dev)
+        with self.subTest(desc="rollout_data on cuda"):
+            self.assertEqual(buf.rollout_data.device.type, "cuda")
+        with self.subTest(desc="timestamp_data on cuda"):
+            self.assertEqual(buf.timestamp_data.device.type, "cuda")
+        with self.subTest(desc="not pinned"):
+            self.assertFalse(buf.rollout_data.is_pinned())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required for GPU-resident buffer round-trip test")
+    def test_buffer_device_cuda_round_trip_matches_cpu(self, verbose=False):
+        # End-to-end: CUDA-resident buffer must produce the same file as a
+        # CPU buffer for identical inputs. This catches mistakes in the
+        # GPU→CPU bridge inside _flush_buffer_to_disk.
+        cuda_dev = torch.device("cuda:0")
+        num_samples = 4
+        R = 1
+        H, W = 2, 3
+
+        # build identical inputs (place on CUDA so update() copy_ has work to do)
+        batches_cpu = []
+        for b in range(2):
+            arr = torch.zeros(2, R + 1, 1, 1, H, W)
+            for i in range(2):
+                ic = b * 2 + i
+                for idt in range(R + 1):
+                    arr[i, idt, ...] = float(ic * 10 + idt)
+            batches_cpu.append(arr)
+        batches_cuda = [b.to(cuda_dev) for b in batches_cpu]
+        tstamps_cpu = [torch.tensor([float(b * 2), float(b * 2 + 1)]) for b in range(2)]
+        tstamps_cuda = [t.to(cuda_dev) for t in tstamps_cpu]
+
+        # CPU buffer reference (default buffer_device)
+        out_cpu = os.path.join(self.tmpdir, "buf_cpu.h5")
+        buf_cpu = self._make_buffer(
+            output_file=out_cpu,
+            num_samples=num_samples, batch_size=2,
+            num_rollout_steps=R, ensemble_size=1,
+            img_shape=(H, W), channel_names=("a",),
+        )
+        self._drive_full_rollout(buf_cpu, ic_data_per_batch=batches_cpu, tstamps_per_batch=tstamps_cpu)
+        buf_cpu.finalize()
+
+        # CUDA buffer
+        out_cuda = os.path.join(self.tmpdir, "buf_cuda.h5")
+        # we want device=cuda too so .copy_(non_blocking=True) into a cuda buffer works
+        H_, W_ = H, W
+        lat_lon = (
+            [float(90 - 180.0 * i / max(H_ - 1, 1)) for i in range(H_)],
+            [float(360.0 * j / W_) for j in range(W_)],
+        )
+        buf_cuda = RolloutBuffer(
+            num_samples=num_samples,
+            batch_size=2,
+            num_rollout_steps=R,
+            rollout_dt=6,
+            ensemble_size=1,
+            img_shape=(H, W),
+            local_shape=(H, W),
+            local_offset=(0, 0),
+            channel_names=["a"],
+            lat_lon=lat_lon,
+            device=cuda_dev,
+            scale=None,
+            bias=None,
+            output_channels=["a"],
+            output_file=out_cuda,
+            output_memory_buffer_size=None,
+            streaming_mode=False,
+            buffer_device=cuda_dev,
+        )
+        self._drive_full_rollout(buf_cuda, ic_data_per_batch=batches_cuda, tstamps_per_batch=tstamps_cuda)
+        buf_cuda.finalize()
+
+        with h5.File(out_cpu, "r") as f_c, h5.File(out_cuda, "r") as f_g:
+            with self.subTest(desc="fields match"):
+                self.assertTrue(np.array_equal(f_c["fields"][...], f_g["fields"][...]))
+            with self.subTest(desc="timestamps match"):
+                self.assertTrue(np.array_equal(f_c["timestamp"][...], f_g["timestamp"][...]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this MR add streaming mode support for the rollout buffer as well as device buffers. This is prepared for GDS supports once it lands production ready in h5py and HDF5. However, for small memory footprints, streaming mode is already useful without it.

this should not be merged before https://github.com/NVIDIA/makani/pull/89
(it would work but the diff is much larger than necessary)