### PR TITLE
proper per channel basis decomp in KernelScore

### DIFF
--- a/makani/utils/losses/crps_loss.py
+++ b/makani/utils/losses/crps_loss.py
@@ -1021,7 +1021,7 @@ class KernelScoreLoss(GeometricBaseLoss):
         weight = torch.zeros_like(self.conv.weight.data)
         for i in range(self.n_channels):
             for k in range(self.kernel_basis_size):
-                weight[i*k, 0, k] = 1.0
+                weight[i * self.kernel_basis_size + k, 0, k] = 1.0
 
         # convert weight to buffer to avoid issues with distributed training
         delattr(self.conv, "weight")


### PR DESCRIPTION
This MR is a hot fix for the weight initialization of the disco weights in KernelScoreLoss