### PR TITLE
only render videos on rank 0

### DIFF
--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -784,3 +784,29 @@ class Driver(metaclass=abc.ABCMeta):
             visualizer = None
 
         return visualizer
+
+    def _setup_visualizer(self, out_bias: torch.Tensor, out_scale: torch.Tensor):
+        """Initialize self.visualizer on rank 0; set to None on all other ranks."""
+        if self.world_rank == 0:
+            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
+            if self.visualizer is None:
+                self.logger.info("No channels to visualize, skipping visualization.")
+        else:
+            self.visualizer = None
+
+    def _visualize_step(self, pred_gather: torch.Tensor, targ_gather: torch.Tensor, eval_steps: int, idt: int):
+        """Copy gathered tensors to the visualizer and queue a frame. No-op when self.visualizer is None."""
+        if self.visualizer is None:
+            return
+        if self.visualizer.stream is not None:
+            self.visualizer.stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(self.visualizer.stream):
+                self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
+            self.visualizer.stream.synchronize()
+        else:
+            self.visualizer.prediction_cpu.copy_(pred_gather)
+            self.visualizer.target_cpu.copy_(targ_gather)
+        pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
+        targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
+        self.visualizer.add(f"step{eval_steps}_time{str(idt).zfill(3)}", pred_cpu, targ_cpu)

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -197,15 +197,8 @@ class AutoencoderTrainer(Driver):
 
         self._compile_model(inp_shape)
 
-        # get visualizer: only world-rank 0 renders/logs; other ranks get None.
-        if self.world_rank == 0:
-            out_bias, out_scale = self.train_dataloader.get_output_normalization()
-            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
-
-            if self.visualizer is None:
-                self.logger.info("No channels to visualize, skipping visualization.")
-        else:
-            self.visualizer = None
+        out_bias, out_scale = self.train_dataloader.get_output_normalization()
+        self._setup_visualizer(out_bias, out_scale)
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -637,22 +630,7 @@ class AutoencoderTrainer(Driver):
                             else:
                                 pred_gather = pred[0, ...].clone()
                                 targ_gather = inpt[0, ...].clone()
-                            if self.visualizer is not None:
-                                if self.visualizer.stream is not None:
-                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                    with torch.cuda.stream(self.visualizer.stream):
-                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                    self.visualizer.stream.synchronize()
-                                else:
-                                    self.visualizer.prediction_cpu.copy_(pred_gather)
-                                    self.visualizer.target_cpu.copy_(targ_gather)
-
-                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
-
-                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                                self.visualizer.add(tag, pred_cpu, targ_cpu)
+                            self._visualize_step(pred_gather, targ_gather, eval_steps, idt)
 
                     # log the loss
                     progress_bar.set_postfix({"loss": loss.item()})

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -640,10 +640,10 @@ class AutoencoderTrainer(Driver):
                             if self.visualizer is not None:
                                 if self.visualizer.stream is not None:
                                     self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                with torch.cuda.stream(self.viz_stream):
+                                with torch.cuda.stream(self.visualizer.stream):
                                     self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
                                     self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.viz_stream is not None:
+                                if self.visualizer.stream is not None:
                                     self.visualizer.stream.synchronize()
 
                                 pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -640,11 +640,13 @@ class AutoencoderTrainer(Driver):
                             if self.visualizer is not None:
                                 if self.visualizer.stream is not None:
                                     self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                with torch.cuda.stream(self.visualizer.stream):
-                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.visualizer.stream is not None:
+                                    with torch.cuda.stream(self.visualizer.stream):
+                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
                                     self.visualizer.stream.synchronize()
+                                else:
+                                    self.visualizer.prediction_cpu.copy_(pred_gather)
+                                    self.visualizer.target_cpu.copy_(targ_gather)
 
                                 pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
                                 targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -197,12 +197,15 @@ class AutoencoderTrainer(Driver):
 
         self._compile_model(inp_shape)
 
-        # get visualizer
-        out_bias, out_scale = self.train_dataloader.get_output_normalization()
-        self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
+        # get visualizer: only world-rank 0 renders/logs; other ranks get None.
+        if self.world_rank == 0:
+            out_bias, out_scale = self.train_dataloader.get_output_normalization()
+            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
 
-        if self.visualizer is None:
-            self.logger.info("No channels to visualize, skipping visualization.")
+            if self.visualizer is None:
+                self.logger.info("No channels to visualize, skipping visualization.")
+        else:
+            self.visualizer = None
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -577,7 +580,7 @@ class AutoencoderTrainer(Driver):
         # initialize metrics buffers
         self.metrics.zero_buffers()
 
-        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0) and (self.visualizer is not None)
+        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0)
 
         # we need to distinguish between DDP and no-DDP
         if isinstance(self.model_eval, torch.nn.parallel.DistributedDataParallel):
@@ -634,19 +637,20 @@ class AutoencoderTrainer(Driver):
                             else:
                                 pred_gather = pred[0, ...].clone()
                                 targ_gather = inpt[0, ...].clone()
-                            if self.visualizer.stream is not None:
-                                self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                            with torch.cuda.stream(self.viz_stream):
-                                self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                            if self.viz_stream is not None:
-                                self.visualizer.stream.synchronize()
+                            if self.visualizer is not None:
+                                if self.visualizer.stream is not None:
+                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
+                                with torch.cuda.stream(self.viz_stream):
+                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
+                                if self.viz_stream is not None:
+                                    self.visualizer.stream.synchronize()
 
-                            pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                            targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
+                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
+                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
 
-                            tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                            self.visualizer.add(tag, pred_cpu, targ_cpu)
+                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
+                                self.visualizer.add(tag, pred_cpu, targ_cpu)
 
                     # log the loss
                     progress_bar.set_postfix({"loss": loss.item()})
@@ -666,7 +670,7 @@ class AutoencoderTrainer(Driver):
 
         # finalize plotting
         viz_time = time.perf_counter_ns()
-        if visualize_data:
+        if visualize_data and self.visualizer is not None:
             self.visualizer.finalize()
         viz_time = (time.perf_counter_ns() - viz_time) * 10 ** (-9)
 

--- a/makani/utils/training/deterministic_trainer.py
+++ b/makani/utils/training/deterministic_trainer.py
@@ -223,14 +223,17 @@ class Trainer(Driver):
             self._compile_model(inp_shape)
         self.timers["compile model"] = timer.time
 
-        # visualization wrapper:
-        with Timer() as timer:
-            out_bias, out_scale = self.train_dataloader.get_output_normalization()
-            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
+        # visualization wrapper: only world-rank 0 renders/logs; other ranks get None.
+        if self.world_rank == 0:
+            with Timer() as timer:
+                out_bias, out_scale = self.train_dataloader.get_output_normalization()
+                self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
 
-            if self.visualizer is None:
-                self.logger.info("No channels to visualize, skipping visualization.")
-        self.timers["visualizer init"] = timer.time
+                if self.visualizer is None:
+                    self.logger.info("No channels to visualize, skipping visualization.")
+            self.timers["visualizer init"] = timer.time
+        else:
+            self.visualizer = None
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -591,7 +594,7 @@ class Trainer(Driver):
         # initialize metrics buffers
         self.metrics.zero_buffers()
 
-        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0) and (self.visualizer is not None)
+        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0)
 
         # start the timer
         valid_start = time.time()
@@ -638,19 +641,20 @@ class Trainer(Driver):
                                 pred_gather = self.metrics._gather_input(pred_gather)
                                 targ_gather = self.metrics._gather_input(targ_gather)
 
-                                if self.visualizer.stream is not None:
-                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                with torch.cuda.stream(self.visualizer.stream):
-                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.visualizer.stream is not None:
-                                    self.visualizer.stream.synchronize()
+                                if self.visualizer is not None:
+                                    if self.visualizer.stream is not None:
+                                        self.visualizer.stream.wait_stream(torch.cuda.current_stream())
+                                    with torch.cuda.stream(self.visualizer.stream):
+                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
+                                    if self.visualizer.stream is not None:
+                                        self.visualizer.stream.synchronize()
 
-                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
+                                    pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
+                                    targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
 
-                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                                self.visualizer.add(tag, pred_cpu, targ_cpu)
+                                    tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
+                                    self.visualizer.add(tag, pred_cpu, targ_cpu)
 
                         # log the loss
                         progress_bar.set_postfix({"loss": loss.item()})
@@ -673,7 +677,7 @@ class Trainer(Driver):
 
         # finalize plotting
         viz_time = time.perf_counter_ns()
-        if visualize_data:
+        if visualize_data and self.visualizer is not None:
             self.visualizer.finalize()
         viz_time = (time.perf_counter_ns() - viz_time) * 10 ** (-9)
 

--- a/makani/utils/training/deterministic_trainer.py
+++ b/makani/utils/training/deterministic_trainer.py
@@ -644,11 +644,13 @@ class Trainer(Driver):
                                 if self.visualizer is not None:
                                     if self.visualizer.stream is not None:
                                         self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                    with torch.cuda.stream(self.visualizer.stream):
-                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                    if self.visualizer.stream is not None:
+                                        with torch.cuda.stream(self.visualizer.stream):
+                                            self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                            self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
                                         self.visualizer.stream.synchronize()
+                                    else:
+                                        self.visualizer.prediction_cpu.copy_(pred_gather)
+                                        self.visualizer.target_cpu.copy_(targ_gather)
 
                                     pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
                                     targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/deterministic_trainer.py
+++ b/makani/utils/training/deterministic_trainer.py
@@ -224,16 +224,10 @@ class Trainer(Driver):
         self.timers["compile model"] = timer.time
 
         # visualization wrapper: only world-rank 0 renders/logs; other ranks get None.
-        if self.world_rank == 0:
-            with Timer() as timer:
-                out_bias, out_scale = self.train_dataloader.get_output_normalization()
-                self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
-
-                if self.visualizer is None:
-                    self.logger.info("No channels to visualize, skipping visualization.")
-            self.timers["visualizer init"] = timer.time
-        else:
-            self.visualizer = None
+        with Timer() as timer:
+            out_bias, out_scale = self.train_dataloader.get_output_normalization()
+            self._setup_visualizer(out_bias, out_scale)
+        self.timers["visualizer init"] = timer.time
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -641,22 +635,7 @@ class Trainer(Driver):
                                 pred_gather = self.metrics._gather_input(pred_gather)
                                 targ_gather = self.metrics._gather_input(targ_gather)
 
-                                if self.visualizer is not None:
-                                    if self.visualizer.stream is not None:
-                                        self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                        with torch.cuda.stream(self.visualizer.stream):
-                                            self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                            self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                        self.visualizer.stream.synchronize()
-                                    else:
-                                        self.visualizer.prediction_cpu.copy_(pred_gather)
-                                        self.visualizer.target_cpu.copy_(targ_gather)
-
-                                    pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                                    targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
-
-                                    tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                                    self.visualizer.add(tag, pred_cpu, targ_cpu)
+                                self._visualize_step(pred_gather, targ_gather, eval_steps, idt)
 
                         # log the loss
                         progress_bar.set_postfix({"loss": loss.item()})

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -229,13 +229,16 @@ class EnsembleTrainer(Trainer):
         self.timers["compile model"] = timer.time
 
         # visualization wrapper:
-        with Timer() as timer:
-            out_bias, out_scale = self.train_dataloader.get_output_normalization()
-            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
+        if self.world_rank == 0:
+            with Timer() as timer:
+                out_bias, out_scale = self.train_dataloader.get_output_normalization()
+                self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
 
-            if self.visualizer is None:
-                self.logger.info("No channels to visualize, skipping visualization.")
-        self.timers["visualizer init"] = timer.time
+                if self.visualizer is None:
+                    self.logger.info("No channels to visualize, skipping visualization.")
+            self.timers["visualizer init"] = timer.time
+        else:
+            self.visualizer = None
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -627,7 +630,7 @@ class EnsembleTrainer(Trainer):
         # initialize metrics buffers
         self.metrics.zero_buffers()
 
-        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0) and (self.visualizer is not None)
+        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0)
 
         # start the timer
         valid_start = time.time()
@@ -708,19 +711,20 @@ class EnsembleTrainer(Trainer):
                             pred_gather = self.metrics._gather_input(pred_gather)
                             targ_gather = self.metrics._gather_input(targ_gather)
 
-                            if self.visualizer.stream is not None:
-                                self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                            with torch.cuda.stream(self.visualizer.stream):
-                                self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                            if self.visualizer.stream is not None:
-                                self.visualizer.stream.synchronize()
+                            if self.visualizer is not None:
+                                if self.visualizer.stream is not None:
+                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
+                                with torch.cuda.stream(self.visualizer.stream):
+                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
+                                if self.visualizer.stream is not None:
+                                    self.visualizer.stream.synchronize()
 
-                            pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                            targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
+                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
+                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
 
-                            tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                            self.visualizer.add(tag, pred_cpu, targ_cpu)
+                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
+                                self.visualizer.add(tag, pred_cpu, targ_cpu)
 
                         # update metrics
                         self.metrics.update(pred, targ, loss, idt)
@@ -737,7 +741,7 @@ class EnsembleTrainer(Trainer):
 
         # finalize plotting
         viz_time = time.perf_counter_ns()
-        if visualize_data:
+        if visualize_data and self.visualizer is not None:
             self.visualizer.finalize()
         viz_time = (time.perf_counter_ns() - viz_time) * 10 ** (-9)
 

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -714,11 +714,13 @@ class EnsembleTrainer(Trainer):
                             if self.visualizer is not None:
                                 if self.visualizer.stream is not None:
                                     self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                with torch.cuda.stream(self.visualizer.stream):
-                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.visualizer.stream is not None:
+                                    with torch.cuda.stream(self.visualizer.stream):
+                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
                                     self.visualizer.stream.synchronize()
+                                else:
+                                    self.visualizer.prediction_cpu.copy_(pred_gather)
+                                    self.visualizer.target_cpu.copy_(targ_gather)
 
                                 pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
                                 targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -229,16 +229,10 @@ class EnsembleTrainer(Trainer):
         self.timers["compile model"] = timer.time
 
         # visualization wrapper:
-        if self.world_rank == 0:
-            with Timer() as timer:
-                out_bias, out_scale = self.train_dataloader.get_output_normalization()
-                self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
-
-                if self.visualizer is None:
-                    self.logger.info("No channels to visualize, skipping visualization.")
-            self.timers["visualizer init"] = timer.time
-        else:
-            self.visualizer = None
+        with Timer() as timer:
+            out_bias, out_scale = self.train_dataloader.get_output_normalization()
+            self._setup_visualizer(out_bias, out_scale)
+        self.timers["visualizer init"] = timer.time
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -711,22 +705,7 @@ class EnsembleTrainer(Trainer):
                             pred_gather = self.metrics._gather_input(pred_gather)
                             targ_gather = self.metrics._gather_input(targ_gather)
 
-                            if self.visualizer is not None:
-                                if self.visualizer.stream is not None:
-                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                    with torch.cuda.stream(self.visualizer.stream):
-                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                    self.visualizer.stream.synchronize()
-                                else:
-                                    self.visualizer.prediction_cpu.copy_(pred_gather)
-                                    self.visualizer.target_cpu.copy_(targ_gather)
-
-                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
-
-                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                                self.visualizer.add(tag, pred_cpu, targ_cpu)
+                            self._visualize_step(pred_gather, targ_gather, eval_steps, idt)
 
                         # update metrics
                         self.metrics.update(pred, targ, loss, idt)

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -207,12 +207,15 @@ class StochasticTrainer(Driver):
 
         self._compile_model(inp_shape)
 
-        # visualization wrapper:
-        out_bias, out_scale = self.train_dataloader.get_output_normalization()
-        self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
+        # visualization wrapper: only world-rank 0 renders/logs; other ranks get None.
+        if self.world_rank == 0:
+            out_bias, out_scale = self.train_dataloader.get_output_normalization()
+            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
 
-        if self.visualizer is None:
-            self.logger.info("No channels to visualize, skipping visualization.")
+            if self.visualizer is None:
+                self.logger.info("No channels to visualize, skipping visualization.")
+        else:
+            self.visualizer = None
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -564,7 +567,7 @@ class StochasticTrainer(Driver):
         # initialize metrics buffers
         self.metrics.zero_buffers()
 
-        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0) and (self.visualizer is not None)
+        visualize_data = self.params.log_video and (epoch % self.params.log_video == 0)
 
         # start the timer
         valid_start = time.time()
@@ -637,19 +640,20 @@ class StochasticTrainer(Driver):
                             pred_gather = self.metrics._gather_input(pred_gather)
                             targ_gather = self.metrics._gather_input(targ_gather)
 
-                            if self.visualizer.stream is not None:
-                                self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                            with torch.cuda.stream(self.visualizer.stream):
-                                self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                            if self.viz_stream is not None:
-                                self.visualizer.stream.synchronize()
+                            if self.visualizer is not None:
+                                if self.visualizer.stream is not None:
+                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
+                                with torch.cuda.stream(self.visualizer.stream):
+                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
+                                if self.viz_stream is not None:
+                                    self.visualizer.stream.synchronize()
 
-                            pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                            targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
+                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
+                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
 
-                            tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                            self.visualizer.add(tag, pred_cpu, targ_cpu)
+                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
+                                self.visualizer.add(tag, pred_cpu, targ_cpu)
 
                         # log the loss
                         progress_bar.set_postfix({"loss": loss.item()})
@@ -662,7 +666,7 @@ class StochasticTrainer(Driver):
 
         # finalize plotting
         viz_time = time.perf_counter_ns()
-        if visualize_data:
+        if visualize_data and self.visualizer is not None:
             self.visualizer.finalize()
         viz_time = (time.perf_counter_ns() - viz_time) * 10 ** (-9)
 

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -643,11 +643,13 @@ class StochasticTrainer(Driver):
                             if self.visualizer is not None:
                                 if self.visualizer.stream is not None:
                                     self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                with torch.cuda.stream(self.visualizer.stream):
-                                    self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                    self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.visualizer.stream is not None:
+                                    with torch.cuda.stream(self.visualizer.stream):
+                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
+                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
                                     self.visualizer.stream.synchronize()
+                                else:
+                                    self.visualizer.prediction_cpu.copy_(pred_gather)
+                                    self.visualizer.target_cpu.copy_(targ_gather)
 
                                 pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
                                 targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -646,7 +646,7 @@ class StochasticTrainer(Driver):
                                 with torch.cuda.stream(self.visualizer.stream):
                                     self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
                                     self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                if self.viz_stream is not None:
+                                if self.visualizer.stream is not None:
                                     self.visualizer.stream.synchronize()
 
                                 pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -208,14 +208,8 @@ class StochasticTrainer(Driver):
         self._compile_model(inp_shape)
 
         # visualization wrapper: only world-rank 0 renders/logs; other ranks get None.
-        if self.world_rank == 0:
-            out_bias, out_scale = self.train_dataloader.get_output_normalization()
-            self.visualizer = self.init_visualizer(self.params, self.lat_lon_global, out_bias, out_scale, self.device)
-
-            if self.visualizer is None:
-                self.logger.info("No channels to visualize, skipping visualization.")
-        else:
-            self.visualizer = None
+        out_bias, out_scale = self.train_dataloader.get_output_normalization()
+        self._setup_visualizer(out_bias, out_scale)
 
         # reload checkpoints
         counters = {"iters": 0, "start_epoch": 0}
@@ -640,22 +634,7 @@ class StochasticTrainer(Driver):
                             pred_gather = self.metrics._gather_input(pred_gather)
                             targ_gather = self.metrics._gather_input(targ_gather)
 
-                            if self.visualizer is not None:
-                                if self.visualizer.stream is not None:
-                                    self.visualizer.stream.wait_stream(torch.cuda.current_stream())
-                                    with torch.cuda.stream(self.visualizer.stream):
-                                        self.visualizer.prediction_cpu.copy_(pred_gather, non_blocking=True)
-                                        self.visualizer.target_cpu.copy_(targ_gather, non_blocking=True)
-                                    self.visualizer.stream.synchronize()
-                                else:
-                                    self.visualizer.prediction_cpu.copy_(pred_gather)
-                                    self.visualizer.target_cpu.copy_(targ_gather)
-
-                                pred_cpu = self.visualizer.prediction_cpu.to(torch.float32).numpy()
-                                targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
-
-                                tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                                self.visualizer.add(tag, pred_cpu, targ_cpu)
+                            self._visualize_step(pred_gather, targ_gather, eval_steps, idt)
 
                         # log the loss
                         progress_bar.set_postfix({"loss": loss.item()})


### PR DESCRIPTION
This may be less relevant after the changes in https://github.com/NVIDIA/makani/pull/115, but might still be (slightly) useful if memory-constrained.

Instead of running the visualization on _every_ rank, these changes ensure only world rank 0 runs it. Otherwise, non-0 ranks would also render the videos and try to save them to disk in the same location (wandb logging is guarded to be rank 0 only).