### PR TITLE
adding odirect support to inferencer buffer IO

### DIFF
--- a/makani/inference.py
+++ b/makani/inference.py
@@ -225,6 +225,7 @@ if __name__ == "__main__":
                     end_date=args.end_date,
                     date_step=args.date_step,
                     wb2_compatible=args.wb2_compatible,
+                    enable_odirect=args.enable_odirect,
                     profiler=profiler,
                 )
         elif args.capture_type == "cupti":
@@ -242,6 +243,7 @@ if __name__ == "__main__":
                         end_date=args.end_date,
                         date_step=args.date_step,
                         wb2_compatible=args.wb2_compatible,
+                        enable_odirect=args.enable_odirect,
                         profiler=profiler,
                     )
 
@@ -258,6 +260,7 @@ if __name__ == "__main__":
             end_date=args.end_date,
             date_step=args.date_step,
             wb2_compatible=args.wb2_compatible,
+            enable_odirect=args.enable_odirect,
         )
 
     # cleanup

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -206,7 +206,7 @@ class Inferencer(Driver):
 
     # shorthand for inference range running over the full dataset
     def inference_epoch(
-            self, rollout_steps: int, dhours: int, compute_metrics: bool = False, output_channels: List[str] = [], output_file: Optional[str] = None, output_memory_buffer_size: Optional[int] = None, bias_file: Optional[str] = None, spectrum_file: Optional[str] = None, zonal_spectrum_file: Optional[str] = None, wb2_compatible: Optional[bool] = False, profiler=None
+            self, rollout_steps: int, dhours: int, compute_metrics: bool = False, output_channels: List[str] = [], output_file: Optional[str] = None, output_memory_buffer_size: Optional[int] = None, bias_file: Optional[str] = None, spectrum_file: Optional[str] = None, zonal_spectrum_file: Optional[str] = None, wb2_compatible: Optional[bool] = False, enable_odirect: bool = False, profiler=None
     ):
         """
         Runs the model in autoregressive inference mode on the entire validation dataset. Computes metrics and scores the model.
@@ -237,6 +237,7 @@ class Inferencer(Driver):
             spectrum_file=spectrum_file,
             zonal_spectrum_file=zonal_spectrum_file,
             wb2_compatible=wb2_compatible,
+            enable_odirect=enable_odirect,
             profiler=profiler,
         )
 
@@ -260,6 +261,7 @@ class Inferencer(Driver):
         spectrum_file: Optional[str] = None,
         zonal_spectrum_file: Optional[str] = None,
         wb2_compatible: Optional[bool] = False,
+        enable_odirect: bool = False,
         profiler=None,
     ):
 
@@ -281,6 +283,7 @@ class Inferencer(Driver):
             spectrum_file=spectrum_file,
             zonal_spectrum_file=zonal_spectrum_file,
             wb2_compatible=wb2_compatible,
+            enable_odirect=enable_odirect,
             profiler=profiler,
         )
 
@@ -301,6 +304,7 @@ class Inferencer(Driver):
         spectrum_file: Optional[str] = None,
         zonal_spectrum_file: Optional[str] = None,
         wb2_compatible: Optional[bool] = False,
+        enable_odirect: bool = False,
         profiler=None,
     ):
 
@@ -361,6 +365,7 @@ class Inferencer(Driver):
                 output_file=output_file,
                 output_channels=output_channels,
                 output_memory_buffer_size=output_memory_buffer_size,
+                enable_odirect=enable_odirect,
             )
         else:
             rollout_buffer = None
@@ -719,7 +724,7 @@ class Inferencer(Driver):
         return
 
     def score_model(
-            self, metrics_file: Optional[str] = None, output_channels: List[str] = [], output_file: Optional[str] = None, output_memory_buffer_size: Optional[int]=None, bias_file: Optional[str]=None, spectrum_file: Optional[str]=None, zonal_spectrum_file: Optional[str]=None, start_date=None, end_date=None, date_step=1, wb2_compatible=False, profiler=None
+            self, metrics_file: Optional[str] = None, output_channels: List[str] = [], output_file: Optional[str] = None, output_memory_buffer_size: Optional[int]=None, bias_file: Optional[str]=None, spectrum_file: Optional[str]=None, zonal_spectrum_file: Optional[str]=None, start_date=None, end_date=None, date_step=1, wb2_compatible=False, enable_odirect: bool = False, profiler=None
     ):
         """
         main routine for scoring models. Runs the inference over the entire dataset and computes the score. Then writes them to disk
@@ -784,6 +789,7 @@ class Inferencer(Driver):
             spectrum_file=spectrum_file,
             zonal_spectrum_file=zonal_spectrum_file,
             wb2_compatible=wb2_compatible,
+            enable_odirect=enable_odirect,
             profiler=profiler,
         )
 

--- a/makani/utils/inference/rollout_buffer.py
+++ b/makani/utils/inference/rollout_buffer.py
@@ -171,6 +171,13 @@ class RolloutBuffer(DataBuffer):
         avoid GPU→CPU transfers on every ``update()``; the buffer is copied
         to host once at flush time. Ignored when ``streaming_mode`` is
         ``True``.
+    enable_odirect: bool, optional
+        When ``True``, open the output file with HDF5's ``direct`` VFD so
+        writes bypass the host page cache (O_DIRECT). Requires an HDF5 build
+        with the direct VFD compiled in (``--enable-direct-vfd``) and
+        ``output_file`` to be set. Incompatible with the MPI-IO driver used
+        for distributed writes; use only on single-rank or per-rank file
+        layouts. Default is ``False``.
     """
 
     def __init__(
@@ -193,8 +200,17 @@ class RolloutBuffer(DataBuffer):
         output_memory_buffer_size: Optional[int] = None,
         streaming_mode: bool = False,
         buffer_device: Union[str, torch.device] = torch.device("cpu"),
+        enable_odirect: bool = False,
     ):
         super().__init__(num_rollout_steps, rollout_dt, channel_names, device, scale, bias, output_channels, output_file)
+
+        # O_DIRECT (HDF5 ``direct`` VFD): bypasses the host page cache. Requires an
+        # output file and a non-MPI single-writer layout — the direct VFD is mutually
+        # exclusive with ``mpio``. Validation against the MPI driver happens later
+        # in ``_create_output_file`` where we know whether ``mpi_comm`` was created.
+        if enable_odirect and output_file is None:
+            raise ValueError("enable_odirect=True requires output_file to be set.")
+        self.enable_odirect = enable_odirect
 
         # streaming mode has no in-memory fallback — every update writes to disk.
         # Two ways to opt in:
@@ -304,8 +320,17 @@ class RolloutBuffer(DataBuffer):
 
     def _create_output_file(self, output_file):
         if self.mpi_comm is not None:
+            # MPI-IO is mutually exclusive with the direct VFD; the user picks one.
+            if self.enable_odirect:
+                raise ValueError(
+                    "enable_odirect=True is incompatible with the MPI-IO driver "
+                    "(used whenever world_size > 1). Use a per-rank file layout or disable O_DIRECT."
+                )
             # initialize MPI. This call is collective!
             self.file_handle = h5.File(output_file, "w", driver="mpio", comm=self.mpi_comm)
+        elif self.enable_odirect:
+            # HDF5 ``direct`` VFD: writes go through O_DIRECT, bypassing the page cache.
+            self.file_handle = h5.File(output_file, "w", driver="direct")
         else:
             self.file_handle = h5.File(output_file, "w")
 

--- a/tests/test_rollout_buffers.py
+++ b/tests/test_rollout_buffers.py
@@ -1300,6 +1300,7 @@ class TestRolloutBufferStreaming(unittest.TestCase):
         output_memory_buffer_size=None,
         streaming_mode=False,
         buffer_device=torch.device("cpu"),
+        enable_odirect=False,
     ):
         if output_channels is None:
             output_channels = list(channel_names)
@@ -1327,6 +1328,7 @@ class TestRolloutBufferStreaming(unittest.TestCase):
             output_memory_buffer_size=output_memory_buffer_size,
             streaming_mode=streaming_mode,
             buffer_device=buffer_device,
+            enable_odirect=enable_odirect,
         )
 
     def _drive_full_rollout(self, buf, *, ic_data_per_batch, tstamps_per_batch):
@@ -1340,6 +1342,66 @@ class TestRolloutBufferStreaming(unittest.TestCase):
         # directly to disk, so output_file is mandatory.
         with self.assertRaises(ValueError):
             self._make_buffer(output_file=None, streaming_mode=True)
+
+    def test_enable_odirect_without_output_file_raises(self, verbose=False):
+        # O_DIRECT writes need a real file — same contract as streaming mode.
+        with self.assertRaises(ValueError):
+            self._make_buffer(output_file=None, enable_odirect=True)
+
+    def test_enable_odirect_round_trip(self, verbose=False):
+        # When the HDF5 build includes the direct VFD, enable_odirect=True must:
+        #   (1) construct without error,
+        #   (2) open the file with driver="direct" (no host page cache),
+        #   (3) produce a file readable with the default driver — same bytes as
+        #       a control run with enable_odirect=False.
+        # Skip-if-unavailable: not every HDF5 build ships the direct VFD.
+        ctrl_path = os.path.join(self.tmpdir, "odirect_ctrl.h5")
+        odirect_path = os.path.join(self.tmpdir, "odirect.h5")
+
+        # build identical inputs
+        H, W = 2, 4
+        num_samples = 4
+        R = 1
+        batches = []
+        for b in range(2):
+            arr = torch.zeros(2, R + 1, 1, 2, H, W)
+            for i in range(2):
+                ic = b * 2 + i
+                for idt in range(R + 1):
+                    arr[i, idt, ...] = float(ic * 10 + idt)
+            batches.append(arr)
+        tstamps = [torch.tensor([float(b * 2), float(b * 2 + 1)]) for b in range(2)]
+
+        # control
+        buf_ctrl = self._make_buffer(
+            output_file=ctrl_path,
+            num_samples=num_samples, batch_size=2,
+            num_rollout_steps=R, ensemble_size=1,
+            img_shape=(H, W),
+        )
+        self._drive_full_rollout(buf_ctrl, ic_data_per_batch=batches, tstamps_per_batch=tstamps)
+        buf_ctrl.finalize()
+
+        # O_DIRECT path — skip if the local HDF5 build lacks the direct VFD
+        try:
+            buf_od = self._make_buffer(
+                output_file=odirect_path,
+                num_samples=num_samples, batch_size=2,
+                num_rollout_steps=R, ensemble_size=1,
+                img_shape=(H, W),
+                enable_odirect=True,
+            )
+        except (ValueError, OSError, RuntimeError) as e:
+            self.skipTest(f"HDF5 build does not support the direct VFD: {e}")
+
+        self._drive_full_rollout(buf_od, ic_data_per_batch=batches, tstamps_per_batch=tstamps)
+        buf_od.finalize()
+
+        with h5.File(ctrl_path, "r") as f_c, h5.File(odirect_path, "r") as f_o:
+            with self.subTest(desc="fields match control"):
+                self.assertTrue(np.array_equal(f_c["fields"][...], f_o["fields"][...]))
+            with self.subTest(desc="timestamps match control"):
+                self.assertTrue(np.array_equal(f_c["timestamp"][...], f_o["timestamp"][...]))
 
     def test_output_memory_buffer_size_zero_implies_streaming(self, verbose=False):
         # Legacy shorthand from tkurth/gds-support: passing


### PR DESCRIPTION
This exposes the O_DIRECT driver to inference buffer writing. Cannot be used in conjunction with MPIIO but can be useful for IO performance tests and single GPU inference