### PR TITLE
cleaning up dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,25 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy matplotlib pillow tensorly tensorly-torch more_itertools importlib-metadata
+        # Install torch first, then build torch-harmonics against it. Anything
+        # after this step must respect the torch version that TH was compiled
+        # with, otherwise the prebuilt _C.so will hit ABI-mismatch import errors.
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
         python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
+        # Freeze whatever torch version TH just compiled against. Strip the
+        # local label (+cpu) so the constraint matches any build of that
+        # public version.
+        TH_TORCH=$(python -c "import torch; print(torch.__version__.split('+')[0])")
+        echo "torch_harmonics was built against torch ${TH_TORCH}"
+        echo "torch==${TH_TORCH}" > "${GITHUB_WORKSPACE}/constraints.txt"
+        cat "${GITHUB_WORKSPACE}/constraints.txt"
+        # Make the constraint visible to later workflow steps.
+        echo "PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt" >> "$GITHUB_ENV"
+        # Everything from here on must honor the constraint, so timm / physicsnemo
+        # / etc. can't silently upgrade torch and break TH's _C.so.
+        python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy matplotlib pillow tensorly tensorly-torch more_itertools importlib-metadata
+        python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
     - name: Install package
       run: |
         python -m pip install --no-deps -e .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
         echo "torch_harmonics was built against torch ${TH_TORCH}"
         echo "torch==${TH_TORCH}" > "${GITHUB_WORKSPACE}/constraints.txt"
         cat "${GITHUB_WORKSPACE}/constraints.txt"
-        # Make the constraint visible to later workflow steps so timm / physicsnemo
-        # / etc. can't silently upgrade torch and break TH's _C.so.
+        # Make the constraint visible to later workflow steps so physicsnemo
+        # or any transitive dep can't silently upgrade torch and break TH's _C.so.
         echo "PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt" >> "$GITHUB_ENV"
         # Pin physicsnemo to the git tag before installing the package so the
         # `nvidia-physicsnemo>=1.1.1` dep in pyproject.toml resolves to this

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         python -m pip install -e .[test,vis]
     - name: Test with pytest
       run: |
-        python -m pytest ./tests --cov=makani --cov-report=term-missing
+        python -m pytest -ra ./tests --cov=makani --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,16 +29,16 @@ jobs:
         echo "torch_harmonics was built against torch ${TH_TORCH}"
         echo "torch==${TH_TORCH}" > "${GITHUB_WORKSPACE}/constraints.txt"
         cat "${GITHUB_WORKSPACE}/constraints.txt"
-        # Make the constraint visible to later workflow steps.
-        echo "PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt" >> "$GITHUB_ENV"
-        # Everything from here on must honor the constraint, so timm / physicsnemo
+        # Make the constraint visible to later workflow steps so timm / physicsnemo
         # / etc. can't silently upgrade torch and break TH's _C.so.
-        python -m pip install tqdm numpy parameterized xarray xskillscore timm jsbeautifier pynvml h5py wandb ruamel.yaml moviepy matplotlib pillow tensorly tensorly-torch more_itertools importlib-metadata
+        echo "PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt" >> "$GITHUB_ENV"
+        # Pin physicsnemo to the git tag before installing the package so the
+        # `nvidia-physicsnemo>=1.1.1` dep in pyproject.toml resolves to this
+        # build rather than whatever PyPI offers.
         python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
     - name: Install package
       run: |
-        python -m pip install --no-deps -e .
+        python -m pip install -e .[test,vis]
     - name: Test with pytest
       run: |
-        python -m pip install pytest pytest-cov parameterized
         python -m pytest ./tests --cov=makani --cov-report=term-missing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt remove cmake -y && \
 RUN SETUPTOOLS_USE_DISTUTILS=local pip install mpi4py
 
 # install onnx
-RUN pip install onnx onnxruntime onnxruntime-gpu
+RUN pip install onnxruntime onnxruntime-gpu
 
 # hdf5 and h5py
 ENV HDF5_VERSION=2.0.0
@@ -52,10 +52,10 @@ ENV PATH=/opt/hdf5/bin:${PATH}
 RUN pip install cdsapi>=0.7.2
 
 # install zarr and data stuff
-RUN pip install more_itertools zarr xarray pandas gcsfs boto3
+RUN pip install more_itertools zarr xarray gcsfs boto3
 
-# moviepy imageio for wandb video logging
-RUN pip install moviepy imageio
+# moviepy for wandb video logging
+RUN pip install moviepy
 
 # other python stuff
 RUN pip install --upgrade wandb ruamel.yaml tqdm progressbar2

--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -30,7 +30,7 @@ RUN apt remove cmake -y && \
 RUN SETUPTOOLS_USE_DISTUTILS=local pip install mpi4py
 
 # install onnx
-RUN pip install onnx onnxruntime onnxruntime-gpu
+RUN pip install onnxruntime onnxruntime-gpu
 
 # install AWS prereqs for HDF5
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-common.git && \
@@ -138,10 +138,10 @@ ENV PATH=/opt/hdf5/bin:${PATH}
 RUN pip install cdsapi>=0.7.2
 
 # install zarr and data stuff
-RUN pip install more_itertools zarr xarray pandas gcsfs boto3
+RUN pip install more_itertools zarr xarray gcsfs boto3
 
-# moviepy imageio for wandb video logging
-RUN pip install moviepy imageio
+# moviepy for wandb video logging
+RUN pip install moviepy
 
 # other python stuff
 RUN pip install --upgrade wandb ruamel.yaml tqdm progressbar2

--- a/makani/models/model_registry.py
+++ b/makani/models/model_registry.py
@@ -161,7 +161,8 @@ def get_model(params: ParamsBase, use_stochastic_interpolation: bool = False, mu
 
     model_handle = _model_registry.get(params.nettype)
     if model_handle is not None:
-        # EntryPoint-like (stdlib or backport importlib_metadata): call .load() to get the callable
+        # Registry entries are either EntryPoint objects (from entry_points discovery)
+        # or direct class refs (from register_model). Resolve EntryPoints to the callable.
         if hasattr(model_handle, "load") and callable(model_handle.load):
             model_handle = model_handle.load()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,12 @@ version = {attr = "makani.__version__"}
 dev = [
     "black>=22.10.0",
     "coverage>=6.5.0",
-    "nvidia_dali_cuda110>=1.16.0",
+    "nvidia-dali-cuda120>=1.40.0",
 ]
 
 test = [
     "pytest>=6.0.0",
+    "pytest-cov",
     "parameterized",
     "properscoring",
     "xarray",
@@ -100,7 +101,6 @@ legacy_data_process = [
 
 vis = [
     "matplotlib>=3.8.1",
-    "imageio>=2.28.1",
     "moviepy>=1.0.3",
 ]
 


### PR DESCRIPTION
fixing torch installation mixup in CI by freezing torch to the version against which torch-harmonics was compiled.

also, removing a lot of stale dependencies across all installation methods from makani.