### PR TITLE
Tkurth/optimizer paramgroup fix

### DIFF
--- a/makani/utils/checkpoint_helpers.py
+++ b/makani/utils/checkpoint_helpers.py
@@ -125,26 +125,44 @@ def gather_optimizer_state_dict(model: nn.Module, optimizer: Optimizer) -> Order
         pdict = {key: value for key, value in pgroup.items()}
         optimizer_dict["param_groups"].append(pdict)
 
-    # check whether the corresponding model paramter is distributed.
-    # if yes, we need to gather it
+    # The integer keys in state_dict["state"] follow torch.optim's own packing order:
+    # parameters are numbered group-by-group, in optimizer.param_groups order (deduplicated).
+    # We reconstruct the index -> param map from optimizer.param_groups so each state entry is
+    # paired with the parameter that actually owns it. This is correct for any number of param
+    # groups, unlike indexing by enumerate(model.parameters()), which only matches when there is
+    # a single group built directly from model.parameters().
     optimizer_dict["state"] = {}
-    for index, param in enumerate(model.parameters()):
-        optimizer_dict["state"][index] = {"step": state_dict["state"][index]["step"].clone()}
-        if hasattr(param, "sharded_dims_mp"):
-            exp_avg = state_dict["state"][index]["exp_avg"].clone()
-            exp_avg_sq = state_dict["state"][index]["exp_avg_sq"].clone()
+    seen = set()
+    index = 0
+    for pgroup in optimizer.param_groups:
+        for param in pgroup["params"]:
+            if id(param) in seen:
+                continue
+            seen.add(id(param))
 
-            # gather the optimizer state across all sharded dimensions
-            for d, group in enumerate(param.sharded_dims_mp):
-                if group is not None:
-                    exp_avg = gather_uneven(exp_avg, d, group)
-                    exp_avg_sq = gather_uneven(exp_avg_sq, d, group)
+            # params without optimizer state (e.g. never received a gradient) carry no state,
+            # but still consume an index so we stay aligned with the packing
+            if index not in state_dict["state"]:
+                index += 1
+                continue
 
-            optimizer_dict["state"][index]["exp_avg"] = exp_avg
-            optimizer_dict["state"][index]["exp_avg_sq"] = exp_avg_sq
-        else:
-            optimizer_dict["state"][index]["exp_avg"] = state_dict["state"][index]["exp_avg"].clone()
-            optimizer_dict["state"][index]["exp_avg_sq"] = state_dict["state"][index]["exp_avg_sq"].clone()
+            pstate = state_dict["state"][index]
+            exp_avg = pstate["exp_avg"].clone()
+            exp_avg_sq = pstate["exp_avg_sq"].clone()
+
+            # if the parameter is sharded, gather its optimizer moments across all sharded dims
+            if hasattr(param, "sharded_dims_mp"):
+                for d, group in enumerate(param.sharded_dims_mp):
+                    if group is not None:
+                        exp_avg = gather_uneven(exp_avg, d, group)
+                        exp_avg_sq = gather_uneven(exp_avg_sq, d, group)
+
+            optimizer_dict["state"][index] = {
+                "step": pstate["step"].clone(),
+                "exp_avg": exp_avg,
+                "exp_avg_sq": exp_avg_sq,
+            }
+            index += 1
 
     return optimizer_dict
 
@@ -159,27 +177,37 @@ def scatter_optimizer_state_dict(model: nn.Module, optimizer: Optimizer, optimiz
     if not (isinstance(optimizer, torch.optim.Adam) or isinstance(optimizer, torch.optim.AdamW)):
         raise NotImplementedError("Error, only Adam and AdamW state can be restored from flexible format at the moment.")
 
-    # iterate over model parameters and split accordingly
-    for idp, param in enumerate(model.parameters()):
+    # Reconstruct the index -> param map from optimizer.param_groups (matching torch.optim's
+    # packing order) so each saved state entry is split with the sharding of its true owner,
+    # for any number of parameter groups. See gather_optimizer_state_dict for details.
+    seen = set()
+    index = 0
+    for pgroup in optimizer.param_groups:
+        for param in pgroup["params"]:
+            if id(param) in seen:
+                continue
+            seen.add(id(param))
 
-        # in this case, we need to distribute the weight
-        if hasattr(param, "sharded_dims_mp"):
+            # in this case, we need to distribute the state
+            if (index in optimizer_state_dict["state"]) and hasattr(param, "sharded_dims_mp"):
 
-            # clone the state
-            exp_avg = optimizer_state_dict["state"][idp]["exp_avg"].clone()
-            exp_avg_sq = optimizer_state_dict["state"][idp]["exp_avg_sq"].clone()
+                # clone the state
+                exp_avg = optimizer_state_dict["state"][index]["exp_avg"].clone()
+                exp_avg_sq = optimizer_state_dict["state"][index]["exp_avg_sq"].clone()
 
-            for d, group in enumerate(param.sharded_dims_mp):
-                # continue if there is nothing to do
-                if (group is None) or (comm.get_size(group) == 1):
-                    continue
+                for d, group in enumerate(param.sharded_dims_mp):
+                    # continue if there is nothing to do
+                    if (group is None) or (comm.get_size(group) == 1):
+                        continue
 
-                exp_avg = split_tensor_along_dim(exp_avg, dim=d, num_chunks=comm.get_size(group))[comm.get_rank(group)]
-                exp_avg_sq = split_tensor_along_dim(exp_avg_sq, dim=d, num_chunks=comm.get_size(group))[comm.get_rank(group)]
+                    exp_avg = split_tensor_along_dim(exp_avg, dim=d, num_chunks=comm.get_size(group))[comm.get_rank(group)]
+                    exp_avg_sq = split_tensor_along_dim(exp_avg_sq, dim=d, num_chunks=comm.get_size(group))[comm.get_rank(group)]
 
-            # update the state dict
-            optimizer_state_dict["state"][idp]["exp_avg"] = exp_avg
-            optimizer_state_dict["state"][idp]["exp_avg_sq"] = exp_avg_sq
+                # update the state dict
+                optimizer_state_dict["state"][index]["exp_avg"] = exp_avg
+                optimizer_state_dict["state"][index]["exp_avg_sq"] = exp_avg_sq
+
+            index += 1
 
     return optimizer_state_dict
 

--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -35,6 +35,7 @@ from makani.utils.YParams import YParams
 from makani.utils.features import get_auxiliary_channels
 from makani.utils import comm
 from makani.utils.dataloaders.data_helpers import get_data_normalization
+from makani.utils.training.training_helpers import get_parameter_groups
 from makani.utils.checkpoint_helpers import (
     gather_model_state_dict,
     scatter_model_state_dict,
@@ -650,19 +651,24 @@ class Driver(metaclass=abc.ABCMeta):
 
         # optimizer setup
         betas = (params.optimizer_beta1, params.optimizer_beta2)
-        all_parameters = model.parameters()
+        # build parameter groups according to the weight-decay mode ("full" decays
+        # everything; "transformer" excludes biases and norm affine params). Each group
+        # carries its own weight_decay, so it is no longer passed at the optimizer level.
+        weight_decay = params.get("weight_decay", 0)
+        weight_decay_mode = params.get("weight_decay_mode", "full")
+        all_parameters = get_parameter_groups(model, weight_decay, weight_decay_mode)
         if params.optimizer_type == "Adam":
             if self.log_to_screen:
-                self.logger.info("using Adam optimizer")
-            optimizer = optim.Adam(all_parameters, lr=params.get("lr", 1e-3), betas=betas, eps=params.get("optimizer_eps", 1e-8), weight_decay=params.get("weight_decay", 0), foreach=True)
+                self.logger.info(f"using Adam optimizer (weight_decay_mode={weight_decay_mode})")
+            optimizer = optim.Adam(all_parameters, lr=params.get("lr", 1e-3), betas=betas, eps=params.get("optimizer_eps", 1e-8), foreach=True)
         elif params.optimizer_type == "AdamW":
             if self.log_to_screen:
-                self.logger.info("using AdamW optimizer")
-            optimizer = optim.AdamW(all_parameters, lr=params.get("lr", 1e-3), betas=betas, eps=params.get("optimizer_eps", 1e-8), weight_decay=params.get("weight_decay", 0), foreach=True)
+                self.logger.info(f"using AdamW optimizer (weight_decay_mode={weight_decay_mode})")
+            optimizer = optim.AdamW(all_parameters, lr=params.get("lr", 1e-3), betas=betas, eps=params.get("optimizer_eps", 1e-8), foreach=True)
         elif params.optimizer_type == "SGD":
             if self.log_to_screen:
-                self.logger.info("using SGD optimizer")
-            optimizer = optim.SGD(all_parameters, lr=params.get("lr", 1e-3), weight_decay=params.get("weight_decay", 0), momentum=params.get("momentum", 0), nesterov=params.get("nesterov", False), foreach=True)
+                self.logger.info(f"using SGD optimizer (weight_decay_mode={weight_decay_mode})")
+            optimizer = optim.SGD(all_parameters, lr=params.get("lr", 1e-3), momentum=params.get("momentum", 0), nesterov=params.get("nesterov", False), foreach=True)
         elif params.optimizer_type == "SIRFShampoo":
             if self.log_to_screen:
                 self.logger.info("using SIRFShampoo optimizer")

--- a/makani/utils/training/training_helpers.py
+++ b/makani/utils/training/training_helpers.py
@@ -19,6 +19,70 @@ import torch.distributed as dist
 from makani.utils import comm
 
 
+# standard torch normalization module base classes whose affine parameters
+# (gain / shift) should be excluded from weight decay
+_NORM_MODULE_TYPES = (
+    nn.LayerNorm,
+    nn.GroupNorm,
+    nn.modules.batchnorm._BatchNorm,
+    nn.modules.instancenorm._InstanceNorm,
+)
+
+
+def _is_norm_module(module: nn.Module) -> bool:
+    """True for standard torch norms and makani's custom normalization layers.
+
+    The class-name fallback catches the custom S2 / distributed norms
+    (GeometricInstanceNormS2, DistributedInstanceNorm2d, DistributedGeometricInstanceNormS2,
+    DistributedLayerNorm) without importing them (which would risk circular imports).
+    """
+    return isinstance(module, _NORM_MODULE_TYPES) or ("norm" in type(module).__name__.lower())
+
+
+def get_parameter_groups(model: nn.Module, weight_decay: float, mode: str = "full") -> list:
+    """Build optimizer parameter groups according to the weight-decay mode.
+
+    - ``"full"``: a single group with ``weight_decay`` applied to every trainable
+      parameter (the historical behavior).
+    - ``"transformer"``: two groups -- ``weight_decay`` on the weight matrices and
+      ``weight_decay = 0`` on biases and normalization-layer affine parameters, the
+      standard modern-transformer convention. Biases are matched by name (robust to
+      expanded ``(1, C, 1, 1)`` bias shapes), norm affine params by their owning
+      module type, plus a 1-D safety net for any stray scale/gain.
+
+    Any other ``mode`` raises ``ValueError``.
+    """
+    trainable = [(name, p) for name, p in model.named_parameters() if p.requires_grad]
+
+    if mode == "full":
+        return [{"params": [p for _, p in trainable], "weight_decay": weight_decay}]
+
+    if mode != "transformer":
+        raise ValueError(f"Unknown weight_decay_mode '{mode}', expected 'full' or 'transformer'.")
+
+    # parameters owned by normalization modules (their affine gain / shift)
+    norm_param_ids = set()
+    for module in model.modules():
+        if _is_norm_module(module):
+            for p in module.parameters(recurse=False):
+                norm_param_ids.add(id(p))
+
+    decay, no_decay = [], []
+    for name, p in trainable:
+        leaf = name.rsplit(".", 1)[-1]
+        if ("bias" in leaf) or (id(p) in norm_param_ids) or (p.ndim < 2):
+            no_decay.append(p)
+        else:
+            decay.append(p)
+
+    groups = []
+    if decay:
+        groups.append({"params": decay, "weight_decay": weight_decay})
+    if no_decay:
+        groups.append({"params": no_decay, "weight_decay": 0.0})
+    return groups
+
+
 def get_memory_usage(device):
     free_mem, total_mem = torch.cuda.mem_get_info(device=device)
     allocated_mem_gb = (total_mem - free_mem) / (1024.0 * 1024.0 * 1024.0)

--- a/tests/distributed/tests_distributed_checkpoint.py
+++ b/tests/distributed/tests_distributed_checkpoint.py
@@ -262,5 +262,76 @@ class TestDistributedCheckpoint(unittest.TestCase):
             self._verify_match(fresh, snapshot, label="flexible-fresh", verbose=verbose)
 
 
+    # ----------------------------------------------------------------------
+    # Optimizer state, flexible format, with MULTIPLE parameter groups.
+    #
+    # torch.optim packs optimizer-state indices group-by-group (in
+    # optimizer.param_groups order), which does NOT match model.parameters()
+    # order once parameters are split across >1 group. gather/scatter of the
+    # optimizer state must therefore pair each state entry with the parameter
+    # that actually owns it. We build the groups in REVERSE order (no-decay/bias
+    # first, then decay/weight) so the packing order differs from model order --
+    # the configuration that exposed the original index-vs-param mismatch. With
+    # the old enumerate(model.parameters()) indexing this even crashes, because
+    # the (h,w)-sharded weight's gather is applied to the 1-D bias state.
+    # ----------------------------------------------------------------------
+    def _build_reordered_param_groups(self, model):
+        decay, no_decay = [], []
+        for p in model.parameters():
+            (decay if p.ndim >= 2 else no_decay).append(p)
+        # no-decay group FIRST -> optimizer packing order != model.parameters() order
+        return [
+            {"params": no_decay, "weight_decay": 0.0},
+            {"params": decay, "weight_decay": 0.1},
+        ]
+
+    def _make_stepped_optimizer(self, model):
+        optimizer = torch.optim.AdamW(self._build_reordered_param_groups(model), lr=1e-3)
+        # populate exp_avg / exp_avg_sq with one deterministic step
+        for p in model.parameters():
+            p.grad = torch.ones_like(p)
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        return optimizer
+
+    def _snapshot_opt_state(self, optimizer):
+        state = optimizer.state_dict()["state"]
+        return {i: {k: v.detach().clone() for k, v in s.items() if torch.is_tensor(v)} for i, s in state.items()}
+
+    def test_flexible_optimizer_state_roundtrip_multigroup(self, verbose=False):
+        ckpt_path = os.path.join(self.tmpdir, "flexible_optstate_mp{mp_rank}_v0.tar")
+
+        model = self._build_model()
+        optimizer = self._make_stepped_optimizer(model)
+        opt_snapshot = self._snapshot_opt_state(optimizer)
+
+        # 1. Save flexible: rank 0 gathers the (sharded) optimizer moments into a global dict.
+        Driver.save_checkpoint(
+            ckpt_path, model, optimizer=optimizer, checkpoint_mode="flexible",
+        )
+        if dist.is_initialized():
+            dist.barrier()
+
+        # 2. Corrupt the live optimizer moments so a no-op restore would be detected.
+        with torch.no_grad():
+            for s in optimizer.state.values():
+                if "exp_avg" in s:
+                    s["exp_avg"].zero_()
+                    s["exp_avg_sq"].zero_()
+
+        # 3. Restore flexible: each rank reads the global file and scatters back to its shard.
+        Driver._restore_checkpoint_flexible(ckpt_path, model, optimizer=optimizer)
+
+        # 4. Per-rank optimizer moments must match the pre-save snapshot bit-for-bit.
+        restored = optimizer.state_dict()["state"]
+        for i, ref in opt_snapshot.items():
+            for k in ("exp_avg", "exp_avg_sq"):
+                with self.subTest(desc=f"opt state[{i}][{k}] rank {self.world_rank}"):
+                    self.assertTrue(
+                        torch.equal(restored[i][k].cpu(), ref[k].cpu()),
+                        msg=f"rank {self.world_rank}: optimizer state[{i}][{k}] mismatch after multigroup restore",
+                    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_training_helpers.py
+++ b/tests/test_training_helpers.py
@@ -17,7 +17,7 @@ import unittest
 import torch
 import torch.nn as nn
 
-from makani.utils.training.training_helpers import clip_grads, _compute_total_grad_norm, normalize_weights
+from makani.utils.training.training_helpers import clip_grads, _compute_total_grad_norm, normalize_weights, get_parameter_groups
 
 import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -206,6 +206,81 @@ class TestNormalizeWeights(unittest.TestCase):
         normalize_weights(model)
         norm = model.p.data.abs().norm().item()
         self.assertAlmostEqual(norm, 1.0, places=4)
+
+
+class _WeirdNorm(nn.Module):
+    """A norm-like module whose gain is 2-D and named 'weight'. Only module-type
+    detection (not the name or ndim rules) can classify its gain as no-decay -- this
+    proves the norm detection works beyond the simple heuristics."""
+
+    def __init__(self, n=4):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(n, n))
+        self.bias = nn.Parameter(torch.zeros(n))
+
+    def forward(self, x):
+        return x
+
+
+class _ParamGroupNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(8, 8)                                   # weight(2D)->decay, bias(1D)->no_decay
+        self.conv = nn.Conv2d(4, 4, 1)                               # weight(4D)->decay, bias(1D)->no_decay
+        self.ln = nn.LayerNorm(8)                                    # weight/bias -> no_decay (module type)
+        self.wnorm = _WeirdNorm(4)                                   # 2D gain -> no_decay only via module type
+        self.expanded_bias = nn.Parameter(torch.zeros(1, 4, 1, 1))   # 4D bias -> no_decay BY NAME
+        self.plain_weight = nn.Parameter(torch.randn(8, 8))          # 2D weight -> decay
+
+    def forward(self, x):
+        return x
+
+
+class TestParameterGroups(unittest.TestCase):
+    def setUp(self):
+        set_seed(0)
+        self.model = _ParamGroupNet()
+        self.wd = 0.1
+
+    def _named(self):
+        return dict(self.model.named_parameters())
+
+    def test_full_mode_is_single_group(self):
+        groups = get_parameter_groups(self.model, self.wd, "full")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["weight_decay"], self.wd)
+        self.assertEqual(len(groups[0]["params"]), sum(1 for _ in self.model.parameters()))
+
+    def test_transformer_mode_splits_norms_and_biases(self):
+        groups = get_parameter_groups(self.model, self.wd, "transformer")
+        self.assertEqual(len(groups), 2)
+
+        decay = next(g for g in groups if g["weight_decay"] == self.wd)
+        no_decay = next(g for g in groups if g["weight_decay"] == 0.0)
+        decay_ids = {id(p) for p in decay["params"]}
+        no_decay_ids = {id(p) for p in no_decay["params"]}
+
+        named = self._named()
+
+        # weight matrices keep weight decay
+        for nm in ("lin.weight", "conv.weight", "plain_weight"):
+            self.assertIn(id(named[nm]), decay_ids, f"{nm} should be in the decay group")
+
+        # biases (incl. the 4-D expanded one) and all norm affine params (incl. the
+        # 2-D weird-norm gain) are excluded from weight decay
+        for nm in ("lin.bias", "conv.bias", "expanded_bias",
+                   "ln.weight", "ln.bias", "wnorm.weight", "wnorm.bias"):
+            self.assertIn(id(named[nm]), no_decay_ids, f"{nm} should be in the no-decay group")
+
+        # partition is exact: every param classified once, no overlap
+        total = sum(1 for _ in self.model.parameters())
+        self.assertEqual(len(decay_ids) + len(no_decay_ids), total)
+        self.assertEqual(decay_ids & no_decay_ids, set())
+
+    def test_unknown_mode_raises(self):
+        for bad in ("selective", "Transformer", "none", ""):
+            with self.assertRaises(ValueError):
+                get_parameter_groups(self.model, self.wd, bad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This MR fixes parameter group support which was broken on restore. It also adds a weight_decay_mode, which can either be "full" (WD on everything) or "transformer", in which cases norm layers and biases are excluded from weight decays. 