### PR TITLE
draw progress bar on rollout videos

### DIFF
--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -720,7 +720,7 @@ class EnsembleTrainer(Trainer):
                             targ_cpu = self.visualizer.target_cpu.to(torch.float32).numpy()
 
                             tag = f"step{eval_steps}_time{str(idt).zfill(3)}"
-                            self.visualizer.add(tag, pred_cpu, targ_cpu)
+                            self.visualizer.add(tag, pred_cpu, targ_cpu, progress=idt / max(len(tarlist) - 1, 1))
 
                         # update metrics
                         self.metrics.update(pred, targ, loss, idt)

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -19,7 +19,7 @@ import re
 import multiprocessing as mp
 import numpy as np
 import concurrent.futures as cf
-from PIL import Image
+from PIL import Image, ImageDraw
 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 import wandb
 
@@ -198,7 +198,22 @@ def plot_rollout_metrics(metric_curves, var_names, score_path=None, file_prefix=
             fig.savefig(os.path.join(score_path, file_prefix + "_" + var_name + ".png"))
 
 
-def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias, diverging):
+def _draw_progress_bar(image, progress: float):
+    """Overlay a horizontal progress bar on the seam between the pred/truth subplots."""
+    w, h = image.size
+    margin = 20
+    x0, x1 = margin, w - margin
+    y_mid = h // 2
+    y0, y1 = y_mid - 3, y_mid + 3
+    fill_x = int(x0 + progress * (x1 - x0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([x0, y0, x1, y1], fill=(225, 225, 225))
+    if fill_x > x0:
+        draw.rectangle([x0, y0, fill_x, y1], fill=(40, 40, 40))
+    return image
+
+
+def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias, diverging, progress: float | None = None):
     torch.cuda.nvtx.range_push("visualize_field")
 
     # get func handle:
@@ -214,6 +229,9 @@ def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias,
 
     # generate image
     image = plot_comparison(pred, targ, lat, lon, pred_title="Prediction", truth_title="Ground truth", projection="mollweide", diverging=diverging)
+
+    if progress is not None:
+        image = _draw_progress_bar(image, progress)
 
     torch.cuda.nvtx.range_pop()
 
@@ -259,7 +277,7 @@ class VisualizationWrapper(object):
     def reset(self):
         self.requests = []
 
-    def add(self, tag, prediction, target):
+    def add(self, tag, prediction, target, progress: float | None = None):
         if self.channel_indices is not None:
             pred = prediction[self.channel_indices].copy()
             tar = target[self.channel_indices].copy()
@@ -272,7 +290,7 @@ class VisualizationWrapper(object):
             func_string = item["functor"]
             plot_diverge = item["diverging"]
             self.requests.append(
-                self.executor.submit(visualize_field, (tag, field_name), func_string, pred, tar, self.lat, self.lon, self.scale, self.bias, plot_diverge)
+                self.executor.submit(visualize_field, (tag, field_name), func_string, pred, tar, self.lat, self.lon, self.scale, self.bias, plot_diverge, progress=progress)
             )
 
         return

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -16,6 +16,7 @@
 import os
 import io
 import re
+from typing import Optional
 import multiprocessing as mp
 import numpy as np
 import concurrent.futures as cf
@@ -213,7 +214,7 @@ def _draw_progress_bar(image, progress: float):
     return image
 
 
-def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias, diverging, progress: float | None = None):
+def visualize_field(tag, func_string, prediction, target, lat, lon, scale, bias, diverging, progress: Optional[float] = None):
     torch.cuda.nvtx.range_push("visualize_field")
 
     # get func handle:
@@ -277,7 +278,7 @@ class VisualizationWrapper(object):
     def reset(self):
         self.requests = []
 
-    def add(self, tag, prediction, target, progress: float | None = None):
+    def add(self, tag, prediction, target, progress: Optional[float] = None):
         if self.channel_indices is not None:
             pred = prediction[self.channel_indices].copy()
             tar = target[self.channel_indices].copy()

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -165,7 +165,9 @@ def plot_comparison(
     fig.savefig(buf)
     buf.seek(0)
 
-    return Image.open(buf)
+    img = Image.open(buf)
+    img.load()
+    return img
 
 
 def plot_rollout_metrics(metric_curves, var_names, score_path=None, file_prefix="curve", dtxdh=6):

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -199,14 +199,24 @@ def plot_rollout_metrics(metric_curves, var_names, score_path=None, file_prefix=
             fig.savefig(os.path.join(score_path, file_prefix + "_" + var_name + ".png"))
 
 
-def _draw_progress_bar(image, progress: float):
+def _draw_progress_bar(image, progress: float, y_pos: float = 0.5, margin: int = 20, thickness: int = 6):
     """Overlay a horizontal progress bar on the seam between the pred/truth subplots."""
     w, h = image.size
-    margin = 20
+
+    y_pos = min(max(y_pos, 0.0), 1.0)
+    progress = min(max(progress, 0.0), 1.0)
+    margin = min(max(margin, 0), w // 2 - 1)
+    thickness = max(thickness, 1)
+
+    dy_neg = thickness // 2
+    dy_pos = thickness - dy_neg
+
+    y_mid = min(max(int(y_pos * h), dy_neg), h - dy_pos)
+
     x0, x1 = margin, w - margin
-    y_mid = h // 2
-    y0, y1 = y_mid - 3, y_mid + 3
+    y0, y1 = y_mid - dy_neg, y_mid + dy_pos
     fill_x = int(x0 + progress * (x1 - x0))
+
     draw = ImageDraw.Draw(image)
     draw.rectangle([x0, y0, x1, y1], fill=(225, 225, 225))
     if fill_x > x0:


### PR DESCRIPTION
Optionally draw a progress bar in the middle of the rollout visualization image. A bit hacky & hardcoded – assumes the middle of the image is where the progress bar should be, and draws it on top of the already rendered image with `ImageDraw`.

A better version would probably hook into MPL and render a progress bar in relation to where (some of) the axes are.

Feel free to close the PR if too hacky. :-)