### PR TITLE
using log std instead of plain std to parameterize spread

### DIFF
--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -293,20 +293,22 @@ class StochasticMLP(nn.Module):
 
         # First fully connected layer
         if input_format == "nchw":
-            self.fc1_weight_std = nn.Parameter(torch.zeros(hidden_features, in_features, 1, 1))
+            self.fc1_weight_log_std = nn.Parameter(torch.zeros(hidden_features, in_features, 1, 1))
             self.fc1_weight_mean = nn.Parameter(torch.zeros(hidden_features, in_features, 1, 1))
             self.fc1_bias = nn.Parameter(torch.zeros(hidden_features))
         else:
             raise NotImplementedError(f"Error, input format {input_format} not supported.")
 
         # sharing settings
-        self.fc1_weight_std.is_shared_mp = ["spatial"]
+        self.fc1_weight_log_std.is_shared_mp = ["spatial"]
         self.fc1_weight_mean.is_shared_mp = ["spatial"]
         self.fc1_bias.is_shared_mp = ["spatial"]
 
-        # initialize the weights correctly
+        # The stochastic weight is  weight = scale * exp(log_std) * eps + mean  with
+        # eps ~ N(0, 1). log_std keeps its zero init (so the effective std == scale and
+        # is always positive thanks to exp), and the fan-in scale is a constant factor.
         scale = math.sqrt(1.0 / in_features)
-        nn.init.normal_(self.fc1_weight_std, mean=0.0, std=scale)
+        self.fc1_weight_std_scale = scale
         nn.init.normal_(self.fc1_weight_mean, mean=0.0, std=scale)
 
         # activation
@@ -318,21 +320,22 @@ class StochasticMLP(nn.Module):
 
         # output layer
         if input_format == "nchw":
-            self.fc2_weight_std = nn.Parameter(torch.zeros(out_features, hidden_features, 1, 1))
+            self.fc2_weight_log_std = nn.Parameter(torch.zeros(out_features, hidden_features, 1, 1))
             self.fc2_weight_mean = nn.Parameter(torch.zeros(out_features, hidden_features, 1, 1))
             self.fc2_bias = nn.Parameter(torch.zeros(out_features)) if output_bias else None
         else:
             raise NotImplementedError(f"Error, input format {input_format} not supported.")
 
         # sharing settings
-        self.fc2_weight_std.is_shared_mp = ["spatial"]
+        self.fc2_weight_log_std.is_shared_mp = ["spatial"]
         self.fc2_weight_mean.is_shared_mp = ["spatial"]
         if self.fc2_bias is not None:
             self.fc2_bias.is_shared_mp = ["spatial"]
 
         # gain factor for the output determines the scaling of the output init
+        # (same scheme as fc1: log_std stays at its zero init, scale is a constant factor)
         scale = math.sqrt(gain / hidden_features / 2)
-        nn.init.normal_(self.fc2_weight_std, mean=0.0, std=scale)
+        self.fc2_weight_std_scale = scale
         nn.init.normal_(self.fc2_weight_mean, mean=0.0, std=scale)
         if self.fc2_bias is not None:
             nn.init.constant_(self.fc2_bias, 0.0)
@@ -361,10 +364,11 @@ class StochasticMLP(nn.Module):
 
     def fwd(self, x):
 
-        # generate weight1
+        # generate weight1: weight = scale * exp(log_std) * eps + mean
         weight1 = torch.empty_like(self.fc1_weight_mean)
         weight1.normal_(mean=0.0, std=1.0, generator=self.rng_gpu if weight1.is_cuda else self.rng_cpu)
-        weight1 = self.fc1_weight_std * weight1 + self.fc1_weight_mean
+        std1 = self.fc1_weight_std_scale * torch.exp(self.fc1_weight_log_std)
+        weight1 = std1 * weight1 + self.fc1_weight_mean
 
         # fully connected 1
         x = nn.functional.conv2d(x, weight1, bias=self.fc1_bias)
@@ -375,10 +379,11 @@ class StochasticMLP(nn.Module):
         # dropout
         x = self.drop(x)
 
-        # generate weight1
+        # generate weight2: weight = scale * exp(log_std) * eps + mean
         weight2 = torch.empty_like(self.fc2_weight_mean)
         weight2.normal_(mean=0.0, std=1.0, generator=self.rng_gpu if weight2.is_cuda else self.rng_cpu)
-        weight2 = self.fc2_weight_std * weight2 + self.fc2_weight_mean
+        std2 = self.fc2_weight_std_scale * torch.exp(self.fc2_weight_log_std)
+        weight2 = std2 * weight2 + self.fc2_weight_mean
 
         # fully connected 2
         x = nn.functional.conv2d(x, weight2, bias=self.fc2_bias)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -31,6 +31,7 @@ from makani.models.common.layers import (
 )
 from makani.models.common.imputation import MLPImputation, ConstantImputation
 from makani.models.common.pos_embedding import LearnablePositionEmbedding
+from makani.mpu.layers import StochasticMLP
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_tensors
@@ -836,6 +837,89 @@ class TestLearnablePositionEmbedding(unittest.TestCase):
         )
         self.assertEqual(emb.position_embeddings.is_shared_mp, [])
         self.assertEqual(emb.position_embeddings.sharded_dims_mp, [None, None, "h", "w"])
+
+
+class TestStochasticMLP(unittest.TestCase):
+    """Tests for the variational StochasticMLP (mpu/layers.py).
+
+    The stochastic weight is  weight = scale * exp(log_std) * eps + mean,  eps ~ N(0, 1),
+    so the std is parametrized in log space (see issue #98): log_std is initialized to 0
+    (effective std == scale, stable init) and is always positive via exp.
+    """
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def _make(self, in_features=16, hidden_features=32, out_features=16, **kw):
+        return StochasticMLP(
+            in_features=in_features,
+            hidden_features=hidden_features,
+            out_features=out_features,
+            **kw,
+        ).to(self.device)
+
+    def test_output_shape(self):
+        mlp = self._make()
+        x = torch.randn(2, 16, 8, 8, device=self.device)
+        out = mlp(x)
+        self.assertEqual(tuple(out.shape), (2, 16, 8, 8))
+
+    def test_log_std_initialized_to_zero(self):
+        """#98: std is stored in log space and initialized to 0 (so effective std == scale)."""
+        mlp = self._make()
+        self.assertTrue(torch.count_nonzero(mlp.fc1_weight_log_std) == 0)
+        self.assertTrue(torch.count_nonzero(mlp.fc2_weight_log_std) == 0)
+
+    def test_effective_std_positive(self):
+        """exp(log_std) is strictly positive for any log_std value (incl. negative)."""
+        mlp = self._make()
+        with torch.no_grad():
+            mlp.fc1_weight_log_std.uniform_(-5.0, 5.0)
+            mlp.fc2_weight_log_std.uniform_(-5.0, 5.0)
+        std1 = mlp.fc1_weight_std_scale * torch.exp(mlp.fc1_weight_log_std)
+        std2 = mlp.fc2_weight_std_scale * torch.exp(mlp.fc2_weight_log_std)
+        self.assertTrue((std1 > 0).all())
+        self.assertTrue((std2 > 0).all())
+
+    def test_init_does_not_blow_up(self):
+        """Regression for #98: at init the output std must stay O(input std), not be
+        amplified by ~sqrt(fan_in) (which a literal std=1 init would produce)."""
+        in_features = 64
+        mlp = self._make(in_features=in_features, hidden_features=64, out_features=in_features, gain=1.0)
+        x = torch.randn(8, in_features, 16, 16, device=self.device)
+        out = mlp(x)
+        self.assertTrue(torch.isfinite(out).all())
+        self.assertLess(out.std().item(), 5.0, f"init output std too large: {out.std().item()}")
+
+    def test_stochastic_and_reproducible(self):
+        """Successive forwards differ (weights are resampled), and resetting the seeded
+        generators reproduces the exact output."""
+        mlp = self._make(seed=1234)
+        x = torch.randn(2, 16, 8, 8, device=self.device)
+        out1 = mlp(x)
+        out2 = mlp(x)
+        self.assertFalse(torch.allclose(out1, out2), "two forwards were identical (no stochasticity)")
+
+        mlp.set_rng(seed=1234)
+        out1b = mlp(x)
+        self.assertTrue(compare_tensors("stochastic reproducible", out1, out1b, atol=1e-5, rtol=1e-5))
+
+    def test_backward_finite(self):
+        mlp = self._make()
+        x = torch.randn(2, 16, 8, 8, device=self.device, requires_grad=True)
+        mlp(x).sum().backward()
+        for name, p in [
+            ("fc1_weight_mean", mlp.fc1_weight_mean),
+            ("fc1_weight_log_std", mlp.fc1_weight_log_std),
+            ("fc2_weight_mean", mlp.fc2_weight_mean),
+            ("fc2_weight_log_std", mlp.fc2_weight_log_std),
+        ]:
+            self.assertIsNotNone(p.grad, f"{name} has no grad")
+            self.assertTrue(torch.isfinite(p.grad).all(), f"{name} grad not finite")
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(torch.isfinite(x.grad).all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this MR changes stochasticMLP to use log_std parameterization to guarantee non negative spread. 

addresses https://github.com/NVIDIA/makani/issues/98, renders old checkpoints with that layer incompatible.