### PR TITLE
small loss improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy tensorly tensorly-torch more_itertools importlib-metadata
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install git+https://github.com/NVIDIA/torch-harmonics.git@main
+        python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
         python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
     - name: Install package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy tensorly tensorly-torch more_itertools importlib-metadata
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install torch-harmonics
+        python -m pip install "torch-harmonics>=0.9.0"
         python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
     - name: Install package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
     - name: Install package
       run: |
-        python -m pip install -e .
+        python -m pip install --no-deps -e .
     - name: Test with pytest
       run: |
         python -m pip install pytest pytest-cov parameterized

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy tensorly tensorly-torch more_itertools importlib-metadata
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install "torch-harmonics>=0.9.0"
+        python -m pip install git+https://github.com/NVIDIA/torch-harmonics.git@main
         python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
     - name: Install package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
         python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy tensorly tensorly-torch more_itertools importlib-metadata
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
         python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
+        python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
     - name: Install package
       run: |
         python -m pip install -e .

--- a/makani/utils/losses/base_loss.py
+++ b/makani/utils/losses/base_loss.py
@@ -404,7 +404,7 @@ class SpectralBaseLoss(nn.Module, metaclass=ABCMeta):
 
     @property
     def n_channels(self):
-        return len(self.n_channels)
+        return len(self.channel_names)
 
     @torch.compiler.disable(recursive=False)
     def compute_channel_weighting(self, channel_weight_type: str, time_diff_scale: torch.Tensor = None) -> torch.Tensor:
@@ -470,7 +470,7 @@ class VortDivBaseLoss(nn.Module, metaclass=ABCMeta):
 
     @property
     def n_channels(self):
-        return len(self.n_channels)
+        return self.wind_chans.shape[0]
 
     @torch.compiler.disable(recursive=False)
     def compute_channel_weighting(self, channel_weight_type: str, time_diff_scale: torch.Tensor = None) -> torch.Tensor:
@@ -540,7 +540,7 @@ class GradientBaseLoss(nn.Module, metaclass=ABCMeta):
 
     @property
     def n_channels(self):
-        return len(self.n_channels)
+        return len(self.channel_names)
 
     @torch.compiler.disable(recursive=False)
     def compute_channel_weighting(self, channel_weight_type: str, time_diff_scale: torch.Tensor = None) -> torch.Tensor:

--- a/makani/utils/losses/crps_loss.py
+++ b/makani/utils/losses/crps_loss.py
@@ -282,8 +282,8 @@ class CRPSLoss(GeometricBaseLoss):
         self.alpha = alpha
         self.eps = eps
 
-        if (self.crps_type != "skillspread") and (self.alpha < 1.0):
-            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernel.")
+        if (self.crps_type not in ("skillspread", "naive skillspread")) and (self.alpha < 1.0):
+            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernels.")
 
         # we also need a variant of the weights split in ensemble direction:
         quad_weight_split = self.quadrature.quad_weight.reshape(1, 1, -1)
@@ -448,8 +448,8 @@ class SpectralCRPSLoss(SpectralBaseLoss):
         self.alpha = alpha
         self.eps = eps
 
-        if (self.crps_type != "skillspread") and (self.alpha < 1.0):
-            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernel.")
+        if (self.crps_type not in ("skillspread", "naive skillspread")) and (self.alpha < 1.0):
+            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernels.")
 
         if ensemble_weights is not None:
             self.register_buffer("ensemble_weights", ensemble_weights, persistent=False)
@@ -623,8 +623,8 @@ class GradientCRPSLoss(GradientBaseLoss):
         self.alpha = alpha
         self.eps = eps
 
-        if (self.crps_type != "skillspread") and (self.alpha < 1.0):
-            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernel.")
+        if (self.crps_type not in ("skillspread", "naive skillspread")) and (self.alpha < 1.0):
+            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernels.")
 
         # we also need a variant of the weights split in ensemble direction:
         quad_weight_split = self.quadrature.quad_weight.reshape(1, 1, -1)
@@ -809,8 +809,8 @@ class VortDivCRPSLoss(VortDivBaseLoss):
         self.alpha = alpha
         self.eps = eps
 
-        if (self.crps_type != "skillspread") and (self.alpha < 1.0):
-            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernel.")
+        if (self.crps_type not in ("skillspread", "naive skillspread")) and (self.alpha < 1.0):
+            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernels.")
 
         # we also need a variant of the weights split in ensemble direction:
         quad_weight_split = self.quadrature.quad_weight.reshape(1, 1, -1)
@@ -974,8 +974,8 @@ class KernelScoreLoss(GeometricBaseLoss):
         self.alpha = alpha
         self.eps = eps
 
-        if (self.crps_type != "skillspread") and (self.alpha < 1.0):
-            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernel.")
+        if (self.crps_type not in ("skillspread", "naive skillspread")) and (self.alpha < 1.0):
+            raise NotImplementedError("The alpha parameter (almost fair CRPS factor) is only supported for the skillspread kernels.")
 
         # we also need a variant of the weights split in ensemble direction:
         quad_weight_split = self.quadrature.quad_weight.reshape(1, 1, -1)

--- a/makani/utils/losses/energy_score.py
+++ b/makani/utils/losses/energy_score.py
@@ -598,6 +598,7 @@ class SpectralCoherenceLoss(SpectralBaseLoss):
         spatial_distributed: Optional[bool] = False,
         ensemble_distributed: Optional[bool] = False,
         ensemble_weights: Optional[torch.Tensor] = None,
+        channel_reduction: Optional[bool] = True,
         alpha: Optional[float] = 1.0,
         eps: Optional[float] = 1.0e-6,
         **kwargs,
@@ -616,6 +617,7 @@ class SpectralCoherenceLoss(SpectralBaseLoss):
         self.relative = relative
         self.spatial_distributed = spatial_distributed and comm.is_distributed("spatial")
         self.ensemble_distributed = ensemble_distributed and comm.is_distributed("ensemble") and (comm.get_size("ensemble") > 1)
+        self.channel_reduction = channel_reduction
         self.eps = eps
 
         if ensemble_weights is not None:
@@ -749,8 +751,11 @@ class SpectralCoherenceLoss(SpectralBaseLoss):
         if self.spatial_distributed:
             loss = reduce_from_parallel_region(loss, "h")
 
-        # reduce over the channel dimension
-        loss = loss.sum(dim=-1)
+        # reduce over the channel dimension if requested; matches sibling loss
+        # contract: output has shape (B, n_channels) where n_channels is 1 if
+        # reduction is on, else len(channel_names)
+        if self.channel_reduction:
+            loss = loss.sum(dim=-1, keepdim=True)
 
         return loss
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1330,6 +1330,103 @@ class TestLossHandler(unittest.TestCase):
         out = loss_obj(torch.randn(*shape), torch.randn(*shape))
         self.assertTrue(torch.isfinite(out))
 
+    # ------------------------------------------------------------------
+    # reset_running_stats — loss.py:292-296
+    # ------------------------------------------------------------------
+
+    def test_reset_running_stats(self, verbose=False):
+        """reset_running_stats restores running_mean=0, running_var=1, and
+        num_batches_tracked=0 after warm-up batches have populated them."""
+        self.params.losses = [{"type": "l2"}]
+        loss_obj = LossHandler(self.params, track_running_stats=True)
+        loss_obj.train()
+
+        shape = (self.params.batch_size, self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+
+        # warm up — populate running stats
+        for _ in range(5):
+            loss_obj(torch.randn(*shape), torch.randn(*shape))
+        self.assertGreater(loss_obj.num_batches_tracked.item(), 0,
+                           "warm-up failed to populate running stats")
+
+        # reset and verify each buffer is restored to its initial state
+        loss_obj.reset_running_stats()
+        self.assertTrue(
+            compare_tensors("running_mean reset", loss_obj.running_mean,
+                            torch.zeros_like(loss_obj.running_mean), verbose=verbose)
+        )
+        self.assertTrue(
+            compare_tensors("running_var reset", loss_obj.running_var,
+                            torch.ones_like(loss_obj.running_var), verbose=verbose)
+        )
+        self.assertEqual(loss_obj.num_batches_tracked.item(), 0)
+
+    # ------------------------------------------------------------------
+    # 5-D prd path of random_slice_loss — loss.py:343-346
+    # ------------------------------------------------------------------
+
+    def test_random_slice_loss_ensemble_path(self):
+        """random_slice_loss with 5-D prd reshapes to (B*E, ...) for the conv2d
+        and reshapes back. Use a probabilistic loss (ensemble_crps) so the
+        ensemble dim is preserved through the loss dispatch."""
+        self.params.losses = [{
+            "type": "ensemble_crps",
+            "channel_weights": "constant",
+            "parameters": {"crps_type": "skillspread"},
+        }]
+        self.params.random_slice_loss = True
+
+        loss_obj = LossHandler(self.params)
+
+        E = 5
+        shape_5d = (self.params.batch_size, E, self.params.N_out_channels,
+                    self.params.img_shape_x, self.params.img_shape_y)
+        shape_4d = (self.params.batch_size, self.params.N_out_channels,
+                    self.params.img_shape_x, self.params.img_shape_y)
+        prd = torch.randn(*shape_5d, requires_grad=True)
+        tar = torch.randn(*shape_4d)
+
+        out = loss_obj(prd, tar)
+        self.assertTrue(torch.isfinite(out))
+        out.backward()
+        self.assertIsNotNone(prd.grad)
+        self.assertFalse(torch.isnan(prd.grad).any())
+
+    # ------------------------------------------------------------------
+    # 5-D prd path of tendency — loss.py:377-380
+    # ------------------------------------------------------------------
+
+    def test_tendency_loss_ensemble_path(self):
+        """tendency: True with 5-D prd hits the prd_tendency = prd - inp_state.unsqueeze(1)
+        branch. We assert the path runs cleanly with a probabilistic loss; the
+        actual loss value is invariant under the tendency transform for proper-score
+        ensemble losses (CRPS depends on differences only), so we don't check value
+        change here — covering the code line is the goal."""
+        self.params.losses = [{
+            "type": "ensemble_crps",
+            "channel_weights": "constant",
+            "tendency": True,
+            "parameters": {"crps_type": "skillspread"},
+        }]
+        loss_obj = LossHandler(self.params)
+
+        E = 5
+        shape_5d = (self.params.batch_size, E, self.params.N_out_channels,
+                    self.params.img_shape_x, self.params.img_shape_y)
+        shape_4d = (self.params.batch_size, self.params.N_out_channels,
+                    self.params.img_shape_x, self.params.img_shape_y)
+
+        prd = torch.randn(*shape_5d, requires_grad=True)
+        tar = torch.randn(*shape_4d)
+        inp = torch.randn(*shape_4d)
+
+        out = loss_obj(prd, tar, inp=inp)
+        self.assertTrue(torch.isfinite(out))
+        out.backward()
+        self.assertIsNotNone(prd.grad)
+        self.assertFalse(torch.isnan(prd.grad).any())
+
 
 # ===========================================================================
 class TestComputeChannelWeightingHelper(unittest.TestCase):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1432,6 +1432,85 @@ class TestLossHandler(unittest.TestCase):
         self.assertIsNotNone(prd.grad)
         self.assertFalse(torch.isnan(prd.grad).any())
 
+    # ------------------------------------------------------------------
+    # multistep with empty {} dict — falls back to "constant" weight_type
+    # (loss.py:212, _compute_multistep_weight default branch)
+    # ------------------------------------------------------------------
+
+    def test_multistep_default_weight_type(self):
+        """params.multistep = {} (no weight_type key) must fall back to 'constant'.
+        Verifies the else branch in _compute_multistep_weight that picks the
+        default when the kwarg dict doesn't have weight_type."""
+        self.params.n_future = 2
+        self.params.losses = [{"type": "l2", "channel_weights": "constant"}]
+        self.params.multistep = {}      # no weight_type → defaults to constant
+
+        loss_obj = LossHandler(self.params)
+
+        # constant mode: each step weighted 1/(n_future+1) before tiling over channels
+        ncw = loss_obj.channel_weights.shape[1]
+        expected = torch.full(
+            ((self.params.n_future + 1) * ncw,), 1.0 / (self.params.n_future + 1)
+        )
+        self.assertTrue(
+            compare_tensors("default multistep_weight", loss_obj.multistep_weight, expected)
+        )
+
+    # ------------------------------------------------------------------
+    # channel_weights given as a Python list — loss.py:160-164
+    # The handler accepts a nested list (shape (1, N)) in addition to the
+    # named-string modes ("constant", "auto", etc.).
+    # ------------------------------------------------------------------
+
+    def test_channel_weights_as_list(self):
+        """A list-valued channel_weights bypasses the named-string branch and is
+        loaded directly. Must be nested (shape (1, N)) so the assert at
+        loss.py:164 passes."""
+        custom = [[0.1, 0.2, 0.3, 0.4, 0.5]]   # nested → shape (1, 5) for N=5
+        self.params.losses = [{"type": "l2", "channel_weights": custom}]
+        loss_obj = LossHandler(self.params)
+
+        # before normalization, chw equals the list. The handler ALSO doesn't
+        # renormalize here (that's only in compute_channel_weighting paths),
+        # so we should see the literal values up to a possible reshape.
+        self.assertEqual(loss_obj.channel_weights.shape, (1, 5))
+        self.assertTrue(
+            compare_tensors(
+                "list channel_weights",
+                loss_obj.channel_weights, torch.tensor(custom, dtype=torch.float32),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # relative_weight per loss — loss.py:172-173
+    # Multiplies the channel weights of one loss by a scalar before they're
+    # registered into the channel_weights buffer. Used to balance the
+    # contributions of multiple losses without changing their internal weights.
+    # ------------------------------------------------------------------
+
+    def test_relative_weight_scales_channel_weights(self, verbose=False):
+        """relative_weight on a loss spec multiplies that loss's chw entry.
+        Compare two LossHandlers — one with relative_weight=1.0 (identity, the
+        default-equivalent), one with 2.0 — and check that the second's
+        channel_weights are exactly 2× the first's."""
+        base = {"type": "l2", "channel_weights": "constant", "relative_weight": 1.0}
+        boosted = {"type": "l2", "channel_weights": "constant", "relative_weight": 2.0}
+
+        self.params.losses = [base]
+        loss_obj_base = LossHandler(self.params)
+
+        self.params.losses = [boosted]
+        loss_obj_boosted = LossHandler(self.params)
+
+        self.assertTrue(
+            compare_tensors(
+                "relative_weight scaling",
+                loss_obj_boosted.channel_weights,
+                2.0 * loss_obj_base.channel_weights,
+                verbose=verbose,
+            )
+        )
+
 
 # ===========================================================================
 class TestComputeChannelWeightingHelper(unittest.TestCase):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -2923,6 +2923,134 @@ class TestKernelScoreLoss(unittest.TestCase):
         self.assertLess(loss_close, loss_far, f"closer forecast had higher loss: {loss_close} vs {loss_far}")
 
 
+# ===========================================================================
+class TestEnsembleLossE1FastPath(unittest.TestCase):
+    """E=1 fast-path coverage for all CRPS-style ensemble losses.
+
+    Each of CRPSLoss, SpectralCRPSLoss, GradientCRPSLoss, VortDivCRPSLoss,
+    and KernelScoreLoss has an explicit ``(not ensemble_distributed) and (E == 1)``
+    short-circuit in its forward that bypasses the standard CRPS kernel
+    dispatch and computes ``|obs - fc.squeeze(1)|`` directly. None of the
+    existing tests use E=1 (they all parameterize over E=5), so this branch
+    is untested in production use cases that run with a single ensemble member.
+
+    For each class we verify:
+      - the E=1 path produces a finite, correctly-shaped output
+      - perfect prediction (single member == observation) gives zero loss
+      - backward through the E=1 path produces finite gradients
+
+    Note: the energy-score family (LpEnergyScore, SobolevEnergyScore,
+    SpectralL2EnergyScore, CorrectedSpectralL2EnergyScore, SpectralCoherence)
+    and MMD do *not* have an E=1 fast-path — their spread terms divide by
+    N(N-1), so calling them with E=1 hits division-by-zero. That's a separate
+    concern (whether to add explicit guards or accept E>=2 as a precondition).
+    """
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+
+    # -- factories: build each loss with default kwargs --------------------
+
+    def _crps(self):
+        return CRPSLoss(
+            **_GEOM_KWARGS, crps_type="skillspread",
+            spatial_distributed=False, ensemble_distributed=False,
+        )
+
+    def _spectral_crps(self):
+        return SpectralCRPSLoss(
+            **_SPEC_KWARGS, crps_type="skillspread",
+            spatial_distributed=False, ensemble_distributed=False, absolute=True,
+        )
+
+    def _gradient_crps(self):
+        return GradientCRPSLoss(
+            **_GEOM_KWARGS, crps_type="skillspread",
+            spatial_distributed=False, ensemble_distributed=False, absolute=True,
+        )
+
+    def _vortdiv_crps(self):
+        return VortDivCRPSLoss(
+            **_WIND_GEOM_KWARGS, crps_type="skillspread",
+            spatial_distributed=False, ensemble_distributed=False,
+        )
+
+    def _kernel_score(self):
+        return KernelScoreLoss(
+            **_GEOM_KWARGS, crps_type="skillspread",
+            spatial_distributed=False, ensemble_distributed=False,
+        )
+
+    def _make(self, name):
+        return {
+            "CRPSLoss": (self._crps, _NUM_CH),
+            "SpectralCRPSLoss": (self._spectral_crps, _NUM_CH),
+            "GradientCRPSLoss": (self._gradient_crps, _NUM_CH),
+            "VortDivCRPSLoss": (self._vortdiv_crps, _NUM_WIND_CH),
+            "KernelScoreLoss": (self._kernel_score, _NUM_CH),
+        }[name]
+
+    # -- tests --------------------------------------------------------------
+
+    @parameterized.expand([
+        ("CRPSLoss",),
+        ("SpectralCRPSLoss",),
+        ("GradientCRPSLoss",),
+        ("VortDivCRPSLoss",),
+        ("KernelScoreLoss",),
+    ])
+    def test_e1_output_shape_and_finite(self, name):
+        """E=1 path produces (B, n_channels) and finite values."""
+        builder, n_ch = self._make(name)
+        fn = builder()
+        fc = torch.randn(_BATCH, 1, n_ch, _IMG_H, _IMG_W)
+        obs = torch.randn(_BATCH, n_ch, _IMG_H, _IMG_W)
+        out = fn(fc, obs)
+        self.assertEqual(out.shape[0], _BATCH)
+        self.assertEqual(out.shape[1], fn.n_channels)
+        self.assertTrue(torch.isfinite(out).all(), f"{name}: non-finite values in E=1 output")
+
+    @parameterized.expand([
+        ("CRPSLoss",),
+        ("SpectralCRPSLoss",),
+        ("GradientCRPSLoss",),
+        ("VortDivCRPSLoss",),
+        ("KernelScoreLoss",),
+    ])
+    def test_e1_zero_on_perfect_prediction(self, name, verbose=False):
+        """At E=1, fc[:,0] == obs reduces to |obs - obs| = 0; loss must be (near) zero."""
+        builder, n_ch = self._make(name)
+        fn = builder()
+        obs = torch.randn(_BATCH, n_ch, _IMG_H, _IMG_W)
+        fc = obs.unsqueeze(1).clone()    # (B, 1, C, H, W) — single member equals obs
+        out = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                f"{name} E=1 zero", out, torch.zeros_like(out), atol=1e-4, verbose=verbose,
+            )
+        )
+
+    @parameterized.expand([
+        ("CRPSLoss",),
+        ("SpectralCRPSLoss",),
+        ("GradientCRPSLoss",),
+        ("VortDivCRPSLoss",),
+        ("KernelScoreLoss",),
+    ])
+    def test_e1_backward_finite(self, name):
+        """Gradient through the E=1 path must be finite — no NaN/Inf even though
+        the loss reduces to a piecewise-linear |x| at the bottom."""
+        builder, n_ch = self._make(name)
+        fn = builder()
+        fc = torch.randn(_BATCH, 1, n_ch, _IMG_H, _IMG_W, requires_grad=True)
+        obs = torch.randn(_BATCH, n_ch, _IMG_H, _IMG_W)
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), f"{name}: NaN grad in E=1 backward")
+        self.assertFalse(torch.isinf(fc.grad).any(), f"{name}: Inf grad in E=1 backward")
+
+
 if __name__ == "__main__":
     disable_tf32()
     unittest.main()

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -143,6 +143,7 @@ _COMMON_NONNEG = [
     ("spectral_l2",), ("spectral_h1",),
     ("drift_regularization",),
     ("crps_cdf",), ("crps_gauss",),
+    ("crps_pwm",), ("crps_naive_skillspread",),
 ]
 
 # Losses expected to be (near) zero when prd perfectly matches tar.
@@ -156,6 +157,7 @@ _COMMON_ZERO_PERFECT = [
     ("spectral_l2",), ("spectral_h1",),
     ("drift_regularization",),
     ("crps_cdf",), ("crps_gauss",),
+    ("crps_pwm",), ("crps_naive_skillspread",),
 ]
 
 # All losses participate in the batch-size independence test.
@@ -165,6 +167,7 @@ _COMMON_BATCHSIZE = [
     ("spectral_l2",), ("spectral_h1",),
     ("drift_regularization",),
     ("crps_cdf",), ("crps_gauss",),
+    ("crps_pwm",), ("crps_naive_skillspread",),
     ("nll",),
     ("mmd",),
 ]
@@ -205,6 +208,12 @@ class TestLossCommon(unittest.TestCase):
         if name == "crps_gauss":
             return CRPSLoss(**_GEOM_KWARGS, crps_type="gauss",
                                     spatial_distributed=False, ensemble_distributed=False, eps=1e-5)
+        if name == "crps_pwm":
+            return CRPSLoss(**_GEOM_KWARGS, crps_type="probability weighted moment",
+                                    spatial_distributed=False, ensemble_distributed=False)
+        if name == "crps_naive_skillspread":
+            return CRPSLoss(**_GEOM_KWARGS, crps_type="naive skillspread",
+                                    spatial_distributed=False, ensemble_distributed=False)
         if name == "nll":
             return EnsembleNLLLoss(**_GEOM_KWARGS)
         if name == "mmd":
@@ -217,7 +226,7 @@ class TestLossCommon(unittest.TestCase):
         """Return *(prd, tar)*.  Ensemble losses get a 5-D prd; others 4-D."""
         E = cls._E
         tar = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
-        if name in ("crps_cdf", "crps_gauss", "nll", "mmd"):
+        if name in ("crps_cdf", "crps_gauss", "crps_pwm", "crps_naive_skillspread", "nll", "mmd"):
             if perfect:
                 # all E members equal the observation
                 prd = tar.unsqueeze(1).expand(_BATCH, E, _NUM_CH, _IMG_H, _IMG_W).clone()
@@ -1311,7 +1320,62 @@ class TestCRPSLossExtended(unittest.TestCase):
             f"E={ensemble_size}: CDF and skillspread(alpha=0) gradients diverged",
         )
 
-    @parameterized.expand([("cdf",), ("skillspread",)])
+    # ------ skillspread (rank trick) == naive skillspread (O(N²) pairwise) ------
+    #
+    # Both compute fair CRPS = eskill - 0.5 * espread.  The rank-based version
+    # uses the order-statistic identity  sum_{i<j} |F_i - F_j| = sum_k (2k-N-1) F_(k)
+    # to collapse the O(N²) pairwise sum into an O(N log N) sort + weighted sum;
+    # the naive version evaluates the pairwise sum directly.  On real-valued
+    # ensembles they must produce numerically identical results, and identical
+    # gradients, for any alpha in [0, 1].
+    #
+    # Why test E=2: the rank coefficients reduce to (2*1-2-1, 2*2-2-1) = (-1, +1)
+    # at N=2, which is also the smallest case where the naive O(N²) pairwise
+    # tensor has off-diagonal terms — a known edge-case worth pinning down.
+
+    @parameterized.expand([(2, 1.0), (5, 1.0), (10, 1.0), (5, 0.0), (5, 0.5)])
+    def test_skillspread_equals_naive_skillspread(self, ensemble_size, alpha, verbose=False):
+        """Rank-based skillspread and naive skillspread must agree on real-valued forecasts
+        for any alpha (the (N - 1 + alpha) / (N²(N - 1)) factor is identical in both)."""
+        fn_skill = self._fn("skillspread", alpha=alpha)
+        fn_naive = self._fn("naive skillspread", alpha=alpha)
+        set_seed(333)
+        fc  = torch.randn(_BATCH, ensemble_size, _NUM_CH, _IMG_H, _IMG_W)
+        obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
+        result_skill = fn_skill(fc, obs)
+        result_naive = fn_naive(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                f"skillspread vs naive skillspread E={ensemble_size} alpha={alpha}",
+                result_skill, result_naive, atol=1e-5, rtol=1e-4, verbose=verbose,
+            ),
+            f"E={ensemble_size} alpha={alpha}: skillspread and naive skillspread diverged beyond float32 rounding",
+        )
+
+    @parameterized.expand([(2, 1.0), (5, 1.0), (10, 1.0), (5, 0.0), (5, 0.5)])
+    def test_skillspread_equals_naive_skillspread_gradients(self, ensemble_size, alpha, verbose=False):
+        """Rank-based and naive skillspread must produce identical gradients w.r.t. forecasts."""
+        fn_skill = self._fn("skillspread", alpha=alpha)
+        fn_naive = self._fn("naive skillspread", alpha=alpha)
+        set_seed(333)
+        fc_skill = torch.randn(_BATCH, ensemble_size, _NUM_CH, _IMG_H, _IMG_W, requires_grad=True)
+        fc_naive = fc_skill.detach().clone().requires_grad_(True)
+        obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
+
+        fn_skill(fc_skill, obs).sum().backward()
+        fn_naive(fc_naive, obs).sum().backward()
+
+        self.assertIsNotNone(fc_skill.grad)
+        self.assertIsNotNone(fc_naive.grad)
+        self.assertTrue(
+            compare_tensors(
+                f"skillspread vs naive skillspread gradients E={ensemble_size} alpha={alpha}",
+                fc_skill.grad, fc_naive.grad, atol=1e-4, rtol=1e-3, verbose=verbose,
+            ),
+            f"E={ensemble_size} alpha={alpha}: skillspread and naive skillspread gradients diverged",
+        )
+
+    @parameterized.expand([("cdf",), ("skillspread",), ("naive skillspread",), ("probability weighted moment",)])
     def test_gradient_sum_zero_on_perfect_prediction(self, crps_type, verbose=False):
         """Gradients summed over the ensemble dim must be zero at every pixel for a
         perfect forecast (all members == observation).  For the CDF kernel this
@@ -1375,7 +1439,7 @@ class TestSpectralCRPSLoss(unittest.TestCase):
 
     # ------ output shape: (B, C) for all three kernels ------
 
-    @parameterized.expand([("cdf",), ("skillspread",), ("gauss",)])
+    @parameterized.expand([("cdf",), ("skillspread",), ("gauss",), ("probability weighted moment",)])
     def test_output_shape(self, crps_type):
         fn  = self._fn(crps_type)
         fc  = torch.randn(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W)
@@ -1385,7 +1449,7 @@ class TestSpectralCRPSLoss(unittest.TestCase):
 
     # ------ non-negative output ------
 
-    @parameterized.expand([("cdf",), ("skillspread",), ("gauss",)])
+    @parameterized.expand([("cdf",), ("skillspread",), ("gauss",), ("probability weighted moment",)])
     def test_nonneg(self, crps_type):
         fn  = self._fn(crps_type)
         fc  = torch.randn(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W)
@@ -1398,7 +1462,7 @@ class TestSpectralCRPSLoss(unittest.TestCase):
 
     # ------ zero on perfect prediction for cdf and skillspread ------
 
-    @parameterized.expand([("cdf",), ("skillspread",)])
+    @parameterized.expand([("cdf",), ("skillspread",), ("probability weighted moment",)])
     def test_zero_on_perfect_prediction(self, crps_type, verbose=False):
         """Perfect ensemble (all members = observation) must give zero loss."""
         fn  = self._fn(crps_type)
@@ -1506,7 +1570,7 @@ class TestSpectralCRPSLoss(unittest.TestCase):
         self.assertFalse(torch.isnan(fc.grad).any(), "NaN in fc.grad")
         self.assertFalse(torch.isinf(fc.grad).any(), "Inf in fc.grad")
 
-    @parameterized.expand([("cdf",), ("skillspread",)])
+    @parameterized.expand([("cdf",), ("skillspread",), ("probability weighted moment",)])
     def test_backward_finite_on_perfect_prediction(self, crps_type):
         """Perfect ensemble (all members == obs) must produce finite gradients."""
         fn  = self._fn(crps_type)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -41,7 +41,7 @@ from makani.utils.losses import (
     LpEnergyScoreLoss,
     SpectralL2EnergyScoreLoss,
 )
-from makani.utils.losses.energy_score import SobolevEnergyScoreLoss
+from makani.utils.losses.energy_score import SobolevEnergyScoreLoss, SpectralCoherenceLoss
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_tensors, compare_arrays
@@ -2131,6 +2131,182 @@ class TestVortDivCRPSLoss(unittest.TestCase):
         obs = _rand(channels=_NUM_WIND_CH)
         with self.assertRaises(ValueError):
             fn(fc, obs)
+
+
+# ===========================================================================
+class TestSpectralCoherenceLoss(unittest.TestCase):
+    """Tests for SpectralCoherenceLoss.
+
+    The loss is a probabilistic spectral score with two terms:
+      - PSD skill:        ((P_F - P_T)^2) averaged over the ensemble; senses
+                          the wrong *amplitude* at each spherical-harmonic
+                          degree l
+      - Coherence skill / spread:  energy-score-style decomposition of the
+                          phase alignment between forecast↔truth and between
+                          ensemble members; senses the wrong *phase* at each l
+
+    These tests verify (a) the output-shape contract, (b) that perfect
+    predictions yield zero loss, (c) that the PSD term and the coherence term
+    each pick up the kind of error they're designed for.
+    """
+
+    _E = 5
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+
+    def _fn(self, channel_reduction=True, relative=False, **kw):
+        return SpectralCoherenceLoss(
+            **_SPEC_KWARGS,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            channel_reduction=channel_reduction,
+            relative=relative,
+            **kw,
+        )
+
+    # -- output-shape contract -----------------------------------------------
+
+    def test_output_shape_channel_reduction(self):
+        fn = self._fn(channel_reduction=True)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out = fn(fc, obs)
+        # contract: (B, n_channels) where n_channels=1 when reducing
+        self.assertEqual(tuple(out.shape), (_BATCH, 1))
+
+    def test_output_shape_no_channel_reduction(self):
+        fn = self._fn(channel_reduction=False)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out = fn(fc, obs)
+        self.assertEqual(tuple(out.shape), (_BATCH, _NUM_CH))
+
+    def test_n_channels_matches_output(self):
+        """n_channels must agree with the per-sample output dim under both reduction modes.
+
+        Regression test for the previously-undefined self.channel_reduction:
+        before this fix, n_channels would AttributeError before forward was
+        even called.
+        """
+        fn_red = self._fn(channel_reduction=True)
+        fn_no_red = self._fn(channel_reduction=False)
+        self.assertEqual(fn_red.n_channels, 1)
+        self.assertEqual(fn_no_red.n_channels, _NUM_CH)
+
+    def test_wrong_forecast_dims_raises(self):
+        fn = self._fn()
+        fc = _rand()                # 4-D, missing ensemble dim
+        obs = _rand()
+        with self.assertRaises(ValueError):
+            fn(fc, obs)
+
+    # -- backward / zero-on-perfect-prediction -------------------------------
+
+    def test_backward_finite(self):
+        fn = self._fn()
+        fc = _rand_ensemble(self._E, requires_grad=True)
+        obs = _rand()
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN in fc.grad")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf in fc.grad")
+
+    @parameterized.expand([(True,), (False,)])
+    def test_zero_on_perfect_prediction(self, relative, verbose=True):
+        """All ensemble members == observation:
+          - psd_skill = 0 exactly (same inputs through the same op)
+          - coherences = P / sqrt(P² + eps) → 1 only as eps → 0
+
+        Setting eps=0 collapses ``1 - P/sqrt(P²)`` to algebraically zero, but
+        the loss uses two paths to compute |X|²: ``X.abs().square()`` for the
+        PSD term and ``Re(X.conj() * X)`` for coherence. These are equal in
+        real arithmetic but differ by a sqrt-then-square ULP per mode in fp32,
+        so after summing 75 (l, channel) modes the residual lands at ~1e-6 for
+        the relative case. atol is set above that floor."""
+        fn = self._fn(relative=relative, eps=0.0)
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        out = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                f"spectral coherence zero (relative={relative})",
+                out, torch.zeros_like(out), atol=5e-6, verbose=verbose,
+            )
+        )
+
+    def test_backward_finite_on_perfect_prediction(self):
+        """Perfect forecast must not produce NaN/Inf gradients (eps in the
+        normalizer protects against the 0/0 in coherence)."""
+        fn = self._fn()
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone().requires_grad_(True)
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN at perfect forecast")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf at perfect forecast")
+
+    # -- the decomposition does what it claims ------------------------------
+
+    def test_negated_forecast_isolates_coherence_term(self):
+        """fc = -obs has identical PSD as obs but opposite phase, so:
+          - psd_skill ≈ 0          (amplitudes match)
+          - coherence(fc, obs) ≈ -1 → coh_skill picks up the phase mismatch
+        Loss must therefore be strictly positive even though amplitudes are right.
+        This proves the coherence/phase term is active and not masked by the
+        PSD term.
+        """
+        obs = _rand()
+        fc = (-obs).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        # ensemble members are identical, so coh_spread ≈ 0; the contribution
+        # is entirely from the coh_skill term
+        out = self._fn()(fc, obs)
+        self.assertTrue((out > 0.0).all(), f"loss not strictly positive on -obs: {out}")
+
+    def test_scaled_forecast_isolates_psd_term(self):
+        """fc = 2*obs has the same phases as obs (so coherence ≈ 1) but
+        4× the PSD, so:
+          - coh_skill ≈ 0          (phases match)
+          - psd_skill ≈ (4P - P)^2 = 9P^2  per (b, c, l)
+        Loss must therefore be strictly positive even though phases are right.
+        This proves the PSD/amplitude term is active and not masked by the
+        coherence term.
+        """
+        obs = _rand()
+        fc = (2.0 * obs).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        out = self._fn()(fc, obs)
+        self.assertTrue((out > 0.0).all(), f"loss not strictly positive on 2*obs: {out}")
+
+    def test_better_forecast_lower_loss(self):
+        """Monotonicity in error magnitude: a forecast closer to the obs must
+        produce a strictly lower loss than one farther from it. This is the
+        weakest-but-most-useful behavioral guarantee against the loss
+        accidentally pointing the wrong way after a refactor."""
+        obs = _rand()
+        # both forecasts are perturbations of obs, replicated across ensemble
+        set_seed(101)
+        small_noise = 0.05 * torch.randn_like(obs)
+        large_noise = 0.50 * torch.randn_like(obs)
+        fc_close = (obs + small_noise).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        fc_far   = (obs + large_noise).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        fn = self._fn()
+        loss_close = fn(fc_close, obs).sum().item()
+        loss_far   = fn(fc_far, obs).sum().item()
+        self.assertLess(loss_close, loss_far, f"closer forecast had higher loss: {loss_close} vs {loss_far}")
+
+    def test_relative_flag_changes_output(self):
+        """relative=True divides psd_skill by psd_observations and drops the
+        psd_observations weight on the coherence term, so the two modes must
+        produce different values on a non-trivial input."""
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out_abs = self._fn(relative=False)(fc, obs)
+        out_rel = self._fn(relative=True)(fc, obs)
+        self.assertFalse(
+            compare_tensors("relative vs absolute", out_abs, out_rel, atol=1e-6, rtol=1e-5),
+            "relative=True and relative=False produced identical outputs",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1910,6 +1910,54 @@ class TestSpectralCRPSLoss(unittest.TestCase):
         obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
         self.assertFalse(compare_tensors("abs vs real skillspread", fn_abs(fc, obs), fn_real(fc, obs)))
 
+    def test_absolute_false_zero_on_perfect_prediction(self, verbose=False):
+        """absolute=False keeps the spectral coefficients complex; at a perfect
+        ensemble both eskill and espread (computed by the naive skillspread
+        kernel via abs() of complex differences) collapse to 0, so the loss
+        must be (near) zero."""
+        fn  = self._fn("skillspread", absolute=False)
+        obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
+        fc  = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        out = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                "absolute=False zero", out, torch.zeros_like(out), atol=1e-4, verbose=verbose,
+            )
+        )
+
+    def test_absolute_false_backward_finite(self):
+        """Gradient through the complex spectral CRPS (absolute=False path) must be
+        finite — the .abs() of complex pairwise differences has a kink at zero,
+        but with random inputs that's measure-zero."""
+        fn  = self._fn("skillspread", absolute=False)
+        fc  = torch.randn(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W, requires_grad=True)
+        obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN in absolute=False gradient")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf in absolute=False gradient")
+
+    def test_absolute_false_e1_path(self):
+        """E=1 + absolute=False hits the early-return at loss.py:506-509 with
+        complex spectral coefficients; ``torch.abs(complex_diff)`` produces a
+        real magnitude that the spatial reduction can sum normally. No crash,
+        finite output, near-zero on perfect prediction."""
+        fn = self._fn("skillspread", absolute=False)
+        obs = torch.randn(_BATCH, _NUM_CH, _IMG_H, _IMG_W)
+        # perfect single-member ensemble: forecasts == obs after SHT,
+        # so |obs - fc.squeeze(1)| in spectral space is 0 → output ≈ 0
+        fc_perfect = obs.unsqueeze(1).clone()    # (B, 1, C, H, W)
+        out_perfect = fn(fc_perfect, obs)
+        self.assertTrue(
+            compare_tensors(
+                "absolute=False E=1 zero", out_perfect, torch.zeros_like(out_perfect), atol=1e-4,
+            )
+        )
+        # also assert finite on a random forecast
+        fc_random = torch.randn(_BATCH, 1, _NUM_CH, _IMG_H, _IMG_W)
+        out_random = fn(fc_random, obs)
+        self.assertTrue(torch.isfinite(out_random).all())
+
     # ------ dim validation in forward (lines 398-403) ------
 
     def test_wrong_forecast_dims_raises(self):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1285,11 +1285,16 @@ class TestLossHandler(unittest.TestCase):
     # Mixes channels through a random orthonormal matrix before computing the loss.
     # ------------------------------------------------------------------
 
-    def test_random_slice_loss(self):
-        """random_slice_loss=True must run end-to-end without crashing and produce
-        a finite scalar loss with finite gradients."""
+    @parameterized.expand([
+        ("random_slice_loss",),         # mixes channels via a random orthonormal slice BEFORE the loss
+        ("randomized_loss_weights",),   # multiplies per-channel weights by a random mask AFTER the loss
+    ])
+    def test_loss_modifier_flag(self, flag_name):
+        """Both random-channel modifier flags must run end-to-end without crashing
+        and produce a finite scalar with finite gradients. They exercise different
+        code paths in LossHandler.forward but share the same smoke-test contract."""
         self.params.losses = [{"type": "l2", "channel_weights": "constant"}]
-        self.params.random_slice_loss = True
+        setattr(self.params, flag_name, True)
 
         loss_obj = LossHandler(self.params)
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -42,6 +42,7 @@ from makani.utils.losses import (
     SpectralL2EnergyScoreLoss,
 )
 from makani.utils.losses.energy_score import SobolevEnergyScoreLoss, SpectralCoherenceLoss, CorrectedSpectralL2EnergyScoreLoss
+from makani.utils.losses.crps_loss import KernelScoreLoss
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_tensors, compare_arrays
@@ -2516,6 +2517,182 @@ class TestCorrectedSpectralL2EnergyScoreLoss(unittest.TestCase):
             compare_tensors("corrected vs standard random", out_corrected, out_standard, atol=1e-6, rtol=1e-4),
             "corrected and standard agree on random ensemble — ratio≠1 should produce a measurable difference",
         )
+
+
+# ===========================================================================
+class TestKernelScoreLoss(unittest.TestCase):
+    """Tests for KernelScoreLoss (CRPS-style score with a fixed DISCO kernel).
+
+    KernelScoreLoss applies a non-trainable spherical convolution to forecasts
+    and observations before computing the CRPS, so it scores structural error
+    rather than pointwise error. The conv is fixed (registered as a buffer) and
+    the loss dispatches on crps_type just like CRPSLoss/SpectralCRPSLoss.
+
+    Tests cover:
+      - shape contract (B, n_channels)
+      - all four crps_type branches (cdf, skillspread, naive skillspread,
+        probability weighted moment)
+      - zero on perfect prediction (the conv applies identically to both inputs
+        so any deterministic kernel preserves the perfect-forecast → zero
+        property regardless of the actual weight values)
+      - alpha < 1 guard: rejected for non-skillspread kernels, accepted for
+        both skillspread variants (regression test for the recent guard fix)
+    """
+
+    _E = 5
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+
+    def _fn(self, crps_type="skillspread", **kw):
+        return KernelScoreLoss(
+            **_GEOM_KWARGS,
+            crps_type=crps_type,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            **kw,
+        )
+
+    # -- shape contract / dispatch validation --------------------------------
+
+    @parameterized.expand([
+        ("cdf",),
+        ("skillspread",),
+        ("naive skillspread",),
+        ("probability weighted moment",),
+    ])
+    def test_output_shape(self, crps_type):
+        """Output must be (B, n_channels) for every crps_type."""
+        fn = self._fn(crps_type)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out = fn(fc, obs)
+        self.assertEqual(tuple(out.shape), (_BATCH, _NUM_CH))
+
+    def test_n_channels_matches_output(self):
+        fn = self._fn()
+        self.assertEqual(fn.n_channels, _NUM_CH)
+
+    def test_wrong_forecast_dims_raises(self):
+        fn = self._fn()
+        fc = _rand()                # 4-D, missing ensemble dim
+        obs = _rand()
+        with self.assertRaises(ValueError):
+            fn(fc, obs)
+
+    def test_unknown_crps_type_raises_in_forward(self):
+        """Unknown crps_type bypassed init guard must raise ValueError in forward."""
+        fn = self._fn("cdf")
+        fn.crps_type = "bogus"
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        with self.assertRaises(ValueError):
+            fn(fc, obs)
+
+    # -- alpha guard ---------------------------------------------------------
+
+    def test_alpha_lt1_raises_for_cdf(self):
+        with self.assertRaises(NotImplementedError):
+            self._fn("cdf", alpha=0.5)
+
+    def test_alpha_lt1_raises_for_pwm(self):
+        with self.assertRaises(NotImplementedError):
+            self._fn("probability weighted moment", alpha=0.5)
+
+    def test_alpha_lt1_allowed_for_skillspread(self):
+        """Both skillspread variants accept alpha < 1 — the guard widening
+        we did earlier must hold for KernelScoreLoss too."""
+        fn_skill = self._fn("skillspread", alpha=0.5)
+        fn_naive = self._fn("naive skillspread", alpha=0.5)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        # both must run without raising
+        out_skill = fn_skill(fc, obs)
+        out_naive = fn_naive(fc, obs)
+        self.assertTrue(torch.isfinite(out_skill).all())
+        self.assertTrue(torch.isfinite(out_naive).all())
+
+    # -- backward / zero-on-perfect-prediction -------------------------------
+
+    def test_backward_finite(self):
+        fn = self._fn()
+        fc = _rand_ensemble(self._E, requires_grad=True)
+        obs = _rand()
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN in fc.grad")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf in fc.grad")
+
+    @parameterized.expand([
+        ("cdf",),
+        ("skillspread",),
+        ("naive skillspread",),
+        ("probability weighted moment",),
+    ])
+    def test_zero_on_perfect_prediction(self, crps_type, verbose=False):
+        """Perfect ensemble (all members == obs): the conv applies the same
+        deterministic transform to both inputs, so conv(obs) - conv(F_e) = 0
+        for every member regardless of the conv weight values. Every CRPS
+        kernel reduces to zero on identical-to-truth ensembles."""
+        fn = self._fn(crps_type)
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        out = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                f"kernel score {crps_type} zero",
+                out, torch.zeros_like(out), atol=1e-4, verbose=verbose,
+            )
+        )
+
+    @parameterized.expand([
+        ("cdf",),
+        ("skillspread",),
+        ("naive skillspread",),
+        ("probability weighted moment",),
+    ])
+    def test_backward_finite_on_perfect_prediction(self, crps_type):
+        """Perfect ensemble must produce finite gradients across all crps_type
+        branches (the eps-mask paths in each kernel must protect their respective
+        sqrt(0) / 0/0 singularities)."""
+        fn = self._fn(crps_type)
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone().requires_grad_(True)
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), f"NaN in {crps_type} gradient at perfect forecast")
+        self.assertFalse(torch.isinf(fc.grad).any(), f"Inf in {crps_type} gradient at perfect forecast")
+
+    def test_batch_independence(self, verbose=False):
+        """The kernel-score loss for sample [0] computed alone must equal
+        loss[0] in a full batch — the conv and CRPS kernels are per-sample."""
+        fn = self._fn()
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        loss_single = fn(fc[:1], obs[:1])
+        loss_batch = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors("kernel score batch", loss_single[0], loss_batch[0], verbose=verbose)
+        )
+
+    # -- behavioural ---------------------------------------------------------
+
+    def test_better_forecast_lower_loss(self):
+        """Monotonicity sanity: a forecast closer to obs gives a strictly
+        lower kernel score than one farther from obs. Holds for any
+        deterministic kernel because the kernel is applied identically to
+        both inputs."""
+        obs = _rand()
+        set_seed(101)
+        small = 0.05 * torch.randn_like(obs)
+        large = 0.50 * torch.randn_like(obs)
+        fc_close = (obs + small).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        fc_far   = (obs + large).unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        fn = self._fn()
+        loss_close = fn(fc_close, obs).sum().item()
+        loss_far   = fn(fc_far, obs).sum().item()
+        self.assertLess(loss_close, loss_far, f"closer forecast had higher loss: {loss_close} vs {loss_far}")
 
 
 if __name__ == "__main__":

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -43,6 +43,7 @@ from makani.utils.losses import (
 )
 from makani.utils.losses.energy_score import SobolevEnergyScoreLoss, SpectralCoherenceLoss, CorrectedSpectralL2EnergyScoreLoss
 from makani.utils.losses.crps_loss import KernelScoreLoss
+from makani.utils.losses.base_loss import _compute_channel_weighting_helper
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_tensors, compare_arrays
@@ -1151,6 +1152,233 @@ class TestLossHandler(unittest.TestCase):
         with self.subTest(desc="var"):
             self.assertTrue(compare_tensors("var", var, expected_var, verbose=verbose))
 
+    # ------------------------------------------------------------------
+    # multistep_loss_weight modes — _compute_multistep_weight in loss.py:206
+    # The default "constant" is exercised by test_loss_multistep above, but
+    # "balanced", "linear", "last", "last-n-1", "custom" are all currently dead.
+    # ------------------------------------------------------------------
+
+    @parameterized.expand([
+        ("constant",),
+        ("balanced",),
+        ("linear",),
+        ("last",),
+        ("last-n-1",),
+    ])
+    def test_multistep_weight_mode(self, weight_type):
+        """Each multistep weight mode must build, forward, and backward without error.
+        Also asserts the computed multistep_weight buffer has the expected length
+        (n_future + 1) — the only invariant common to all modes."""
+        self.params.n_future = 2
+        self.params.losses = [{"type": "l2", "channel_weights": "constant"}]
+        self.params.multistep = {"weight_type": weight_type}
+
+        loss_obj = LossHandler(self.params)
+
+        # the multistep_weight buffer is tiled by ncw; the per-step prefix is n_future+1 entries
+        # tiled to (n_future + 1) * ncw — verify length matches that contract
+        expected_len = (self.params.n_future + 1) * loss_obj.channel_weights.shape[1]
+        self.assertEqual(loss_obj.multistep_weight.numel(), expected_len)
+
+        shape = (self.params.batch_size, (self.params.n_future + 1) * self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+        inp = torch.randn(*shape, requires_grad=True)
+        tar = torch.randn(*shape)
+        out = loss_obj(tar, inp)
+        self.assertEqual(torch.numel(out), 1)
+        self.assertTrue(torch.isfinite(out))
+        out.backward()
+        self.assertIsNotNone(inp.grad)
+
+    def test_multistep_weight_custom(self):
+        """custom mode passes through user-supplied weights and asserts shape match."""
+        self.params.n_future = 2
+        self.params.losses = [{"type": "l2", "channel_weights": "constant"}]
+        self.params.multistep = {"weight_type": "custom", "weights": [0.1, 0.3, 0.6]}
+
+        loss_obj = LossHandler(self.params)
+        # the prefix of multistep_weight (before tiling over channels) must equal
+        # the user-supplied weights — pull out the per-step values
+        ncw = loss_obj.channel_weights.shape[1]
+        per_step = loss_obj.multistep_weight.reshape(self.params.n_future + 1, ncw)[:, 0]
+        self.assertTrue(
+            compare_tensors("custom multistep weights", per_step, torch.tensor([0.1, 0.3, 0.6]))
+        )
+
+    def test_multistep_weight_custom_wrong_length_raises(self):
+        """custom weights must match n_future + 1 — assertion in _compute_multistep_weight."""
+        self.params.n_future = 2
+        self.params.losses = [{"type": "l2"}]
+        self.params.multistep = {"weight_type": "custom", "weights": [0.1, 0.9]}  # too short
+        with self.assertRaises(AssertionError):
+            LossHandler(self.params)
+
+    def test_multistep_weight_unknown_raises(self):
+        """Unknown weight_type must raise ValueError."""
+        self.params.n_future = 2
+        self.params.losses = [{"type": "l2"}]
+        self.params.multistep = {"weight_type": "bogus_mode"}
+        with self.assertRaises(ValueError):
+            LossHandler(self.params)
+
+    # ------------------------------------------------------------------
+    # tendency: True path — loss.py:360-386
+    # When ANY loss in the list has tendency=True AND inp is passed to forward,
+    # prd/tar are transformed to (prd - inp_state) / (tar - inp_state).
+    # ------------------------------------------------------------------
+
+    def test_tendency_loss_changes_output(self, verbose=False):
+        """Passing inp= to a tendency-flagged loss must change the loss value.
+        With tendency: True the loss is computed on (prd - inp_state) vs (tar - inp_state)
+        instead of on prd vs tar directly.
+
+        We must use a loss that is NOT translation-invariant in (prd, tar) —
+        plain L2 of the difference is invariant ((prd-inp) - (tar-inp) = prd - tar),
+        so it can't distinguish the two paths. Relative L2 divides by ||tar||,
+        which becomes ||tar - inp|| under tendency, making the loss differ.
+        """
+        self.params.losses = [
+            {"type": "l2", "channel_weights": "constant", "tendency": True,
+             "parameters": {"relative": True}},
+        ]
+        loss_obj = LossHandler(self.params)
+
+        shape = (self.params.batch_size, self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+        prd = torch.randn(*shape)
+        tar = torch.randn(*shape)
+        inp = torch.randn(*shape)   # non-zero, so the tendency transform is non-trivial
+
+        # without inp, the tendency branch is skipped (inp is None) — falls back to relative L2 on (prd, tar)
+        out_no_inp = loss_obj(prd, tar)
+        # with inp, tendency transform is active — denominator becomes ||tar - inp||, so the loss differs
+        out_with_inp = loss_obj(prd, tar, inp=inp)
+
+        self.assertFalse(
+            compare_tensors("tendency vs no-tendency", out_no_inp, out_with_inp, atol=1e-6, rtol=1e-5),
+            f"tendency path didn't change the output: no_inp={out_no_inp.item()} with_inp={out_with_inp.item()}",
+        )
+
+    def test_tendency_zero_input_recovers_no_tendency(self, verbose=False):
+        """When inp is exactly zero the tendency-transformed (prd - 0) is just prd,
+        so the loss must equal the no-tendency loss. Sanity check on the formula."""
+        self.params.losses = [
+            {"type": "l2", "channel_weights": "constant", "tendency": True,
+             "parameters": {"relative": True}},
+        ]
+        loss_obj = LossHandler(self.params)
+
+        shape = (self.params.batch_size, self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+        prd = torch.randn(*shape)
+        tar = torch.randn(*shape)
+        inp_zero = torch.zeros(*shape)
+
+        out_no_inp = loss_obj(prd, tar)
+        out_inp_zero = loss_obj(prd, tar, inp=inp_zero)
+        self.assertTrue(
+            compare_tensors("tendency w/ zero inp", out_no_inp, out_inp_zero, verbose=verbose)
+        )
+
+    # ------------------------------------------------------------------
+    # random_slice_loss path — loss.py:330-349
+    # Mixes channels through a random orthonormal matrix before computing the loss.
+    # ------------------------------------------------------------------
+
+    def test_random_slice_loss(self):
+        """random_slice_loss=True must run end-to-end without crashing and produce
+        a finite scalar loss with finite gradients."""
+        self.params.losses = [{"type": "l2", "channel_weights": "constant"}]
+        self.params.random_slice_loss = True
+
+        loss_obj = LossHandler(self.params)
+
+        shape = (self.params.batch_size, self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+        inp = torch.randn(*shape, requires_grad=True)
+        tar = torch.randn(*shape)
+        out = loss_obj(tar, inp)
+        self.assertTrue(torch.isfinite(out))
+        out.backward()
+        self.assertIsNotNone(inp.grad)
+        self.assertFalse(torch.isnan(inp.grad).any())
+
+    # ------------------------------------------------------------------
+    # balanced_weighting path — loss.py:420-424
+    # Activated only when track_running_stats=True AND num_batches_tracked > 100.
+    # ------------------------------------------------------------------
+
+    def test_balanced_weighting_after_warmup(self):
+        """balanced_weighting=True with > 100 tracked batches activates the
+        chw / (mean + eps) branch. Forward must remain finite under that path."""
+        self.params.losses = [{"type": "l2"}]
+        self.params.balanced_weighting = True
+
+        loss_obj = LossHandler(self.params, track_running_stats=True)
+        loss_obj.train()
+
+        shape = (self.params.batch_size, self.params.N_out_channels,
+                 self.params.img_shape_x, self.params.img_shape_y)
+
+        # warm up past the 100-batch gate that swaps from ones-like to running mean
+        for _ in range(105):
+            prd = torch.randn(*shape)
+            tar = torch.randn(*shape)
+            loss_obj(prd, tar)
+
+        # post-warmup forward — exercises the balanced_weighting branch
+        out = loss_obj(torch.randn(*shape), torch.randn(*shape))
+        self.assertTrue(torch.isfinite(out))
+
+
+# ===========================================================================
+class TestComputeChannelWeightingHelper(unittest.TestCase):
+    """Tests for _compute_channel_weighting_helper in base_loss.py.
+
+    The helper maps a list of channel names + a mode string to a normalized
+    channel-weight vector, optionally multiplied by a time-difference scaling
+    tensor. Five named modes ("constant", "auto", "new auto", "custom",
+    "pangu") plus the unknown-mode error path.
+    """
+
+    def setUp(self):
+        set_seed(333)
+
+    def test_constant_uniform(self):
+        """constant mode produces uniformly-weighted channels (1/N each)."""
+        names = ["u10m", "v10m", "t2m", "z500", "q500"]
+        chw = _compute_channel_weighting_helper(names, "constant")
+        self.assertEqual(chw.shape, (len(names),))
+        expected = torch.full((len(names),), 1.0 / len(names))
+        self.assertTrue(compare_tensors("constant chw", chw, expected, atol=1e-7))
+
+    def test_unknown_mode_raises(self):
+        """Unknown mode strings must raise NotImplementedError."""
+        with self.assertRaises(NotImplementedError):
+            _compute_channel_weighting_helper(["t2m"], "bogus_mode_name")
+
+    def test_weights_sum_to_one_for_all_modes(self):
+        """Independent of mode, the returned channel weights must sum to 1
+        when no time_diff_scale is supplied. Also serves as branch coverage
+        for every named mode in one shot."""
+        names = ["u10m", "t2m", "z500", "q200", "msl", "sp"]
+        for mode in ["constant", "auto", "new auto", "custom", "pangu"]:
+            with self.subTest(mode=mode):
+                chw = _compute_channel_weighting_helper(names, mode)
+                self.assertAlmostEqual(chw.sum().item(), 1.0, places=5)
+
+    def test_time_diff_scale_multiplies_weights(self):
+        """When time_diff_scale is supplied, the final weights equal
+        (normalized chw) * time_diff_scale element-wise. No renormalization
+        is applied after the multiplication, so the result need not sum to 1.
+        """
+        names = ["u10m", "t2m", "z500"]
+        scale = torch.tensor([2.0, 0.5, 4.0])
+        chw_no_scale = _compute_channel_weighting_helper(names, "constant")
+        chw_scaled   = _compute_channel_weighting_helper(names, "constant", time_diff_scale=scale)
+        self.assertTrue(
+            compare_tensors("time_diff_scale", chw_scaled, chw_no_scale * scale, atol=1e-7)
+        )
 
 
 # ===========================================================================

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -41,7 +41,7 @@ from makani.utils.losses import (
     LpEnergyScoreLoss,
     SpectralL2EnergyScoreLoss,
 )
-from makani.utils.losses.energy_score import SobolevEnergyScoreLoss, SpectralCoherenceLoss
+from makani.utils.losses.energy_score import SobolevEnergyScoreLoss, SpectralCoherenceLoss, CorrectedSpectralL2EnergyScoreLoss
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_tensors, compare_arrays
@@ -2306,6 +2306,215 @@ class TestSpectralCoherenceLoss(unittest.TestCase):
         self.assertFalse(
             compare_tensors("relative vs absolute", out_abs, out_rel, atol=1e-6, rtol=1e-5),
             "relative=True and relative=False produced identical outputs",
+        )
+
+
+# ===========================================================================
+class TestCorrectedSpectralL2EnergyScoreLoss(unittest.TestCase):
+    """Tests for CorrectedSpectralL2EnergyScoreLoss.
+
+    The corrected variant differs from SpectralL2EnergyScoreLoss only in the
+    spread term: the ensemble pairwise spread is scaled by the ratio
+    psd_true / (psd_pred + eps). The accuracy term (eskill) is identical, so
+    most mechanical tests mirror TestSpectralL2EnergyScoreLoss.
+
+    Two extra semantic tests exercise the *purpose* of the correction:
+      - test_equivalence_at_correct_amplitude: when psd_pred ≈ psd_true the
+        ratio collapses to 1 and the corrected loss must agree with the
+        standard one.
+      - test_cheap_spread_penalty: when the ensemble has the right phases but
+        inflated amplitudes (the canonical "cheap spread" attack on the
+        standard ES), the corrected loss must be strictly larger than the
+        standard one — the diversity reward is bounded by truth PSD instead
+        of by the model's own (inflated) PSD.
+    """
+
+    _E = 5
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+
+    def _fn(self, channel_reduction=True, **kw):
+        return CorrectedSpectralL2EnergyScoreLoss(
+            **_SPEC_KWARGS,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            channel_reduction=channel_reduction,
+            **kw,
+        )
+
+    def _fn_uncorrected(self, channel_reduction=True, **kw):
+        return SpectralL2EnergyScoreLoss(
+            **_SPEC_KWARGS,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            channel_reduction=channel_reduction,
+            **kw,
+        )
+
+    # -- shape contract ------------------------------------------------------
+
+    def test_output_shape_channel_reduction(self):
+        fn = self._fn(channel_reduction=True)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out = fn(fc, obs)
+        self.assertEqual(tuple(out.shape), (_BATCH, 1))
+
+    def test_output_shape_no_channel_reduction(self):
+        fn = self._fn(channel_reduction=False)
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out = fn(fc, obs)
+        self.assertEqual(tuple(out.shape), (_BATCH, _NUM_CH))
+
+    def test_n_channels_matches_output(self):
+        self.assertEqual(self._fn(channel_reduction=True).n_channels, 1)
+        self.assertEqual(self._fn(channel_reduction=False).n_channels, _NUM_CH)
+
+    def test_wrong_forecast_dims_raises(self):
+        fn = self._fn()
+        fc = _rand()                # 4-D, missing ensemble dim
+        obs = _rand()
+        with self.assertRaises(ValueError):
+            fn(fc, obs)
+
+    # -- backward / zero-on-perfect-prediction -------------------------------
+
+    def test_backward_finite(self):
+        fn = self._fn()
+        fc = _rand_ensemble(self._E, requires_grad=True)
+        obs = _rand()
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN in fc.grad")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf in fc.grad")
+
+    def test_zero_on_perfect_prediction(self, verbose=False):
+        """All ensemble members == observation: espread and eskill are zero
+        before sqrt; the eps-mask path replaces them with eps for the sqrt
+        and resets to 0 afterward, so the post-sqrt residual is exactly 0.
+        The ratio (psd_true / (psd_pred + eps)) is finite and unused (multiplied
+        by zero spread), so the eps in the ratio doesn't leak into the result.
+        """
+        fn = self._fn()
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone()
+        out = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors(
+                "corrected spectral L2 ES zero",
+                out, torch.zeros_like(out), atol=1e-6, verbose=verbose,
+            )
+        )
+
+    def test_backward_finite_on_perfect_prediction(self):
+        """Perfect ensemble must produce finite gradients; the eps-mask
+        protects against the sqrt(0) gradient singularity."""
+        fn = self._fn()
+        obs = _rand()
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone().requires_grad_(True)
+        fn(fc, obs).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any(), "NaN at perfect forecast")
+        self.assertFalse(torch.isinf(fc.grad).any(), "Inf at perfect forecast")
+
+    def test_batch_independence(self, verbose=False):
+        """The loss for sample [0] computed alone must equal loss[0] in a full batch."""
+        fn = self._fn()
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        loss_single = fn(fc[:1], obs[:1])
+        loss_batch = fn(fc, obs)
+        self.assertTrue(
+            compare_tensors("corrected spectral L2 ES batch", loss_single[0], loss_batch[0], verbose=verbose)
+        )
+
+    # -- semantic tests: the correction does what its docstring claims -------
+
+    def test_equivalence_at_correct_amplitude(self, verbose=False):
+        """When psd_pred ≈ psd_true the spread-rescaling ratio collapses to 1
+        and the corrected loss must agree with the standard SpectralL2 ES.
+
+        Construction: forecasts are observations + small noise per member.
+        For small enough noise psd_pred ≈ psd_true to within a small relative
+        tolerance, and the two loss formulas should produce nearly identical
+        outputs.
+        """
+        obs = _rand()
+        # noise-amplitude ≪ obs-amplitude so psd_pred deviation from psd_true
+        # stays in the percent range — atol/rtol below set accordingly
+        noise = 0.02 * torch.randn(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W)
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W).clone() + noise
+
+        out_corrected = self._fn()(fc, obs)
+        out_standard  = self._fn_uncorrected()(fc, obs)
+
+        # absolute tolerance scaled to the typical loss magnitude here (~1e-2);
+        # rtol reflects the fact that ratio ≠ 1 exactly even with tiny noise
+        self.assertTrue(
+            compare_tensors(
+                "corrected ≈ standard at correct amplitude",
+                out_corrected, out_standard, atol=1e-4, rtol=5e-2, verbose=verbose,
+            ),
+            f"corrected={out_corrected.tolist()} standard={out_standard.tolist()}",
+        )
+
+    def test_cheap_spread_penalty(self):
+        """The whole point of the correction.
+
+        Setup: ensemble with the right *phases* (members are scaled obs + noise)
+        but inflated *amplitudes* (k=3). Then psd_pred ≈ k² · psd_true so the
+        ratio psd_true / (psd_pred + eps) ≈ 1/k² ≪ 1.
+
+        The accuracy term (eskill) is identical between the two losses. The
+        spread term in the corrected loss is scaled down by ratio ≈ 1/9, so it
+        provides much less negative contribution. Therefore:
+
+            corrected_loss > standard_loss
+
+        i.e. the corrected loss does not let the model collect cheap spread
+        reward by inflating its predicted PSD.
+        """
+        k = 3.0
+        obs = _rand()
+        # different noise per member so espread > 0; otherwise the spread term
+        # is zero in BOTH losses and the test is degenerate
+        noise = 0.1 * torch.randn(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W)
+        fc_inflated = k * obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_CH, _IMG_H, _IMG_W) + noise
+
+        out_corrected = self._fn()(fc_inflated, obs)
+        out_standard  = self._fn_uncorrected()(fc_inflated, obs)
+
+        # corrected must be strictly larger element-wise — the cheap-spread
+        # protection is per (B, n_channels) and not just on the average
+        self.assertTrue(
+            (out_corrected > out_standard).all(),
+            f"corrected loss not strictly above standard: "
+            f"corrected={out_corrected.tolist()} standard={out_standard.tolist()}",
+        )
+
+    def test_eps_does_not_dominate_when_psd_is_small(self):
+        """Defensive: the ratio psd_true / (psd_pred + eps) uses eps as a guard
+        against divide-by-zero. For very small psd_pred this can dominate and
+        skew the spread-rescaling. We verify that for *unit-scale* random
+        inputs (where psd_pred is well above eps everywhere) the corrected and
+        standard losses are within a few percent — i.e. eps doesn't leak into
+        the result at the default eps=1e-6.
+        """
+        fc = _rand_ensemble(self._E)
+        obs = _rand()
+        out_corrected = self._fn()(fc, obs)
+        out_standard  = self._fn_uncorrected()(fc, obs)
+        # both finite, no NaN/Inf
+        self.assertTrue(torch.isfinite(out_corrected).all())
+        self.assertTrue(torch.isfinite(out_standard).all())
+        # not the same — random forecasts have psd_pred ≠ psd_true so ratio ≠ 1
+        # and the spread term is rescaled
+        self.assertFalse(
+            compare_tensors("corrected vs standard random", out_corrected, out_standard, atol=1e-6, rtol=1e-4),
+            "corrected and standard agree on random ensemble — ratio≠1 should produce a measurable difference",
         )
 
 


### PR DESCRIPTION
this MR does the following:

Test improvements:
- adds loss testing for some crps kernels
- adds test which compares naive and sorted skill spread loss term in terms of fwd result and grads
- adds test for coherence loss, testing the assumptions for every term in the loss
- adds test for corrected energy score loss
- add tests for kernel score loss
- small code branching tests for weighted losses and some other non commonly exercised branches
- adding tests for skill spread kernel with absolute=False 

Bug fixes:
- enables alpha factor for naive skill spread kernel. that was already supported in 2 of 5 call sites but now all call sites support it
- spectral coherence loss now honors the channel_reduction flag and mimics the behavior of other energy type losses 
- recursion bug in loss base classes when querying the number of channels

Other changes:
- changing text.yml file to more careful torch harmonics installation, currently pulling from main branch because of missing harmonics filter basis function