### PR TITLE
vort div loss now passes through all channels

### DIFF
--- a/makani/utils/losses/base_loss.py
+++ b/makani/utils/losses/base_loss.py
@@ -417,7 +417,9 @@ class SpectralBaseLoss(nn.Module, metaclass=ABCMeta):
 
 class VortDivBaseLoss(nn.Module, metaclass=ABCMeta):
     """
-    Geometric base loss class used by all geometric losses
+    Base loss class for losses that score the wind channels in vorticity/divergence
+    space (via a vector-SHT round-trip on each u/v pair). All non-wind channels are
+    passed through unchanged so they still contribute to the loss.
     """
 
     def __init__(
@@ -470,17 +472,24 @@ class VortDivBaseLoss(nn.Module, metaclass=ABCMeta):
 
     @property
     def n_channels(self):
-        return self.wind_chans.shape[0]
+        # the loss is scored over all channels: wind pairs in vort/div space plus every
+        # other channel passed through unchanged
+        return len(self.channel_names)
 
     @torch.compiler.disable(recursive=False)
     def compute_channel_weighting(self, channel_weight_type: str, time_diff_scale: torch.Tensor = None) -> torch.Tensor:
 
+        # weighting for ALL channels (in the original channel order); non-wind channels
+        # keep their normal weight
         chw = _compute_channel_weighting_helper(self.channel_names, channel_weight_type, time_diff_scale=time_diff_scale)
-        chw = chw[self.wind_chans.to(chw.device)]
 
-        # average u and v component weightings to weight vort and div equally
-        chw[1::2] = (chw[1::2] + chw[0::2]) / 2
-        chw[0::2] = chw[1::2]
+        # average the u and v component weightings so the vorticity and divergence
+        # derived from each wind pair are weighted equally
+        wind = self.wind_chans.to(chw.device)
+        u_idx, v_idx = wind[0::2], wind[1::2]
+        avg = (chw[u_idx] + chw[v_idx]) / 2
+        chw[u_idx] = avg
+        chw[v_idx] = avg
 
         return chw
 

--- a/makani/utils/losses/crps_loss.py
+++ b/makani/utils/losses/crps_loss.py
@@ -844,25 +844,27 @@ class VortDivCRPSLoss(VortDivBaseLoss):
         # we assume the following shapes:
         # forecasts: batch, ensemble, channels, lat, lon
         # observations: batch, channels, lat, lon
-        B, E, _, H, W = forecasts.shape
-        C = self.wind_chans.shape[0]
+        B, E, C, H, W = forecasts.shape
+        Cw = self.wind_chans.shape[0]
 
-        # extract wind channels
-        forecasts = forecasts[..., self.wind_chans, :, :].reshape(B, E, C//2, 2, H, W)
-        observations = observations[..., self.wind_chans, :, :].reshape(B, C//2, 2, H, W)
-
-        # get the data type before stripping amp types
-        dtype = forecasts.dtype
-
-        # before anything else compute the transform
-        # as the CDF definition doesn't generalize well to more than one-dimensional variables, we treat complex and imaginary part as the same
+        # Transform the wind channels (u, v pairs) into vorticity/divergence space via
+        # the vector-SHT round-trip and scatter them back in place. Every other (scalar)
+        # channel is passed through unchanged so it still contributes to the score
+        # instead of being silently dropped (see GitHub issue #94).
+        # The CDF definition doesn't generalize well to multi-dimensional variables, so
+        # the two vector components are treated independently.
         with amp.autocast(device_type="cuda", enabled=False):
-            forecasts = self.isht(self.vsht(forecasts.float()))
-            observations = self.isht(self.vsht(observations.float()))
+            forecasts = forecasts.float()
+            observations = observations.float()
 
-        # extract wind channels
-        forecasts = forecasts.reshape(B, E, C, H, W)
-        observations = observations.reshape(B, C, H, W)
+            fc_wind = forecasts[..., self.wind_chans, :, :].reshape(B, E, Cw // 2, 2, H, W)
+            ob_wind = observations[..., self.wind_chans, :, :].reshape(B, Cw // 2, 2, H, W)
+            fc_wind = self.isht(self.vsht(fc_wind)).reshape(B, E, Cw, H, W)
+            ob_wind = self.isht(self.vsht(ob_wind)).reshape(B, Cw, H, W)
+
+            # out-of-place scatter back into the full channel set (original order)
+            forecasts = forecasts.index_copy(-3, self.wind_chans, fc_wind)
+            observations = observations.index_copy(-3, self.wind_chans, ob_wind)
 
         # if ensemble dim is one dimensional then computing the score is quick:
         if (not self.ensemble_distributed) and (E == 1):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -2539,8 +2539,8 @@ class TestVortDivCRPSLoss(unittest.TestCase):
         fc = _rand_ensemble(self._E, channels=_NUM_WIND_CH)
         obs = _rand(channels=_NUM_WIND_CH)
         out = fn(fc, obs)
-        n_wind = fn.wind_chans.shape[0]
-        self.assertEqual(tuple(out.shape), (_BATCH, n_wind))
+        # the loss now scores all channels (wind in vort/div space + scalars passed through)
+        self.assertEqual(tuple(out.shape), (_BATCH, fn.n_channels))
 
     @parameterized.expand([("skillspread",), ("cdf",)])
     def test_nonneg(self, crps_type):
@@ -2589,6 +2589,31 @@ class TestVortDivCRPSLoss(unittest.TestCase):
         obs = _rand(channels=_NUM_WIND_CH)
         with self.assertRaises(ValueError):
             fn(fc, obs)
+
+    def test_scores_all_channels(self):
+        """Regression for issue #94: non-wind (scalar) channels must contribute to the
+        loss instead of being silently dropped."""
+        fn = self._fn("skillspread")
+
+        # the loss now covers the whole state, not just the wind channels
+        self.assertEqual(fn.n_channels, len(_WIND_CHANNEL_NAMES))
+        nonwind = [i for i in range(_NUM_WIND_CH) if i not in fn.wind_chans.tolist()]
+        self.assertGreaterEqual(len(nonwind), 1, "test config must contain a non-wind channel")
+
+        obs = _rand(channels=_NUM_WIND_CH)
+        fc = obs.unsqueeze(1).expand(_BATCH, self._E, _NUM_WIND_CH, _IMG_H, _IMG_W).clone()
+        loss_perfect = fn(fc, obs).sum().item()
+
+        # perturbing ONLY a non-wind channel must change the loss
+        fc_pert = fc.clone()
+        fc_pert[:, :, nonwind[0], ...] += 1.0
+        loss_pert = fn(fc_pert, obs).sum().item()
+
+        self.assertGreater(
+            loss_pert, loss_perfect + 1e-3,
+            f"non-wind channel perturbation did not affect the loss "
+            f"(perfect={loss_perfect}, perturbed={loss_pert})",
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
This MR changes the VortDiv loss such that it transforms the wind channels but does not filter the scalar channels as done previously. 

This addresses issue https://github.com/NVIDIA/makani/issues/94 