### PR TITLE
adding 1e-5 lr warmup start

### DIFF
--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -701,7 +701,7 @@ class Driver(metaclass=abc.ABCMeta):
         if params.lr_warmup_steps > 0:
             if params.scheduler == "ReduceLROnPlateau":
                 raise NotImplementedError("Error, warmup scheduler not implemented for ReduceLROnPlateau scheduler")
-            warmup_scheduler = lr_scheduler.LinearLR(optimizer, start_factor=params.get("lr_start", 0.0), end_factor=1.0, total_iters=params.get("lr_warmup_steps", 0))
+            warmup_scheduler = lr_scheduler.LinearLR(optimizer, start_factor=params.get("lr_start", 1E-5), end_factor=1.0, total_iters=params.get("lr_warmup_steps", 0))
 
             scheduler = lr_scheduler.SequentialLR(optimizer, [warmup_scheduler, scheduler], milestones=[params.get("lr_warmup_steps", 0)])
 


### PR DESCRIPTION
this sets the default start LR for LR warmup to something >0, because 0 is not supported by pytorch anymore. 