### PR TITLE
Only keep visualized channels for visualization

### DIFF
--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -718,16 +718,21 @@ class Driver(metaclass=abc.ABCMeta):
         Initialize the visualizer
         """
         from makani.utils import visualize
+        # channels used in visualization; pass this to the visualizer to avoid
+        # keeping around big prediction tensors with many unnecessary channels
+        # while plots are being renedered
+        channel_indices = []
 
         # windspeed
         cnames = params.channel_names
         u10m_channel_index = cnames.index("u10m") if "u10m" in cnames else None
         v10m_channel_index = cnames.index("v10m") if "v10m" in cnames else None
         if u10m_channel_index is not None and v10m_channel_index is not None:
+            channel_indices += [u10m_channel_index, v10m_channel_index]
             plot_list = [
                 {
                     "name": "windspeed_uv10",
-                    "functor": f"lambda x: np.sqrt(np.square(x[{u10m_channel_index}, ...]) + np.square(x[{v10m_channel_index}, ...]))",
+                    "functor": f"lambda x: np.sqrt(np.square(x[{len(channel_indices) - 2}, ...]) + np.square(x[{len(channel_indices) - 1}, ...]))",
                     "diverging": False
                 }
             ]
@@ -737,10 +742,11 @@ class Driver(metaclass=abc.ABCMeta):
         # z500
         channel_index = cnames.index("z500") if "z500" in cnames else None
         if channel_index is not None:
+            channel_indices += [channel_index]
             plot_list += [
                 {
-                    "name": "geopotential_z500", 
-                    "functor": f"lambda x: x[{channel_index}, ...]", 
+                    "name": "geopotential_z500",
+                    "functor": f"lambda x: x[{len(channel_indices) - 1}, ...]",
                     "diverging": False
                 }
             ]
@@ -748,10 +754,11 @@ class Driver(metaclass=abc.ABCMeta):
         # q100
         channel_index = cnames.index("q100") if "q100" in cnames else None
         if channel_index is not None:
+            channel_indices += [channel_index]
             plot_list += [
                 {
-                    "name": "specific_humidity_q100", 
-                    "functor": f"lambda x: x[{channel_index}, ...]", 
+                    "name": "specific_humidity_q100",
+                    "functor": f"lambda x: x[{len(channel_indices) - 1}, ...]",
                     "diverging": False
                 }
             ]
@@ -767,6 +774,7 @@ class Driver(metaclass=abc.ABCMeta):
                 scale=out_scale[0, ...],
                 bias=out_bias[0, ...],
                 num_workers=params.num_visualization_workers,
+                channel_indices=channel_indices,
             )
             # allocate pinned tensors for faster copy:
             if device.type == "cuda":

--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -718,50 +718,34 @@ class Driver(metaclass=abc.ABCMeta):
         Initialize the visualizer
         """
         from makani.utils import visualize
-        # channels used in visualization; pass this to the visualizer to avoid
-        # keeping around big prediction tensors with many unnecessary channels
-        # while plots are being renedered
-        channel_indices = []
 
-        # windspeed
+        # Functors reference channels symbolically via {name} placeholders. The
+        # visualizer resolves them against channel_names, ships only the
+        # referenced channels to the renderer subprocesses, and rewrites each
+        # functor to index into the stripped tensor.
         cnames = params.channel_names
-        u10m_channel_index = cnames.index("u10m") if "u10m" in cnames else None
-        v10m_channel_index = cnames.index("v10m") if "v10m" in cnames else None
-        if u10m_channel_index is not None and v10m_channel_index is not None:
-            channel_indices += [u10m_channel_index, v10m_channel_index]
-            plot_list = [
-                {
-                    "name": "windspeed_uv10",
-                    "functor": f"lambda x: np.sqrt(np.square(x[{len(channel_indices) - 2}, ...]) + np.square(x[{len(channel_indices) - 1}, ...]))",
-                    "diverging": False
-                }
-            ]
-        else:
-            plot_list = []
+        plot_list = []
 
-        # z500
-        channel_index = cnames.index("z500") if "z500" in cnames else None
-        if channel_index is not None:
-            channel_indices += [channel_index]
-            plot_list += [
-                {
-                    "name": "geopotential_z500",
-                    "functor": f"lambda x: x[{len(channel_indices) - 1}, ...]",
-                    "diverging": False
-                }
-            ]
+        if "u10m" in cnames and "v10m" in cnames:
+            plot_list.append({
+                "name": "windspeed_uv10",
+                "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+                "diverging": False,
+            })
 
-        # q100
-        channel_index = cnames.index("q100") if "q100" in cnames else None
-        if channel_index is not None:
-            channel_indices += [channel_index]
-            plot_list += [
-                {
-                    "name": "specific_humidity_q100",
-                    "functor": f"lambda x: x[{len(channel_indices) - 1}, ...]",
-                    "diverging": False
-                }
-            ]
+        if "z500" in cnames:
+            plot_list.append({
+                "name": "geopotential_z500",
+                "functor": "lambda x: x[{z500}, ...]",
+                "diverging": False,
+            })
+
+        if "q100" in cnames:
+            plot_list.append({
+                "name": "specific_humidity_q100",
+                "functor": "lambda x: x[{q100}, ...]",
+                "diverging": False,
+            })
 
         if plot_list:
             visualizer = visualize.VisualizationWrapper(
@@ -769,12 +753,12 @@ class Driver(metaclass=abc.ABCMeta):
                 path=None,
                 prefix=None,
                 plot_list=plot_list,
+                channel_names=cnames,
                 lat=np.deg2rad(lat_lon_global[0]),
                 lon=np.deg2rad(lat_lon_global[1]) - np.pi,
                 scale=out_scale[0, ...],
                 bias=out_bias[0, ...],
                 num_workers=params.num_visualization_workers,
-                channel_indices=channel_indices,
             )
             # allocate pinned tensors for faster copy:
             if device.type == "cuda":

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -15,6 +15,7 @@
 
 import os
 import io
+import re
 import multiprocessing as mp
 import numpy as np
 import concurrent.futures as cf
@@ -23,6 +24,48 @@ from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 import wandb
 
 import torch
+
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+
+
+def resolve_plot_list(plot_list, channel_names):
+    """
+    Resolve symbolic ``{name}`` channel references in functor strings.
+
+    Each functor string in ``plot_list`` may reference channels by name using
+    ``{name}`` placeholders (e.g. ``"lambda x: x[{z500}, ...]"``). This walks
+    the list, collects the union of referenced channels in first-seen order,
+    rewrites each functor to index into a stripped tensor of just those
+    channels, and returns the new plot list together with the indices into the
+    original ``channel_names`` layout.
+    """
+    ordered_refs = []
+    seen = set()
+    for item in plot_list:
+        for name in _PLACEHOLDER_RE.findall(item["functor"]):
+            if name not in seen:
+                seen.add(name)
+                ordered_refs.append(name)
+
+    stripped_index = {name: i for i, name in enumerate(ordered_refs)}
+
+    channel_indices = []
+    for name in ordered_refs:
+        if name not in channel_names:
+            raise ValueError(
+                f"functor references channel {name!r} which is not in channel_names"
+            )
+        channel_indices.append(channel_names.index(name))
+
+    new_plot_list = []
+    for item in plot_list:
+        new_item = dict(item)
+        new_item["functor"] = _PLACEHOLDER_RE.sub(
+            lambda m: str(stripped_index[m.group(1)]), item["functor"]
+        )
+        new_plot_list.append(new_item)
+
+    return new_plot_list, channel_indices
 
 # we can run matplotlib in Agg mode in the subprocesses to save some memory overhead
 def _worker_init():
@@ -143,7 +186,6 @@ def plot_rollout_metrics(metric_curves, var_names, score_path=None, file_prefix=
         y_locator = ticker.MaxNLocator(nbins=20)
         ax.yaxis.set_major_locator(y_locator)
         ax.grid(which="major", alpha=0.5)
-        ax.legend()
         ax.set_xlabel("Time [h]")
         ax.set_ylabel(file_prefix + " " + var_name)
         plt.setp(ax.get_xticklabels(), rotation=45, horizontalalignment="right")
@@ -151,9 +193,6 @@ def plot_rollout_metrics(metric_curves, var_names, score_path=None, file_prefix=
         # write out the plot
         if score_path is not None:
             fig.savefig(os.path.join(score_path, file_prefix + "_" + var_name + ".png"))
-        # # push to wandb
-        # if params.log_to_wandb:
-        #     wandb.log({metric + "_" + var_name: wandb.Image(fig)}, step=epoch)
 
 
 def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias, diverging):
@@ -181,21 +220,33 @@ def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias,
 class VisualizationWrapper(object):
     "Handles visualization during training"
 
-    def __init__(self, log_to_wandb, path, prefix, plot_list, lat=None, lon=None, scale=1.0, bias=0.0, num_workers=1, channel_indices=None):
+    def __init__(self, log_to_wandb, path, prefix, plot_list, channel_names=None, lat=None, lon=None, scale=1.0, bias=0.0, num_workers=1):
         self.log_to_wandb = log_to_wandb
         self.generate_video = True
         self.path = path
         self.prefix = prefix
-        self.plot_list = plot_list
-        self.channel_indices = channel_indices if channel_indices is not None else slice(None)
+
+        # If channel_names is provided, resolve {name} placeholders in functor
+        # strings to indices into a stripped tensor that contains only the
+        # referenced channels. This avoids shipping unused channels to the
+        # renderer subprocesses.
+        if channel_names is not None:
+            self.plot_list, self.channel_indices = resolve_plot_list(plot_list, channel_names)
+        else:
+            self.plot_list = plot_list
+            self.channel_indices = None
 
         # grid
         self.lat = lat
         self.lon = lon
 
-        # normalization
-        self.scale = scale if isinstance(scale, (int, float)) else scale[self.channel_indices].copy()
-        self.bias = bias if isinstance(bias, (int, float)) else bias[self.channel_indices].copy()
+        # normalization: slice along the channel axis if we have a stripped index list
+        if self.channel_indices is not None and not isinstance(scale, (int, float)):
+            scale = scale[self.channel_indices].copy()
+        if self.channel_indices is not None and not isinstance(bias, (int, float)):
+            bias = bias[self.channel_indices].copy()
+        self.scale = scale
+        self.bias = bias
 
         # this is for parallel processing
         ctx = mp.get_context("spawn")
@@ -206,16 +257,17 @@ class VisualizationWrapper(object):
         self.requests = []
 
     def add(self, tag, prediction, target):
-        # go through the plot list
+        if self.channel_indices is not None:
+            pred = prediction[self.channel_indices].copy()
+            tar = target[self.channel_indices].copy()
+        else:
+            pred = np.copy(prediction)
+            tar = np.copy(target)
+
         for item in self.plot_list:
             field_name = item["name"]
             func_string = item["functor"]
             plot_diverge = item["diverging"]
-
-            # copy only the channels we need for visualisation
-            # assume the functors have been correctly defined only over these
-            pred = prediction[self.channel_indices].copy()
-            tar = target[self.channel_indices].copy()
             self.requests.append(
                 self.executor.submit(visualize_field, (tag, field_name), func_string, pred, tar, self.lat, self.lon, self.scale, self.bias, plot_diverge)
             )

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -181,20 +181,21 @@ def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias,
 class VisualizationWrapper(object):
     "Handles visualization during training"
 
-    def __init__(self, log_to_wandb, path, prefix, plot_list, lat=None, lon=None, scale=1.0, bias=0.0, num_workers=1):
+    def __init__(self, log_to_wandb, path, prefix, plot_list, lat=None, lon=None, scale=1.0, bias=0.0, num_workers=1, channel_indices=None):
         self.log_to_wandb = log_to_wandb
         self.generate_video = True
         self.path = path
         self.prefix = prefix
         self.plot_list = plot_list
+        self.channel_indices = channel_indices if channel_indices is not None else slice(None)
 
         # grid
         self.lat = lat
         self.lon = lon
 
         # normalization
-        self.scale = scale
-        self.bias = bias
+        self.scale = scale if isinstance(scale, (int, float)) else scale[self.channel_indices].copy()
+        self.bias = bias if isinstance(bias, (int, float)) else bias[self.channel_indices].copy()
 
         # this is for parallel processing
         ctx = mp.get_context("spawn")
@@ -210,8 +211,13 @@ class VisualizationWrapper(object):
             field_name = item["name"]
             func_string = item["functor"]
             plot_diverge = item["diverging"]
+
+            # copy only the channels we need for visualisation
+            # assume the functors have been correctly defined only over these
+            pred = prediction[self.channel_indices].copy()
+            tar = target[self.channel_indices].copy()
             self.requests.append(
-                self.executor.submit(visualize_field, (tag, field_name), func_string, np.copy(prediction), np.copy(target), self.lat, self.lon, self.scale, self.bias, plot_diverge)
+                self.executor.submit(visualize_field, (tag, field_name), func_string, pred, tar, self.lat, self.lon, self.scale, self.bias, plot_diverge)
             )
 
         return

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -39,6 +39,7 @@ if _have_visualize_deps:
         _worker_init,
         plot_comparison,
         plot_rollout_metrics,
+        resolve_plot_list,
         visualize_field,
     )
 
@@ -148,6 +149,76 @@ class TestWorkerInit(unittest.TestCase):
                 os.environ["MPLBACKEND"] = original
 
 
+@unittest.skipUnless(_have_visualize_deps, "matplotlib and/or PIL are not installed")
+class TestResolvePlotList(unittest.TestCase):
+    """Unit tests for the symbolic {name}-placeholder resolver."""
+
+    def test_single_channel_substituted(self):
+        plot_list = [{"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False}]
+        new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500", "q100"])
+        self.assertEqual(indices, [2])
+        # only one referenced channel => it lands at stripped index 0
+        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
+        # non-functor fields are preserved
+        self.assertEqual(new_list[0]["name"], "z500")
+        self.assertEqual(new_list[0]["diverging"], False)
+
+    def test_multiple_placeholders_in_single_functor(self):
+        plot_list = [{
+            "name": "wind",
+            "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+            "diverging": False,
+        }]
+        new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500"])
+        self.assertEqual(indices, [0, 1])
+        self.assertEqual(
+            new_list[0]["functor"],
+            "lambda x: np.sqrt(np.square(x[0, ...]) + np.square(x[1, ...]))",
+        )
+
+    def test_first_seen_ordering(self):
+        # channels referenced in a non-source order: stripped indices follow
+        # first-appearance order in the plot_list, not the original layout.
+        plot_list = [
+            {"name": "a", "functor": "lambda x: x[{q100}, ...]", "diverging": False},
+            {"name": "b", "functor": "lambda x: x[{u10m}, ...]", "diverging": False},
+        ]
+        new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500", "q100"])
+        # q100 seen first -> stripped index 0 -> original index 3
+        # u10m seen second -> stripped index 1 -> original index 0
+        self.assertEqual(indices, [3, 0])
+        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
+        self.assertEqual(new_list[1]["functor"], "lambda x: x[1, ...]")
+
+    def test_duplicate_references_dedup(self):
+        plot_list = [
+            {"name": "a", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
+            {"name": "b", "functor": "lambda x: x[{z500}, ...] * 2", "diverging": False},
+        ]
+        new_list, indices = resolve_plot_list(plot_list, ["u10m", "z500"])
+        self.assertEqual(indices, [1])
+        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
+        self.assertEqual(new_list[1]["functor"], "lambda x: x[0, ...] * 2")
+
+    def test_no_placeholders_returns_empty_indices(self):
+        plot_list = [{"name": "raw", "functor": "lambda x: x", "diverging": False}]
+        new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m"])
+        self.assertEqual(indices, [])
+        self.assertEqual(new_list[0]["functor"], "lambda x: x")
+
+    def test_unknown_channel_raises(self):
+        plot_list = [{"name": "bad", "functor": "lambda x: x[{nonexistent}, ...]", "diverging": False}]
+        with self.assertRaises(ValueError):
+            resolve_plot_list(plot_list, ["u10m", "v10m"])
+
+    def test_does_not_mutate_input(self):
+        original = "lambda x: x[{z500}, ...]"
+        plot_list = [{"name": "z500", "functor": original, "diverging": False}]
+        resolve_plot_list(plot_list, ["z500"])
+        # input dict's functor string should be unchanged
+        self.assertEqual(plot_list[0]["functor"], original)
+
+
 @unittest.skipUnless(_have_visualize_deps and _have_moviepy, "matplotlib, PIL, or moviepy is not installed")
 class TestVisualizationWrapper(unittest.TestCase):
     """End-to-end smoke test for the multiprocess visualization pipeline."""
@@ -230,6 +301,63 @@ class TestVisualizationWrapper(unittest.TestCase):
             self.assertEqual(len(wrapper.requests), 2)
         finally:
             wrapper.executor.shutdown(wait=True)
+
+    def test_channel_names_rewrites_plot_list_and_slices_scale_bias(self):
+        channel_names = ["u10m", "v10m", "z500", "q100", "t2m"]
+        plot_list = [
+            {"name": "wind",
+             "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+             "diverging": False},
+            {"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
+        ]
+        scale = np.arange(len(channel_names), dtype=np.float32) + 1.0  # [1, 2, 3, 4, 5]
+        bias = np.arange(len(channel_names), dtype=np.float32) * 10.0  # [0, 10, 20, 30, 40]
+        wrapper = VisualizationWrapper(
+            log_to_wandb=False, path=".", prefix="test",
+            plot_list=plot_list, channel_names=channel_names,
+            scale=scale, bias=bias, num_workers=1,
+        )
+        try:
+            self.assertEqual(wrapper.channel_indices, [0, 1, 2])
+            self.assertEqual(
+                wrapper.plot_list[0]["functor"],
+                "lambda x: np.sqrt(np.square(x[0, ...]) + np.square(x[1, ...]))",
+            )
+            self.assertEqual(wrapper.plot_list[1]["functor"], "lambda x: x[2, ...]")
+            np.testing.assert_array_equal(wrapper.scale, np.array([1.0, 2.0, 3.0]))
+            np.testing.assert_array_equal(wrapper.bias, np.array([0.0, 10.0, 20.0]))
+        finally:
+            wrapper.executor.shutdown(wait=True)
+
+    def test_channel_names_path_runs_end_to_end(self):
+        channel_names = ["u10m", "v10m", "z500", "q100", "t2m"]
+        plot_list = [
+            {"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
+            {"name": "q100", "functor": "lambda x: x[{q100}, ...]", "diverging": True},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            wrapper = VisualizationWrapper(
+                log_to_wandb=False, path=".", prefix="test",
+                plot_list=plot_list, channel_names=channel_names,
+                scale=1.0, bias=0.0, num_workers=1,
+            )
+            try:
+                rng = np.random.default_rng(4)
+                # full-channel tensors; wrapper must slice down to z500/q100
+                pred = rng.standard_normal((len(channel_names), 16, 32)).astype(np.float32)
+                target = rng.standard_normal((len(channel_names), 16, 32)).astype(np.float32)
+                wrapper.add(tag="0", prediction=pred, target=target)
+                self.assertEqual(len(wrapper.requests), 2)
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                    wrapper.finalize()
+                self.assertTrue(os.path.exists("video_output.gif"))
+                self.assertGreater(os.path.getsize("video_output.gif"), 0)
+            finally:
+                wrapper.executor.shutdown(wait=True)
+                os.chdir(cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of keeping copies of all the channels around waiting for the visualization rendering jobs to pick them up, select only the channels being visualized, to reduce RAM usage.

For current training code, the slices we copy & submit to the renderer are 4 channels wide instead of 72, saving lots of memory.

I found this useful when doing long validation rollouts on machines without huge amounts of RAM.