### PR TITLE
Fix data processing progressbar

### DIFF
--- a/data_process/convert_makani_output_to_wb2.py
+++ b/data_process/convert_makani_output_to_wb2.py
@@ -148,7 +148,7 @@ def convert(file_names_to_convert: List[str], output_file: str, batch_size: Opti
                                })
         datastore.to_zarr(store=output_file, mode='w', compute=False)
 
-        pbar = progressbar.ProgressBar(maxval=total_entries)
+        pbar = progressbar.ProgressBar(max_value=total_entries)
         pbar.update(0)
 
     # we need to wait here

--- a/data_process/merge_wb2_dataset.py
+++ b/data_process/merge_wb2_dataset.py
@@ -87,7 +87,7 @@ def transfer_channels(input_file: str, output_file: str, channels: List[str],
             
     # set up progressbar
     if comm_rank == 0:
-        pbar = progressbar.ProgressBar(maxval=num_entries_total)
+        pbar = progressbar.ProgressBar(max_value=num_entries_total)
         pbar.update(0)
 
     # get offsets

--- a/data_process/wb2_helpers.py
+++ b/data_process/wb2_helpers.py
@@ -94,7 +94,7 @@ class DistributedProgressBar(object):
 
         if self.comm.Get_rank() == 0:
             # set up pbar
-            self.pbar = progressbar.ProgressBar(maxval=num_entries)
+            self.pbar = progressbar.ProgressBar(max_value=num_entries)
             self.pbar.start()
         self.reset()
 
@@ -126,4 +126,4 @@ class DistributedProgressBar(object):
     def update_progress(self):
         if self.comm.Get_rank() == 0:
             count = self.get_counter()
-            self.pbar.update(min(count, self.pbar.maxval))
+            self.pbar.update(min(count, self.pbar.max_value))


### PR DESCRIPTION
The code is referencing `progressbar2`, which is a fork of the abandoned `progressbar` package. However, 23cb763 introduced code that doesn't seem to work with `progressbar2` (though presumably it does with the deprecated package?).

Here we update `maxval` to `max_value`, which is the corresponding attribute in `progressbar2` (though `maxval` can still be validly passed to `__init__`), thus fixing the broken data processing code.