### PR TITLE
Tkurth/te support

### DIFF
--- a/makani/ensemble.py
+++ b/makani/ensemble.py
@@ -46,15 +46,14 @@ if __name__ == "__main__":
 
     # distributed
     params["ensemble_parallel_size"] = args.ensemble_parallel_size
-    params["fin_parallel_size"] = args.fin_parallel_size
-    params["fout_parallel_size"] = args.fout_parallel_size
+    params["matmul_parallel_size"] = args.matmul_parallel_size
     params["h_parallel_size"] = args.h_parallel_size
     params["w_parallel_size"] = args.w_parallel_size
 
     params["data_parallel_sizes"] = [args.ensemble_parallel_size, -1]
     params["data_parallel_names"] = ["ensemble", "batch"]
-    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.fin_parallel_size, args.fout_parallel_size]
-    params["model_parallel_names"] = ["h", "w", "fin", "fout"]
+    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.matmul_parallel_size]
+    params["model_parallel_names"] = ["h", "w", "matmul"]
     params["parameters_reduction_buffer_count"] = args.parameters_reduction_buffer_count
 
     # checkpoint format

--- a/makani/inference.py
+++ b/makani/inference.py
@@ -76,15 +76,14 @@ if __name__ == "__main__":
 
     # distributed
     params["ensemble_parallel_size"] = args.ensemble_parallel_size
-    params["fin_parallel_size"] = args.fin_parallel_size
-    params["fout_parallel_size"] = args.fout_parallel_size
+    params["matmul_parallel_size"] = args.matmul_parallel_size
     params["h_parallel_size"] = args.h_parallel_size
     params["w_parallel_size"] = args.w_parallel_size
 
     params["data_parallel_sizes"] = [args.ensemble_parallel_size, -1]
     params["data_parallel_names"] = ["ensemble", "batch"]
-    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.fin_parallel_size, args.fout_parallel_size]
-    params["model_parallel_names"] = ["h", "w", "fin", "fout"]
+    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.matmul_parallel_size]
+    params["model_parallel_names"] = ["h", "w", "matmul"]
 
     # checkpoint format
     params["load_checkpoint"] = args.load_checkpoint

--- a/makani/models/common/layers.py
+++ b/makani/models/common/layers.py
@@ -22,14 +22,9 @@ import warnings
 from makani.utils.context import rng_context
 
 # transformer engine is an optional dependency: it is only used for the
-# (optional) FP8/FP4 MLP path and must not be required for import.
-try:
-    import transformer_engine.pytorch as te
-
-    _TE_AVAILABLE = True
-except ImportError:
-    te = None
-    _TE_AVAILABLE = False
+# (optional) FP8/FP4 MLP path and must not be required for import. availability is
+# checked without importing it; the module is imported lazily where used.
+from makani.utils.te_helpers import TE_AVAILABLE as _TE_AVAILABLE, get_te
 
 
 @torch.compile(fullgraph=False)
@@ -389,6 +384,7 @@ class MLP(nn.Module):
         # transformer engine linears operate on the last (channel) dimension; for
         # nchw inputs we transpose to channels-last around the GEMMs (see forward).
         if self.use_te:
+            te = get_te()
             fc1 = te.Linear(in_features, hidden_features, bias=True)
             fc2 = te.Linear(hidden_features, out_features, bias=output_bias)
         elif input_format == "nchw":

--- a/makani/models/common/layers.py
+++ b/makani/models/common/layers.py
@@ -430,24 +430,39 @@ class MLP(nn.Module):
 
         if self.use_te:
             # keep the modules separate so forward can insert the channels-last
-            # transposes; dropout stays in nchw layout so "features" dropout keeps
-            # dropping channels (dim=1) as in the standard path.
+            # transposes around the te GEMMs.
             self.fc1 = fc1
             self.fc2 = fc2
             self.act = act
             self.drop = drop
+            # Dropout2d ("features") drops whole channels at dim=1, so it needs the
+            # nchw layout and forces a bounce back from channels-last around each
+            # dropout. Plain Dropout ("iid") and Identity are elementwise/no-ops, so
+            # for them we can stay channels-last across the whole MLP and pay only
+            # one permute in + one out.
+            self.inner_transpose = isinstance(drop, nn.Dropout2d)
         else:
             # create forward pass
             self.fwd = nn.Sequential(fc1, act, drop, fc2, drop)
 
     def _te_forward(self, x):
         if self.input_format == "nchw":
-            # nchw -> nhwc for the te GEMM, back to nchw for (channel) dropout
-            x = self.fc1(x.permute(0, 2, 3, 1).contiguous())
-            x = self.act(x)
-            x = self.drop(x.permute(0, 3, 1, 2).contiguous())
-            x = self.fc2(x.permute(0, 2, 3, 1).contiguous())
-            x = self.drop(x.permute(0, 3, 1, 2).contiguous())
+            # permute nchw -> nhwc once for the te GEMMs; act/iid-dropout are
+            # elementwise so they run channels-last too. Only feature dropout
+            # (Dropout2d) needs nchw to drop channels at dim=1, so the inner
+            # transposes around the first dropout are guarded by inner_transpose.
+            x = x.permute(0, 2, 3, 1).contiguous()
+            x = self.act(self.fc1(x))
+            if self.inner_transpose:
+                x = x.permute(0, 3, 1, 2).contiguous()
+            x = self.drop(x)
+            if self.inner_transpose:
+                x = x.permute(0, 2, 3, 1).contiguous()
+            x = self.fc2(x)
+            # final permute back to nchw is unconditional: it is the last op, and
+            # dropping in nchw is correct for both feature and iid/no dropout.
+            x = x.permute(0, 3, 1, 2).contiguous()
+            x = self.drop(x)
         else:
             # traditional format already has the channels in the last dimension
             x = self.drop(self.act(self.fc1(x)))

--- a/makani/models/common/layers.py
+++ b/makani/models/common/layers.py
@@ -17,8 +17,19 @@ import torch
 import torch.nn as nn
 from torch.utils.checkpoint import checkpoint
 import math
+import warnings
 
 from makani.utils.context import rng_context
+
+# transformer engine is an optional dependency: it is only used for the
+# (optional) FP8/FP4 MLP path and must not be required for import.
+try:
+    import transformer_engine.pytorch as te
+
+    _TE_AVAILABLE = True
+except ImportError:
+    te = None
+    _TE_AVAILABLE = False
 
 
 @torch.compile(fullgraph=False)
@@ -357,55 +368,59 @@ class MLP(nn.Module):
         drop_type="iid",
         checkpointing=False,
         gain=1.0,
+        use_te=False,
         **kwargs,
     ):
         super(MLP, self).__init__()
         self.checkpointing = checkpointing
+        self.input_format = input_format
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
 
-        # First fully connected layer
-        if input_format == "nchw":
-            fc1 = nn.Conv2d(in_features, hidden_features, 1, bias=True)
-        elif input_format == "traditional":
-            fc1 = nn.Linear(in_features, hidden_features, bias=True)
-        else:
-            raise NotImplementedError(f"Error, input format {input_format} not supported.")
-
-        # sharing settings
-        fc1.weight.is_shared_mp = ["spatial"]
-        fc1.bias.is_shared_mp = ["spatial"]
-
-        # initialize the weights correctly
-        scale = math.sqrt(2.0 / in_features)
-        nn.init.normal_(fc1.weight, mean=0.0, std=scale)
-        nn.init.constant_(fc1.bias, 0.0)
-
-        # activation
-        act = act_layer()
+        # only use transformer engine if it was requested and is actually available
+        self.use_te = use_te and _TE_AVAILABLE
+        if use_te and not _TE_AVAILABLE:
+            warnings.warn("use_te=True was requested but transformer_engine is not installed; falling back to the standard MLP.")
 
         # sanity checks
         if (input_format == "traditional") and (drop_type == "features"):
             raise NotImplementedError(f"Error, traditional input format and feature dropout cannot be selected simultaneously")
 
-        # output layer
-        if input_format == "nchw":
+        # transformer engine linears operate on the last (channel) dimension; for
+        # nchw inputs we transpose to channels-last around the GEMMs (see forward).
+        if self.use_te:
+            fc1 = te.Linear(in_features, hidden_features, bias=True)
+            fc2 = te.Linear(hidden_features, out_features, bias=output_bias)
+        elif input_format == "nchw":
+            fc1 = nn.Conv2d(in_features, hidden_features, 1, bias=True)
             fc2 = nn.Conv2d(hidden_features, out_features, 1, bias=output_bias)
         elif input_format == "traditional":
+            fc1 = nn.Linear(in_features, hidden_features, bias=True)
             fc2 = nn.Linear(hidden_features, out_features, bias=output_bias)
         else:
             raise NotImplementedError(f"Error, input format {input_format} not supported.")
 
-        # sharing settings
+        # sharing settings: weights/biases are replicated across the spatial model
+        # group, so the gradient reduction hook sums them over "spatial". This must
+        # be stamped on every parameter (including te.Linear ones, which otherwise
+        # arrive unannotated) for the comm hook to reduce them correctly.
+        fc1.weight.is_shared_mp = ["spatial"]
+        fc1.bias.is_shared_mp = ["spatial"]
         fc2.weight.is_shared_mp = ["spatial"]
         if fc2.bias is not None:
             fc2.bias.is_shared_mp = ["spatial"]
 
+        # initialize the weights correctly (identical to the standard path so that
+        # toggling use_te does not change initialization)
+        nn.init.normal_(fc1.weight, mean=0.0, std=math.sqrt(2.0 / in_features))
+        nn.init.constant_(fc1.bias, 0.0)
         # gain factor for the output determines the scaling of the output init
-        scale = math.sqrt(gain / hidden_features)
-        nn.init.normal_(fc2.weight, mean=0.0, std=scale)
+        nn.init.normal_(fc2.weight, mean=0.0, std=math.sqrt(gain / hidden_features))
         if fc2.bias is not None:
             nn.init.constant_(fc2.bias, 0.0)
+
+        # activation
+        act = act_layer()
 
         if drop_rate > 0.0:
             if drop_type == "iid":
@@ -417,16 +432,42 @@ class MLP(nn.Module):
         else:
             drop = nn.Identity()
 
-        # create forward pass
-        self.fwd = nn.Sequential(fc1, act, drop, fc2, drop)
+        if self.use_te:
+            # keep the modules separate so forward can insert the channels-last
+            # transposes; dropout stays in nchw layout so "features" dropout keeps
+            # dropping channels (dim=1) as in the standard path.
+            self.fc1 = fc1
+            self.fc2 = fc2
+            self.act = act
+            self.drop = drop
+        else:
+            # create forward pass
+            self.fwd = nn.Sequential(fc1, act, drop, fc2, drop)
+
+    def _te_forward(self, x):
+        if self.input_format == "nchw":
+            # nchw -> nhwc for the te GEMM, back to nchw for (channel) dropout
+            x = self.fc1(x.permute(0, 2, 3, 1).contiguous())
+            x = self.act(x)
+            x = self.drop(x.permute(0, 3, 1, 2).contiguous())
+            x = self.fc2(x.permute(0, 2, 3, 1).contiguous())
+            x = self.drop(x.permute(0, 3, 1, 2).contiguous())
+        else:
+            # traditional format already has the channels in the last dimension
+            x = self.drop(self.act(self.fc1(x)))
+            x = self.drop(self.fc2(x))
+        return x
 
     @torch.compiler.disable(recursive=False)
     def checkpoint_forward(self, x):
-        return checkpoint(self.fwd, x, use_reentrant=False)
+        fwd = self._te_forward if self.use_te else self.fwd
+        return checkpoint(fwd, x, use_reentrant=False)
 
     def forward(self, x):
         if self.checkpointing:
             return self.checkpoint_forward(x)
+        elif self.use_te:
+            return self._te_forward(x)
         else:
             return self.fwd(x)
 

--- a/makani/models/networks/sfnonet.py
+++ b/makani/models/networks/sfnonet.py
@@ -30,7 +30,6 @@ from makani.models.common import SpectralConv, SpectralAttention
 # get spectral transforms from torch_harmonics
 import torch_harmonics as th
 import torch_harmonics.distributed as thd
-from torch_harmonics.distributed import compute_split_shapes
 
 # wrap fft, to unify interface to spectral transforms
 from makani.models.common import RealFFT2, InverseRealFFT2, GeometricInstanceNormS2
@@ -41,7 +40,6 @@ from makani.mpu.layers import DistributedMLP, DistributedEncoderDecoder
 from makani.utils import comm
 
 # layer normalization
-from makani.mpu.mappings import scatter_to_parallel_region, gather_from_parallel_region
 from makani.mpu.layer_norm import DistributedInstanceNorm2d, DistributedLayerNorm, DistributedGeometricInstanceNormS2
 
 # for annotation of models
@@ -121,8 +119,7 @@ class NeuralOperatorBlock(nn.Module):
         inner_skip="linear",
         outer_skip=None,
         use_mlp=False,
-        comm_feature_inp_name=None,
-        comm_feature_hidden_name=None,
+        comm_feature_name="matmul",
         complex_activation="real",
         spectral_layers=1,
         bias=False,
@@ -207,8 +204,7 @@ class NeuralOperatorBlock(nn.Module):
                 act_layer=act_layer,
                 drop_rate=mlp_drop_rate,
                 drop_type="features",
-                comm_inp_name=comm_feature_inp_name,
-                comm_hidden_name=comm_feature_hidden_name,
+                comm_name=comm_feature_name,
                 checkpointing=(checkpointing_level>=2),
                 gain=gain_factor,
             )
@@ -327,11 +323,8 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
                 hidden_dim=int(encoder_ratio * self.embed_dim),
                 act_layer=activation_function,
                 input_format="nchw",
-                comm_inp_name="fin",
-                comm_out_name="fout",
+                comm_name="matmul",
             )
-            fblock_mlp_inp_name = self.encoder.comm_out_name
-            fblock_mlp_hidden_name = "fout" if (self.encoder.comm_out_name == "fin") else "fin"
         else:
             self.encoder = EncoderDecoder(
                 num_layers=encoder_layers,
@@ -341,8 +334,6 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
                 act_layer=activation_function,
                 input_format="nchw",
             )
-            fblock_mlp_inp_name = "fin"
-            fblock_mlp_hidden_name = "fout"
 
         # dropout
         self.pos_drop = nn.Dropout(p=pos_drop_rate) if pos_drop_rate > 0.0 else nn.Identity()
@@ -423,8 +414,7 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
                 inner_skip=inner_skip,
                 outer_skip=outer_skip,
                 use_mlp=use_mlp,
-                comm_feature_inp_name=fblock_mlp_inp_name,
-                comm_feature_hidden_name=fblock_mlp_hidden_name,
+                comm_feature_name="matmul",
                 rank=rank,
                 separable=separable,
                 complex_activation=complex_activation,
@@ -437,8 +427,6 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
 
         # decoder takes the output of FNO blocks and the residual from the big skip connection
         if comm.get_size("matmul") > 1:
-            comm_inp_name = fblock_mlp_inp_name
-            comm_out_name = fblock_mlp_hidden_name
             self.decoder = DistributedEncoderDecoder(
                 num_layers=encoder_layers,
                 input_dim=embed_dim,
@@ -446,11 +434,9 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
                 hidden_dim=int(decoder_ratio * embed_dim),
                 act_layer=activation_function,
                 gain=0.5 if self.big_skip else 1.0,
-                comm_inp_name=comm_inp_name,
-                comm_out_name=comm_out_name,
+                comm_name="matmul",
                 input_format="nchw",
             )
-            self.gather_shapes = compute_split_shapes(self.out_chans, comm.get_size(self.decoder.comm_out_name))
 
         else:
             self.decoder = EncoderDecoder(
@@ -603,8 +589,8 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
                 # only take the predicted channels
                 residual = x
 
-        if comm.get_size("fin") > 1:
-            x = scatter_to_parallel_region(x, 1, "fin")
+        # the column/row fork-join encoder consumes replicated (full-channel) input,
+        # so no channel scatter is needed at the model boundary
 
         if self.checkpointing_level >= 1:
             x = checkpoint(self.encoder, x, use_reentrant=False)
@@ -633,8 +619,8 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
         else:
             x = self.decoder(x)
 
-        if hasattr(self.decoder, "comm_out_name") and (comm.get_size(self.decoder.comm_out_name) > 1):
-            x = gather_from_parallel_region(x, 1, self.gather_shapes, self.decoder.comm_out_name)
+        # the row-parallel decoder all-reduces to a replicated (full-channel)
+        # output, so no channel gather is needed at the model boundary
 
         if self.big_skip:
             x = x + self.residual_transform(residual)

--- a/makani/models/networks/vit.py
+++ b/makani/models/networks/vit.py
@@ -82,17 +82,15 @@ class Block(nn.Module):
         path_drop_rate=0.0,
         act_layer=nn.GELU,
         norm_layer=nn.LayerNorm,
-        comm_inp_name="fin",
-        comm_hidden_name="fout",
+        comm_name="matmul",
     ):
         super().__init__()
 
-        if (comm.get_size(comm_inp_name) * comm.get_size(comm_hidden_name)) > 1:
+        if comm.get_size(comm_name) > 1:
             self.attn = DistributedAttention(
                 dim,
                 input_format="traditional",
-                comm_inp_name=comm_inp_name,
-                comm_hidden_name=comm_hidden_name,
+                comm_name=comm_name,
                 num_heads=num_heads,
                 qkv_bias=qkv_bias,
                 attn_drop_rate=attn_drop_rate,
@@ -111,7 +109,7 @@ class Block(nn.Module):
         mlp_hidden_dim = int(dim * mlp_ratio)
 
         # distribute MLP for model parallelism
-        if (comm.get_size(comm_inp_name) * comm.get_size(comm_hidden_name)) > 1:
+        if comm.get_size(comm_name) > 1:
             self.mlp = DistributedMLP(
                 in_features=dim,
                 hidden_features=mlp_hidden_dim,
@@ -119,8 +117,7 @@ class Block(nn.Module):
                 act_layer=act_layer,
                 drop_rate=mlp_drop_rate,
                 input_format="traditional",
-                comm_inp_name=comm_inp_name,
-                comm_hidden_name=comm_hidden_name,
+                comm_name=comm_name,
             )
         else:
             self.mlp = MLP(in_features=dim, hidden_features=mlp_hidden_dim, out_features=dim, act_layer=act_layer, drop_rate=mlp_drop_rate, input_format="traditional")
@@ -149,8 +146,7 @@ class VisionTransformer(nn.Module):
         attn_drop_rate=0.0,
         path_drop_rate=0.0,
         norm_layer="layer_norm",
-        comm_inp_name="fin",
-        comm_hidden_name="fout",
+        comm_name="matmul",
         **kwargs,
     ):
         super().__init__()
@@ -158,8 +154,7 @@ class VisionTransformer(nn.Module):
         self.patch_size = patch_size
         self.img_size = inp_shape
         self.out_ch = out_chans
-        self.comm_inp_name = comm_inp_name
-        self.comm_hidden_name = comm_hidden_name
+        self.comm_name = comm_name
 
         self.patch_embed = PatchEmbed2D(img_size=self.img_size, patch_size=patch_size, in_chans=inp_chans, embed_dim=self.embed_dim)
         num_patches = self.patch_embed.num_patches
@@ -188,8 +183,7 @@ class VisionTransformer(nn.Module):
                     attn_drop_rate=attn_drop_rate,
                     path_drop_rate=dpr[i],
                     norm_layer=norm_layer_handle,
-                    comm_inp_name=comm_inp_name,
-                    comm_hidden_name=comm_hidden_name,
+                    comm_name=comm_name,
                 )
                 for i in range(depth)
             ]

--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -27,14 +27,9 @@ from makani.mpu.mappings import gather_from_parallel_region
 from makani.mpu.mappings import copy_to_parallel_region
 
 # transformer engine is an optional dependency: it is only used for the
-# (optional) FP8/FP4 path and must not be required for import.
-try:
-    import transformer_engine.pytorch as te
-
-    _TE_AVAILABLE = True
-except ImportError:
-    te = None
-    _TE_AVAILABLE = False
+# (optional) FP8/FP4 path and must not be required for import. availability is
+# checked without importing it; the module is imported lazily where used.
+from makani.utils.te_helpers import TE_AVAILABLE as _TE_AVAILABLE, get_te
 
 
 class DistributedMatmul(nn.Module):
@@ -101,6 +96,7 @@ class DistributedMatmul(nn.Module):
         # always owned here (te.Linear bias=False) so the row-parallel bias can be
         # added AFTER the all-reduce, matching the native path.
         if self.use_te:
+            te = get_te()
             self.te_linear = te.Linear(inp_dim_local, out_dim_local, bias=False)
             # te weight is always 2D (out_local, in_local) regardless of input_format
             self.weight.is_shared_mp = ["spatial"]

--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -131,10 +131,16 @@ class DistributedMatmul(nn.Module):
     @property
     def weight(self):
         # te.Linear owns the weight in the TE path; expose it through the same
-        # attribute so external init / annotation / the gradient hook are uniform
+        # attribute so external init / annotation / the gradient hook are uniform.
+        # raise AttributeError (not KeyError) when the native weight is not yet
+        # registered: register_parameter() probes hasattr(self, "weight") while
+        # registering, and hasattr only swallows AttributeError.
         if self.use_te:
             return self.te_linear.weight
-        return self._parameters["weight"]
+        weight = self._parameters.get("weight")
+        if weight is None:
+            raise AttributeError("weight")
+        return weight
 
     def _local_matmul(self, x):
         if self.use_te:

--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -17,142 +17,180 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.distributed as dist
 from torch.utils.checkpoint import checkpoint
 from makani.utils import comm
 
 # parallel helpers
 from torch_harmonics.distributed import compute_split_shapes
-from makani.mpu._amp_utils import _custom_setup_context
 from makani.mpu.mappings import reduce_from_parallel_region
 from makani.mpu.mappings import gather_from_parallel_region
 from makani.mpu.mappings import copy_to_parallel_region
 
+# transformer engine is an optional dependency: it is only used for the
+# (optional) FP8/FP4 path and must not be required for import.
+try:
+    import transformer_engine.pytorch as te
 
-class _DistMatmulHelper(torch.autograd.Function):
-    @staticmethod
-    @torch.amp.custom_fwd(device_type="cuda")
-    def forward(X, weight, bias, inp_group_name, out_group_name):
-        # matrix multiplication
-        xconv = F.conv2d(X, weight, bias=None)
-
-        # reduce
-        if comm.get_size(inp_group_name) > 1:
-            dist.all_reduce(xconv, group=comm.get_group(inp_group_name))
-
-        # add bias
-        if bias is not None:
-            xconvbias = xconv + bias
-        else:
-            xconvbias = xconv
-
-        return xconvbias
-
-    @staticmethod
-    @_custom_setup_context(device_type="cuda")
-    def setup_context(ctx, inputs, output):
-        X, weight, bias, inp_group_name, out_group_name = inputs
-        ctx.save_for_backward(X, weight, bias)
-        ctx.out_group_name = out_group_name
-
-    @staticmethod
-    @torch.amp.custom_bwd(device_type="cuda")
-    def backward(ctx, grad_out):
-        X, weight, bias = ctx.saved_tensors
-        gname = ctx.out_group_name
-
-        # do the bwd pass on dgrad
-        grad_input = F.conv_transpose2d(grad_out, weight, bias=None)
-
-        # reduce across nodes
-        if comm.get_size(gname) > 1:
-            dgrad_handle = dist.all_reduce(grad_input, group=comm.get_group(gname), async_op=True)
-
-        # weight grad
-        grad_weight = F.conv2d(X.transpose(0, 1), grad_out.transpose(0, 1), bias=None).transpose(0, 1)
-
-        if bias is not None:
-            grad_bias = torch.sum(grad_out, dim=(0, 2, 3), keepdim=True)
-        else:
-            grad_bias = None
-
-        if comm.get_size(gname) > 1:
-            dgrad_handle.wait()
-
-        return grad_input, grad_weight, grad_bias, None, None
+    _TE_AVAILABLE = True
+except ImportError:
+    te = None
+    _TE_AVAILABLE = False
 
 
 class DistributedMatmul(nn.Module):
-    def __init__(self, inp_dim, out_dim, input_format="nchw", comm_inp_name="fin", comm_out_name="fout", bias=True):
+    """Megatron-style tensor-parallel matmul over a single feature-parallel group.
+
+    The legacy 2D (fin x fout) decomposition has been retired in favor of a 1D
+    column/row fork-join over a single comm group (``comm_name``, "matmul" by
+    default):
+
+    - ``parallel_mode="column"`` shards the OUTPUT dimension. The input is
+      replicated across the group (``copy_to_parallel_region``: identity in the
+      forward, all-reduce in the backward) and there is NO output reduction, so
+      the result is sharded along the output dimension.
+    - ``parallel_mode="row"`` shards the INPUT dimension. The input is assumed to
+      be sharded (e.g. the sharded hidden produced by a preceding column layer),
+      and the partial outputs are all-reduced (``reduce_from_parallel_region``)
+      into a replicated full output. For a row layer the bias is replicated and
+      added AFTER the reduction.
+    """
+
+    def __init__(self, inp_dim, out_dim, input_format="nchw", comm_name="matmul", parallel_mode="column", bias=True, use_te=False):
         super(DistributedMatmul, self).__init__()
 
-        # get sizes
-        self.comm_inp_name = comm_inp_name
-        self.comm_out_name = comm_out_name
-        comm_inp_size = comm.get_size(self.comm_inp_name)
-        comm_out_size = comm.get_size(self.comm_out_name)
+        if parallel_mode not in ["column", "row"]:
+            raise ValueError(f"Error, parallel_mode {parallel_mode} not supported (use 'column' or 'row').")
 
-        # split:
-        if inp_dim % comm_inp_size != 0:
-            raise ValueError(f"the size of input feature dim ({inp_dim}) has to be evenly divisible by the input feature comm dim ({comm_inp_size})")
-        if out_dim % comm_out_size != 0:
-            raise ValueError(f"the size of output feature dim ({out_dim}) has to be evenly divisible by the output feature comm dim ({comm_out_size})")
+        if input_format not in ["nchw", "traditional"]:
+            raise NotImplementedError(f"Error, input format {input_format} not supported.")
 
-        # compute reduced dims
-        inp_dim_local = inp_dim // comm_inp_size
-        out_dim_local = out_dim // comm_out_size
+        self.comm_name = comm_name
+        self.parallel_mode = parallel_mode
+        self.input_format = input_format
 
-        # parameters
-        if input_format == "nchw":
+        # only use transformer engine if it was requested and is actually available
+        self.use_te = use_te and _TE_AVAILABLE
+        if use_te and not _TE_AVAILABLE:
+            import warnings
+
+            warnings.warn("use_te=True was requested but transformer_engine is not installed; falling back to the standard matmul.")
+
+        comm_size = comm.get_size(comm_name)
+
+        # column shards the output dim, row shards the input dim
+        if parallel_mode == "column":
+            if out_dim % comm_size != 0:
+                raise ValueError(f"the output feature dim ({out_dim}) has to be evenly divisible by the matmul comm dim ({comm_size})")
+            out_dim_local = out_dim // comm_size
+            inp_dim_local = inp_dim
+        else:
+            if inp_dim % comm_size != 0:
+                raise ValueError(f"the input feature dim ({inp_dim}) has to be evenly divisible by the matmul comm dim ({comm_size})")
+            out_dim_local = out_dim
+            inp_dim_local = inp_dim // comm_size
+
+        # the dimension that is sharded over the matmul group (None for the
+        # replicated dimension) - used for checkpoint gather/scatter only
+        weight_inp_shard = None if parallel_mode == "column" else comm_name
+        weight_out_shard = comm_name if parallel_mode == "column" else None
+
+        # weight. transformer engine keeps the (2D) weight inside a te.Linear and
+        # performs the local matmul in FP8/FP4; the tensor-parallel communication
+        # (copy/reduce, see forward) and the gradient reduction stay in makani, so
+        # te.Linear is used purely as a local GEMM (no tp_group). The bias is
+        # always owned here (te.Linear bias=False) so the row-parallel bias can be
+        # added AFTER the all-reduce, matching the native path.
+        if self.use_te:
+            self.te_linear = te.Linear(inp_dim_local, out_dim_local, bias=False)
+            # te weight is always 2D (out_local, in_local) regardless of input_format
+            self.weight.is_shared_mp = ["spatial"]
+            self.weight.sharded_dims_mp = [weight_out_shard, weight_inp_shard]
+        elif input_format == "nchw":
             self.weight = nn.Parameter(torch.ones(out_dim_local, inp_dim_local, 1, 1))
             self.weight.is_shared_mp = ["spatial"]
-            self.weight.sharded_dims_mp = [self.comm_out_name, self.comm_inp_name, None, None]
+            self.weight.sharded_dims_mp = [weight_out_shard, weight_inp_shard, None, None]
             self.matmul_handle = F.conv2d
-        elif input_format == "traditional":
+        else:  # traditional
             self.weight = nn.Parameter(torch.ones(out_dim_local, inp_dim_local))
-            self.weight.sharded_dims_mp = [self.comm_out_name, self.comm_inp_name]
+            self.weight.is_shared_mp = ["spatial"]
+            self.weight.sharded_dims_mp = [weight_out_shard, weight_inp_shard]
             self.matmul_handle = F.linear
-        else:
-            raise NotImplementedError(f"Error, input format {input_format} not supported.")
 
         # bias
         self.bias = None
         if bias:
+            # a column bias is sharded over the (sharded) output dim, a row bias
+            # is replicated over the matmul group (added after the all-reduce) and
+            # must therefore NOT be summed over matmul in the gradient hook
+            bias_shard = comm_name if parallel_mode == "column" else None
             if input_format == "nchw":
                 self.bias = nn.Parameter(torch.zeros(1, out_dim_local, 1, 1))
                 self.bias.is_shared_mp = ["spatial"]
-                self.bias.sharded_dims_mp = [None, self.comm_out_name, None, None]
+                self.bias.sharded_dims_mp = [None, bias_shard, None, None]
             elif input_format == "traditional":
                 self.bias = nn.Parameter(torch.zeros(out_dim_local))
-                self.bias.sharded_dims_mp = [self.comm_out_name]
+                self.bias.is_shared_mp = ["spatial"]
+                self.bias.sharded_dims_mp = [bias_shard]
+
+    @property
+    def weight(self):
+        # te.Linear owns the weight in the TE path; expose it through the same
+        # attribute so external init / annotation / the gradient hook are uniform
+        if self.use_te:
+            return self.te_linear.weight
+        return self._parameters["weight"]
+
+    def _local_matmul(self, x):
+        if self.use_te:
+            # te.Linear operates on the last (channel) dim; for nchw we transpose
+            # to channels-last around the GEMM
+            if self.input_format == "nchw":
+                x = self.te_linear(x.permute(0, 2, 3, 1).contiguous())
+                return x.permute(0, 3, 1, 2).contiguous()
+            return self.te_linear(x)
+        return self.matmul_handle(x, self.weight, bias=None)
 
     def forward(self, x):
-        x_cp = copy_to_parallel_region(x, self.comm_out_name)
-        x_loc = self.matmul_handle(x_cp, self.weight, bias=None)
-        x_out = reduce_from_parallel_region(x_loc, self.comm_inp_name)
-        if self.bias is not None:
-            x_out = x_out + self.bias
+        if self.parallel_mode == "column":
+            # replicated input -> sharded output, no output reduction
+            x = copy_to_parallel_region(x, self.comm_name)
+            x = self._local_matmul(x)
+        else:
+            # sharded input -> reduced (replicated) output
+            x = self._local_matmul(x)
+            x = reduce_from_parallel_region(x, self.comm_name)
 
-        return x_out
+        if self.bias is not None:
+            x = x + self.bias
+
+        return x
 
 
 # distributed encoder/decoder
 class DistributedEncoderDecoder(nn.Module):
-    def __init__(self, num_layers, input_dim, output_dim, hidden_dim, act_layer, gain=1.0, input_format="nchw", comm_inp_name="fin", comm_out_name="fout"):
+    def __init__(self, num_layers, input_dim, output_dim, hidden_dim, act_layer, gain=1.0, input_format="nchw", comm_name="matmul", use_te=False):
         super(DistributedEncoderDecoder, self).__init__()
 
-        # get comms
-        comm_inp_size = comm.get_size(comm_inp_name)
-        comm_out_size = comm.get_size(comm_out_name)
+        self.comm_name = comm_name
+
+        # the chain takes a replicated input and must produce a replicated output.
+        # we therefore drive the column/row fork-join from the END: the last layer
+        # is row-parallel (reduces to a replicated output) and we alternate
+        # backwards. for the first layer to be column-parallel (consuming the
+        # replicated input) the number of layers must be even when we are actually
+        # feature-parallel.
+        if (comm.get_size(comm_name) > 1) and (num_layers % 2 != 0):
+            raise ValueError(
+                f"DistributedEncoderDecoder requires an even number of layers under matmul parallelism, got {num_layers}."
+            )
+        modes = ["row" if ((num_layers - 1 - i) % 2 == 0) else "column" for i in range(num_layers)]
 
         # get list of modules
         encoder_modules = []
         current_dim = input_dim
-        comm_inp_name_tmp = comm_inp_name
-        comm_out_name_tmp = comm_out_name
         for i in range(num_layers - 1):
             encoder_modules.append(
-                DistributedMatmul(current_dim, hidden_dim, input_format=input_format, comm_inp_name=comm_inp_name_tmp, comm_out_name=comm_out_name_tmp, bias=True)
+                DistributedMatmul(current_dim, hidden_dim, input_format=input_format, comm_name=comm_name, parallel_mode=modes[i], bias=True, use_te=use_te)
             )
 
             # proper initialization
@@ -163,10 +201,9 @@ class DistributedEncoderDecoder(nn.Module):
 
             encoder_modules.append(act_layer())
             current_dim = hidden_dim
-            comm_inp_name_tmp, comm_out_name_tmp = (comm_out_name_tmp, comm_inp_name_tmp)
 
-        # final layer
-        encoder_modules.append(DistributedMatmul(current_dim, output_dim, input_format=input_format, comm_inp_name=comm_inp_name_tmp, comm_out_name=comm_out_name_tmp, bias=False))
+        # final layer (row-parallel, replicated output, no bias)
+        encoder_modules.append(DistributedMatmul(current_dim, output_dim, input_format=input_format, comm_name=comm_name, parallel_mode=modes[-1], bias=False, use_te=use_te))
 
         # proper initialization of final layer
         scale = math.sqrt(gain / current_dim)
@@ -176,10 +213,6 @@ class DistributedEncoderDecoder(nn.Module):
 
         # create fwd sequence
         self.fwd = nn.Sequential(*encoder_modules)
-
-        # store the comm names for in and out so that they can be queried
-        self.comm_inp_name = comm_inp_name
-        self.comm_out_name = comm_out_name_tmp
 
     def forward(self, x):
         return self.fwd(x)
@@ -194,13 +227,13 @@ class DistributedMLP(nn.Module):
         out_features=None,
         output_bias=True,
         input_format="nchw",
-        comm_inp_name="fin",
-        comm_hidden_name="fout",
+        comm_name="matmul",
         act_layer=nn.GELU,
         drop_rate=0.0,
         drop_type="iid",
         checkpointing=False,
         gain=1.0,
+        use_te=False,
     ):
         super().__init__()
         self.checkpointing = checkpointing
@@ -211,18 +244,16 @@ class DistributedMLP(nn.Module):
         if (input_format == "traditional") and (drop_type == "features"):
             raise NotImplementedError(f"Error, traditional input format and feature dropout cannot be selected simultaneously")
 
-        # get effective embedding size:
-        comm_inp_size = comm.get_size(comm_inp_name)
-        comm_hid_size = comm.get_size(comm_hidden_name)
-
-        self.fc1 = DistributedMatmul(in_features, hidden_features, input_format=input_format, comm_inp_name=comm_inp_name, comm_out_name=comm_hidden_name, bias=True)
+        # column-parallel: replicated input -> hidden sharded over the matmul group
+        self.fc1 = DistributedMatmul(in_features, hidden_features, input_format=input_format, comm_name=comm_name, parallel_mode="column", bias=True, use_te=use_te)
 
         # initialize the weights correctly
         scale = math.sqrt(2.0 / in_features)
         nn.init.normal_(self.fc1.weight, mean=0.0, std=scale)
         nn.init.constant_(self.fc1.bias, 0.0)
 
-        self.fc2 = DistributedMatmul(hidden_features, out_features, input_format=input_format, comm_inp_name=comm_hidden_name, comm_out_name=comm_inp_name, bias=output_bias)
+        # row-parallel: sharded hidden -> all-reduced (replicated) output
+        self.fc2 = DistributedMatmul(hidden_features, out_features, input_format=input_format, comm_name=comm_name, parallel_mode="row", bias=output_bias, use_te=use_te)
 
         # gain factor for the output determines the scaling of the output init
         scale = math.sqrt(gain / hidden_features)
@@ -454,14 +485,14 @@ class DistributedAttention(nn.Module):
         self,
         dim,
         input_format="traditional",
-        comm_inp_name="fin",
-        comm_hidden_name="fout",
+        comm_name="matmul",
         num_heads=8,
         qkv_bias=False,
         qk_norm=False,
         attn_drop_rate=0.0,
         proj_drop_rate=0.0,
         norm_layer=nn.LayerNorm,
+        use_te=False,
     ):
         super().__init__()
 
@@ -469,19 +500,19 @@ class DistributedAttention(nn.Module):
             raise ValueError(f"dim {dim} should be divisible by num_heads {num_heads}")
         self.num_heads = num_heads
 
-        if num_heads % comm.get_size(comm_hidden_name) != 0:
-            raise ValueError(f"heads ({num_heads}) are not evenly split across model ranks ({comm.get_size(comm_hidden_name)})")
-        self.num_heads_local = num_heads // comm.get_size(comm_hidden_name)
+        if num_heads % comm.get_size(comm_name) != 0:
+            raise ValueError(f"heads ({num_heads}) are not evenly split across model ranks ({comm.get_size(comm_name)})")
+        self.num_heads_local = num_heads // comm.get_size(comm_name)
         self.head_dim = dim // self.num_heads
 
-        self.comm_inp_name = comm_inp_name
-        self.comm_hidden_name = comm_hidden_name
+        self.comm_name = comm_name
 
-        self.qkv = DistributedMatmul(dim, dim * 3, input_format, comm_inp_name=comm_inp_name, comm_out_name=comm_hidden_name, bias=qkv_bias)
+        # column-parallel qkv (heads sharded over the matmul group) -> row-parallel proj
+        self.qkv = DistributedMatmul(dim, dim * 3, input_format, comm_name=comm_name, parallel_mode="column", bias=qkv_bias, use_te=use_te)
         self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
         self.k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
         self.attn_drop_rate = attn_drop_rate
-        self.proj = DistributedMatmul(dim, dim, input_format, comm_inp_name=comm_hidden_name, comm_out_name=comm_inp_name, bias=False)
+        self.proj = DistributedMatmul(dim, dim, input_format, comm_name=comm_name, parallel_mode="row", bias=False, use_te=use_te)
         if proj_drop_rate > 0.0:
             self.proj_drop = nn.Dropout(proj_drop_rate)
         else:

--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -246,8 +246,17 @@ class DistributedMLP(nn.Module):
         if (input_format == "traditional") and (drop_type == "features"):
             raise NotImplementedError(f"Error, traditional input format and feature dropout cannot be selected simultaneously")
 
+        # TE GEMMs operate on the last (channel) dim. Rather than permuting
+        # nchw<->nhwc around *each* matmul, when the TE path is active we build the
+        # matmuls in "traditional" (channels-last) mode and permute once at the MLP
+        # boundaries (see fwd) -- two permutes for the whole MLP instead of one pair
+        # per matmul. Feature dropout (Dropout2d) drops channels at dim=1 and so
+        # needs the nchw layout, so keep the standard nchw path in that case.
+        self.channels_last = use_te and _TE_AVAILABLE and (input_format == "nchw") and (drop_type != "features")
+        matmul_format = "traditional" if self.channels_last else input_format
+
         # column-parallel: replicated input -> hidden sharded over the matmul group
-        self.fc1 = DistributedMatmul(in_features, hidden_features, input_format=input_format, comm_name=comm_name, parallel_mode="column", bias=True, use_te=use_te)
+        self.fc1 = DistributedMatmul(in_features, hidden_features, input_format=matmul_format, comm_name=comm_name, parallel_mode="column", bias=True, use_te=use_te)
 
         # initialize the weights correctly
         scale = math.sqrt(2.0 / in_features)
@@ -255,7 +264,7 @@ class DistributedMLP(nn.Module):
         nn.init.constant_(self.fc1.bias, 0.0)
 
         # row-parallel: sharded hidden -> all-reduced (replicated) output
-        self.fc2 = DistributedMatmul(hidden_features, out_features, input_format=input_format, comm_name=comm_name, parallel_mode="row", bias=output_bias, use_te=use_te)
+        self.fc2 = DistributedMatmul(hidden_features, out_features, input_format=matmul_format, comm_name=comm_name, parallel_mode="row", bias=output_bias, use_te=use_te)
 
         # gain factor for the output determines the scaling of the output init
         scale = math.sqrt(gain / hidden_features)
@@ -276,6 +285,12 @@ class DistributedMLP(nn.Module):
             self.drop = nn.Identity()
 
     def fwd(self, x):
+        # on the TE path the matmuls are channels-last ("traditional"): permute
+        # nchw -> nhwc once here and back at the end, keeping act/iid-dropout
+        # channels-last in between.
+        if self.channels_last:
+            x = x.permute(0, 2, 3, 1).contiguous()
+
         # do the mlp
         # first layer
         x = self.fc1(x)
@@ -285,6 +300,9 @@ class DistributedMLP(nn.Module):
         # second layer
         x = self.fc2(x)
         x = self.drop(x)
+
+        if self.channels_last:
+            x = x.permute(0, 3, 1, 2).contiguous()
 
         return x
 

--- a/makani/train.py
+++ b/makani/train.py
@@ -43,13 +43,12 @@ if __name__ == "__main__":
     params = YParams(os.path.abspath(args.yaml_config), args.config)
 
     # distributed
-    params["fin_parallel_size"] = args.fin_parallel_size
-    params["fout_parallel_size"] = args.fout_parallel_size
+    params["matmul_parallel_size"] = args.matmul_parallel_size
     params["h_parallel_size"] = args.h_parallel_size
     params["w_parallel_size"] = args.w_parallel_size
 
-    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.fin_parallel_size, args.fout_parallel_size]
-    params["model_parallel_names"] = ["h", "w", "fin", "fout"]
+    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.matmul_parallel_size]
+    params["model_parallel_names"] = ["h", "w", "matmul"]
     params["parameters_reduction_buffer_count"] = args.parameters_reduction_buffer_count
 
     # checkpoint format

--- a/makani/train_autoencoder.py
+++ b/makani/train_autoencoder.py
@@ -40,13 +40,12 @@ if __name__ == "__main__":
     params = YParams(os.path.abspath(args.yaml_config), args.config)
 
     # distributed
-    params["fin_parallel_size"] = args.fin_parallel_size
-    params["fout_parallel_size"] = args.fout_parallel_size
+    params["matmul_parallel_size"] = args.matmul_parallel_size
     params["h_parallel_size"] = args.h_parallel_size
     params["w_parallel_size"] = args.w_parallel_size
 
-    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.fin_parallel_size, args.fout_parallel_size]
-    params["model_parallel_names"] = ["h", "w", "fin", "fout"]
+    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.matmul_parallel_size]
+    params["model_parallel_names"] = ["h", "w", "matmul"]
     params["parameters_reduction_buffer_count"] = args.parameters_reduction_buffer_count
 
     # checkpoint format

--- a/makani/train_stochastic.py
+++ b/makani/train_stochastic.py
@@ -45,15 +45,14 @@ if __name__ == "__main__":
 
     # distributed
     params["ensemble_parallel_size"] = args.ensemble_parallel_size
-    params["fin_parallel_size"] = args.fin_parallel_size
-    params["fout_parallel_size"] = args.fout_parallel_size
+    params["matmul_parallel_size"] = args.matmul_parallel_size
     params["h_parallel_size"] = args.h_parallel_size
     params["w_parallel_size"] = args.w_parallel_size
 
     params["data_parallel_sizes"] = [args.ensemble_parallel_size, -1]
     params["data_parallel_names"] = ["ensemble", "batch"]
-    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.fin_parallel_size, args.fout_parallel_size]
-    params["model_parallel_names"] = ["h", "w", "fin", "fout"]
+    params["model_parallel_sizes"] = [args.h_parallel_size, args.w_parallel_size, args.matmul_parallel_size]
+    params["model_parallel_names"] = ["h", "w", "matmul"]
     params["parameters_reduction_buffer_count"] = args.parameters_reduction_buffer_count
 
     # checkpoint format

--- a/makani/utils/argument_parser.py
+++ b/makani/utils/argument_parser.py
@@ -30,8 +30,7 @@ def get_default_argument_parser(training=True):
     parser.add_argument("--batch_size", default=-1, type=int, help="Switch for overriding batch size in the configuration file.")
 
     # model parallelization options
-    parser.add_argument("--fin_parallel_size", default=1, type=int, help="Input feature parallelization")
-    parser.add_argument("--fout_parallel_size", default=1, type=int, help="Output feature parallelization")
+    parser.add_argument("--matmul_parallel_size", default=1, type=int, help="Feature (tensor) parallelism dimension")
     parser.add_argument("--h_parallel_size", default=1, type=int, help="Spatial parallelism dimension in h")
     parser.add_argument("--w_parallel_size", default=1, type=int, help="Spatial parallelism dimension in w")
 

--- a/makani/utils/argument_parser.py
+++ b/makani/utils/argument_parser.py
@@ -35,7 +35,7 @@ def get_default_argument_parser(training=True):
     parser.add_argument("--w_parallel_size", default=1, type=int, help="Spatial parallelism dimension in w")
 
     # performance options
-    parser.add_argument("--amp_mode", default="none", type=str, choices=["none", "fp16", "bf16"], help="Specify the mixed precision mode which should be used.")
+    parser.add_argument("--amp_mode", default="none", type=str, help="Mixed precision mode: 'none', 'fp16', 'bf16', or a combined '<amp>-<fp8recipe>' such as 'bf16-fp8_delayed' (requires transformer_engine). See makani.utils.precision.")
     parser.add_argument("--jit_mode", default="none", type=str, choices=["none", "inductor"], help="Specify if and how to use torch compile.")
     parser.add_argument("--checkpointing_level", default=0, type=int, help="How aggressively checkpointing is used")
     parser.add_argument("--print_timings_frequency", default=-1, type=int, help="Frequency at which to print timing information")

--- a/makani/utils/comm.py
+++ b/makani/utils/comm.py
@@ -111,7 +111,7 @@ def cleanup():
     
 
 # initialization routine
-def init(model_parallel_sizes=[1, 1, 1, 1], model_parallel_names=["h", "w", "fin", "fout"], data_parallel_sizes=[1, -1], data_parallel_names=["ensemble", "batch"], verbose=False):
+def init(model_parallel_sizes=[1, 1, 1], model_parallel_names=["h", "w", "matmul"], data_parallel_sizes=[1, -1], data_parallel_names=["ensemble", "batch"], verbose=False):
 
     # call basic init first
     DistributedManager.initialize()
@@ -127,15 +127,14 @@ def init(model_parallel_sizes=[1, 1, 1, 1], model_parallel_names=["h", "w", "fin
     # add nodes:
     # model
     pconfig.add_node(ProcessGroupNode("model"), parent="world")
-    # spatial and matmul
+    # spatial and matmul. matmul is a single (1D) feature-parallel leaf group;
+    # the legacy 2D fin/fout decomposition has been retired in favor of a
+    # Megatron-style column/row fork-join over the single "matmul" group.
     pconfig.add_node(ProcessGroupNode("spatial"), parent="model")
     pconfig.add_node(ProcessGroupNode("matmul"), parent="model")
     # subgroups for spatial
     pconfig.add_node(ProcessGroupNode("w"), parent="spatial")
     pconfig.add_node(ProcessGroupNode("h"), parent="spatial")
-    # subgroups for matmul:
-    pconfig.add_node(ProcessGroupNode("fin"), parent="matmul")
-    pconfig.add_node(ProcessGroupNode("fout"), parent="matmul")
     # add data node last
     pconfig.add_node(ProcessGroupNode("data"), parent="world")
     # other data parallel dims

--- a/makani/utils/dataloader.py
+++ b/makani/utils/dataloader.py
@@ -55,8 +55,7 @@ def init_distributed_io(params):
     if not ((params.io_grid[2] == comm.get_size("w")) or (params.io_grid[2] == 1)):
         raise ValueError(f"io_grid[2] ({params.io_grid[2]}) has to be either 1 or equal to the w comm size ({comm.get_size('w')})")
 
-    # get io ranks: mp_rank = x_coord + params.io_grid[0] * (ycoord + params.io_grid[1] * zcoord)
-    mp_rank = comm.get_rank("model")
+    # get io ranks (channel dim is always 1, so only h/w are sharded)
     params.io_rank = [0, 0, 0]
     if params.io_grid[1] > 1:
         params.io_rank[1] = comm.get_rank("h")

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -36,6 +36,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils import comm
+from makani.utils.precision import AutocastManager
 from makani.utils.dataloaders.data_helpers import get_date_from_string
 
 # inference specific stuff
@@ -68,21 +69,14 @@ class Inferencer(Driver):
         if self.log_to_wandb:
             self._init_wandb(self.params, job_type="inference")
 
-        # set amp_parameters
-        if hasattr(self.params, "amp_mode") and (self.params.amp_mode != "none"):
-            self.amp_enabled = True
-            if self.params.amp_mode == "fp16":
-                self.amp_dtype = torch.float16
-            elif self.params.amp_mode == "bf16":
-                self.amp_dtype = torch.bfloat16
-            else:
-                raise ValueError(f"Unknown amp mode {self.params.amp_mode}")
-
-            if self.log_to_screen:
-                self.logger.info(f"Enabling automatic mixed precision in {self.params.amp_mode}.")
-        else:
-            self.amp_enabled = False
-            self.amp_dtype = torch.float32
+        # set up mixed precision (amp dtype + optional transformer-engine fp8 recipe).
+        # the manager parses the mode once and hands out a single nested autocast cm.
+        amp_mode = self.params.amp_mode if hasattr(self.params, "amp_mode") else "none"
+        self.autocast = AutocastManager(amp_mode, device_type="cuda", fp8_group=comm.get_group("data"))
+        self.amp_dtype = self.autocast.amp_dtype
+        self.amp_enabled = self.autocast.amp_enabled
+        if self.amp_enabled and self.log_to_screen:
+            self.logger.info(f"Enabling automatic mixed precision in '{amp_mode}'.")
 
         # resuming needs is set to False so loading checkpoints does not attempt to set the optimizer state
         self.params["resuming"] = False
@@ -600,7 +594,7 @@ class Inferencer(Driver):
                         # set unpredicted features at (B*E, ...) shape to match the folded-batch inp
                         self.preprocessor.cache_unpredicted_features(None, None, inpz, tarz)
 
-                        with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+                        with self.autocast():
                             # single forward on the folded batch; noise does an AR update
                             # (replace_state=False) before being consumed this step
                             pred_flat = self.model(inp, update_state=True, replace_state=False)

--- a/makani/utils/precision.py
+++ b/makani/utils/precision.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Precision / autocast helper.
+
+Mixed precision in makani is selected by a single ``mode`` string that combines an
+AMP dtype with an optional transformer-engine FP8 recipe:
+
+    none                 -> fp32, no autocast
+    fp16                 -> torch.autocast(float16)
+    bf16                 -> torch.autocast(bfloat16)
+    bf16-fp8_delayed     -> torch.autocast(bfloat16) + te.fp8_autocast(DelayedScaling)
+    fp16-fp8_hybrid      -> torch.autocast(float16)  + te.fp8_autocast(DelayedScaling, HYBRID)
+    bf16-mxfp8           -> torch.autocast(bfloat16)  + te.fp8_autocast(MXFP8BlockScaling)
+    ...
+
+``AutocastManager`` parses the mode once and hands out a single context manager that
+nests the AMP autocast and (if requested) the FP8 autocast at the right level, so call
+sites stay flat:
+
+    self.autocast = AutocastManager(params.amp_mode, fp8_group=comm.get_group("data"))
+    self.gscaler  = amp.GradScaler("cuda", enabled=self.autocast.grad_scaler_enabled)
+    ...
+    with self.autocast():
+        out = model(inp)
+
+instead of hand-nesting ``with amp.autocast(...): with te.fp8_autocast(...): ...``.
+"""
+
+import contextlib
+
+import torch
+from torch import amp
+
+try:
+    import transformer_engine.pytorch as te
+
+    _TE_AVAILABLE = True
+except ImportError:
+    te = None
+    _TE_AVAILABLE = False
+
+
+_AMP_DTYPES = {
+    "none": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+
+def _make_fp8_recipe(key: str):
+    """Build a transformer-engine FP8 recipe from a short key.
+
+    Recipe classes vary across TE versions, so each is imported lazily and a clear
+    error is raised if the key (or the recipe class) is unavailable. This dict is the
+    extension point for new recipes.
+    """
+    if not _TE_AVAILABLE:
+        raise RuntimeError(f"precision mode requests fp8 recipe '{key}' but transformer_engine is not installed")
+
+    from transformer_engine.common import recipe as te_recipe
+
+    builders = {
+        # delayed scaling (amax history); HYBRID = e4m3 fwd / e5m2 bwd
+        "fp8_delayed": lambda: te_recipe.DelayedScaling(fp8_format=te_recipe.Format.HYBRID),
+        "fp8_hybrid": lambda: te_recipe.DelayedScaling(fp8_format=te_recipe.Format.HYBRID),
+        "fp8_e4m3": lambda: te_recipe.DelayedScaling(fp8_format=te_recipe.Format.E4M3),
+        # current (per-tensor, no history) and block scaling (mxfp8); newer TE only
+        "fp8_current": lambda: te_recipe.Float8CurrentScaling(),
+        "mxfp8": lambda: te_recipe.MXFP8BlockScaling(),
+    }
+
+    if key not in builders:
+        raise ValueError(f"unknown fp8 recipe '{key}' (supported: {sorted(builders)})")
+
+    try:
+        return builders[key]()
+    except AttributeError as err:
+        raise RuntimeError(f"fp8 recipe '{key}' is not available in this transformer_engine version") from err
+
+
+def parse_precision_mode(mode: str):
+    """Split a precision ``mode`` string into ``(amp_dtype, fp8_recipe_key)``.
+
+    ``fp8_recipe_key`` is ``None`` when no FP8 recipe is requested. Raises ``ValueError``
+    on an unknown amp precision or a malformed mode.
+    """
+    mode = (mode or "none").lower()
+    parts = mode.split("-")
+    if len(parts) > 2:
+        raise ValueError(f"malformed precision mode '{mode}' (expected '<amp>' or '<amp>-<fp8recipe>')")
+
+    amp_part = parts[0]
+    fp8_part = parts[1] if len(parts) == 2 else None
+
+    if amp_part not in _AMP_DTYPES:
+        raise ValueError(f"unknown amp precision '{amp_part}' in mode '{mode}' (expected one of {sorted(_AMP_DTYPES)})")
+
+    return _AMP_DTYPES[amp_part], fp8_part
+
+
+class AutocastManager:
+    """Parses a precision mode once and yields the combined autocast context manager.
+
+    Parameters
+    ----------
+    mode : str
+        Precision mode, e.g. ``"bf16"`` or ``"bf16-fp8_delayed"`` (see module docstring).
+    device_type : str
+        Device type passed to ``torch.autocast`` (default ``"cuda"``).
+    fp8_group : Optional[torch.distributed.ProcessGroup]
+        Process group for FP8 amax / scale synchronization (delayed scaling). Pass the
+        data-parallel group; ignored when no FP8 recipe is selected.
+
+        NOTE: fp8_group must exclude the tensor-parallel/matmul group. The column/row
+        ``DistributedMatmul`` shards weights across matmul, so each matmul rank owns a
+        distinct weight shard with its own legitimate amax/scale -- reducing amax over
+        matmul would couple independent shards and clamp them to a common (over-
+        conservative) scale. The data group is orthogonal to model (spatial x matmul),
+        so it already excludes matmul. Current scaling / MXFP8 derive scales locally and
+        do not use this group.
+    """
+
+    def __init__(self, mode, device_type="cuda", fp8_group=None):
+        self.mode = mode
+        self.device_type = device_type
+        self.fp8_group = fp8_group
+
+        self.amp_dtype, self._fp8_recipe_key = parse_precision_mode(mode)
+        self.amp_enabled = self.amp_dtype != torch.float32
+        self.fp8_enabled = self._fp8_recipe_key is not None
+
+        # an fp8 mode must fail loudly when transformer_engine is missing rather than
+        # silently degrade to the plain amp dtype
+        if self.fp8_enabled and not _TE_AVAILABLE:
+            raise RuntimeError(
+                f"precision mode '{mode}' requests an fp8 recipe but transformer_engine is not installed; "
+                f"install transformer_engine or choose a non-fp8 mode (none/fp16/bf16)"
+            )
+
+        # build the recipe eagerly so an unsupported mode fails at construction, not in forward
+        self._fp8_recipe = _make_fp8_recipe(self._fp8_recipe_key) if self.fp8_enabled else None
+
+    @property
+    def grad_scaler_enabled(self) -> bool:
+        """The loss scaler is only needed for fp16; bf16 and fp8 do not use it."""
+        return self.amp_dtype == torch.float16
+
+    @contextlib.contextmanager
+    def __call__(self):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(amp.autocast(device_type=self.device_type, enabled=self.amp_enabled, dtype=self.amp_dtype))
+            if self.fp8_enabled:
+                stack.enter_context(te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe, fp8_group=self.fp8_group))
+            yield

--- a/makani/utils/precision.py
+++ b/makani/utils/precision.py
@@ -45,13 +45,7 @@ import contextlib
 import torch
 from torch import amp
 
-try:
-    import transformer_engine.pytorch as te
-
-    _TE_AVAILABLE = True
-except ImportError:
-    te = None
-    _TE_AVAILABLE = False
+from makani.utils.te_helpers import TE_AVAILABLE, get_te
 
 
 _AMP_DTYPES = {
@@ -68,7 +62,7 @@ def _make_fp8_recipe(key: str):
     error is raised if the key (or the recipe class) is unavailable. This dict is the
     extension point for new recipes.
     """
-    if not _TE_AVAILABLE:
+    if not TE_AVAILABLE:
         raise RuntimeError(f"precision mode requests fp8 recipe '{key}' but transformer_engine is not installed")
 
     from transformer_engine.common import recipe as te_recipe
@@ -145,7 +139,7 @@ class AutocastManager:
 
         # an fp8 mode must fail loudly when transformer_engine is missing rather than
         # silently degrade to the plain amp dtype
-        if self.fp8_enabled and not _TE_AVAILABLE:
+        if self.fp8_enabled and not TE_AVAILABLE:
             raise RuntimeError(
                 f"precision mode '{mode}' requests an fp8 recipe but transformer_engine is not installed; "
                 f"install transformer_engine or choose a non-fp8 mode (none/fp16/bf16)"
@@ -164,5 +158,6 @@ class AutocastManager:
         with contextlib.ExitStack() as stack:
             stack.enter_context(amp.autocast(device_type=self.device_type, enabled=self.amp_enabled, dtype=self.amp_dtype))
             if self.fp8_enabled:
+                te = get_te()
                 stack.enter_context(te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe, fp8_group=self.fp8_group))
             yield

--- a/makani/utils/te_helpers.py
+++ b/makani/utils/te_helpers.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+transformer-engine availability helper.
+
+``find_spec`` locates the package without executing it, so we can set the
+availability flag at import time without paying the cost (or CUDA-context side
+effects) of importing transformer_engine just to learn whether it exists. The
+actual module is imported lazily, and cached, the first time it is needed.
+"""
+
+import importlib.util
+
+# cheap, side-effect-free check: is the package installed? (does not import it)
+TE_AVAILABLE = importlib.util.find_spec("transformer_engine") is not None
+
+_te = None
+
+
+def get_te():
+    """Return the ``transformer_engine.pytorch`` module, importing it lazily on first
+    use and caching it. Returns ``None`` if transformer_engine is not installed."""
+    global _te
+    if _te is None and TE_AVAILABLE:
+        import transformer_engine.pytorch as te
+
+        _te = te
+    return _te

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -38,6 +38,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils import comm
+from makani.utils.precision import AutocastManager
 from makani.utils import visualize
 
 from makani.mpu.mappings import init_gradient_reduction_hooks
@@ -73,21 +74,14 @@ class AutoencoderTrainer(Driver):
             tens = torch.ones(1, device=self.device)
             dist.all_reduce(tens, group=comm.get_group("data"))
 
-        # set amp_parameters
-        if hasattr(self.params, "amp_mode") and (self.params.amp_mode != "none"):
-            self.amp_enabled = True
-            if self.params.amp_mode == "fp16":
-                self.amp_dtype = torch.float16
-            elif self.params.amp_mode == "bf16":
-                self.amp_dtype = torch.bfloat16
-            else:
-                raise ValueError(f"Unknown amp mode {self.params.amp_mode}")
-
-            if self.log_to_screen:
-                self.logger.info(f"Enabling automatic mixed precision in {self.params.amp_mode}.")
-        else:
-            self.amp_enabled = False
-            self.amp_dtype = torch.float32
+        # set up mixed precision (amp dtype + optional transformer-engine fp8 recipe).
+        # the manager parses the mode once and hands out a single nested autocast cm.
+        amp_mode = self.params.amp_mode if hasattr(self.params, "amp_mode") else "none"
+        self.autocast = AutocastManager(amp_mode, device_type="cuda", fp8_group=comm.get_group("data"))
+        self.amp_dtype = self.autocast.amp_dtype
+        self.amp_enabled = self.autocast.amp_enabled
+        if self.amp_enabled and self.log_to_screen:
+            self.logger.info(f"Enabling automatic mixed precision in '{amp_mode}'.")
 
         # initialize data loader
         if self.log_to_screen:
@@ -161,7 +155,7 @@ class AutoencoderTrainer(Driver):
         self.scheduler = self.get_scheduler(self.optimizer, self.params)
 
         # gradient scaler
-        self.gscaler = amp.GradScaler(enabled=(self.amp_dtype == torch.float16))
+        self.gscaler = amp.GradScaler("cuda", enabled=self.autocast.grad_scaler_enabled)
 
         # gradient clipping
         self.max_grad_norm = self.params.get("optimizer_max_grad_norm", -1.0)
@@ -478,7 +472,7 @@ class AutoencoderTrainer(Driver):
             if self.params["gradient_accumulation_steps"] > 1:
                 loss_scaling_fact = 1.0 / np.float32(self.params["gradient_accumulation_steps"])
 
-            with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+            with self.autocast():
 
                 if do_update:
                     _, loss = self._autoencoder_step(inp)
@@ -602,7 +596,7 @@ class AutoencoderTrainer(Driver):
                     inpt = inp
 
                     # FW pass
-                    with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+                    with self.autocast():
                         enc = model_handle.model.encoder(inpt)
 
                         if self.params.get("variational", False):

--- a/makani/utils/training/deterministic_trainer.py
+++ b/makani/utils/training/deterministic_trainer.py
@@ -42,6 +42,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils import comm
+from makani.utils.precision import AutocastManager
 
 from makani.mpu.mappings import init_gradient_reduction_hooks
 from makani.mpu.helpers import sync_params, gather_uneven
@@ -80,21 +81,14 @@ class Trainer(Driver):
                 dist.all_reduce(tens, group=comm.get_group("data"))
         self.timers["nccl init"] = timer.time
 
-        # set amp_parameters
-        if hasattr(self.params, "amp_mode") and (self.params.amp_mode != "none"):
-            self.amp_enabled = True
-            if self.params.amp_mode == "fp16":
-                self.amp_dtype = torch.float16
-            elif self.params.amp_mode == "bf16":
-                self.amp_dtype = torch.bfloat16
-            else:
-                raise ValueError(f"Unknown amp mode {self.params.amp_mode}")
-
-            if self.log_to_screen:
-                self.logger.info(f"Enabling automatic mixed precision in {self.params.amp_mode}.")
-        else:
-            self.amp_enabled = False
-            self.amp_dtype = torch.float32
+        # set up mixed precision (amp dtype + optional transformer-engine fp8 recipe).
+        # the manager parses the mode once and hands out a single nested autocast cm.
+        amp_mode = self.params.amp_mode if hasattr(self.params, "amp_mode") else "none"
+        self.autocast = AutocastManager(amp_mode, device_type="cuda", fp8_group=comm.get_group("data"))
+        self.amp_dtype = self.autocast.amp_dtype
+        self.amp_enabled = self.autocast.amp_enabled
+        if self.amp_enabled and self.log_to_screen:
+            self.logger.info(f"Enabling automatic mixed precision in '{amp_mode}'.")
 
         # initialize data loader
         with Timer() as timer:
@@ -183,7 +177,7 @@ class Trainer(Driver):
         self.timers["optimizer and scheduler init"] = timer.time
 
         # gradient scaler
-        self.gscaler = amp.GradScaler("cuda", enabled=(self.amp_dtype == torch.float16))
+        self.gscaler = amp.GradScaler("cuda", enabled=self.autocast.grad_scaler_enabled)
 
         # gradient clipping
         self.max_grad_norm = self.params.get("optimizer_max_grad_norm", -1.0)
@@ -484,7 +478,7 @@ class Trainer(Driver):
             if self.params["gradient_accumulation_steps"] > 1:
                 loss_scaling_fact = 1.0 / np.float32(self.params["gradient_accumulation_steps"])
 
-            with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+            with self.autocast():
                 if do_update:
                     # regular forward pass including DDP
                     pred = self.model_train(inp)
@@ -621,7 +615,7 @@ class Trainer(Driver):
                         targ = self.preprocessor.flatten_history(targ)
 
                         # FW pass
-                        with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+                        with self.autocast():
                             pred = self.model_eval(inpt)
                             loss = self.loss_obj(pred, targ)
 

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -44,6 +44,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils import comm
+from makani.utils.precision import AutocastManager
 from makani.utils import visualize
 
 from makani.mpu.mappings import init_gradient_reduction_hooks
@@ -83,21 +84,14 @@ class EnsembleTrainer(Trainer):
                 dist.all_reduce(tens, group=comm.get_group("data"))
         self.timers["nccl init"] = timer.time
 
-        # set amp_parameters
-        if hasattr(self.params, "amp_mode") and (self.params.amp_mode != "none"):
-            self.amp_enabled = True
-            if self.params.amp_mode == "fp16":
-                self.amp_dtype = torch.float16
-            elif self.params.amp_mode == "bf16":
-                self.amp_dtype = torch.bfloat16
-            else:
-                raise ValueError(f"Unknown amp mode {self.params.amp_mode}")
-
-            if self.log_to_screen:
-                self.logger.info(f"Enabling automatic mixed precision in {self.params.amp_mode}.")
-        else:
-            self.amp_enabled = False
-            self.amp_dtype = torch.float32
+        # set up mixed precision (amp dtype + optional transformer-engine fp8 recipe).
+        # the manager parses the mode once and hands out a single nested autocast cm.
+        amp_mode = self.params.amp_mode if hasattr(self.params, "amp_mode") else "none"
+        self.autocast = AutocastManager(amp_mode, device_type="cuda", fp8_group=comm.get_group("data"))
+        self.amp_dtype = self.autocast.amp_dtype
+        self.amp_enabled = self.autocast.amp_enabled
+        if self.amp_enabled and self.log_to_screen:
+            self.logger.info(f"Enabling automatic mixed precision in '{amp_mode}'.")
 
         # initialize data loader
         with Timer() as	timer:
@@ -185,7 +179,7 @@ class EnsembleTrainer(Trainer):
         self.timers["optimizer and scheduler init"] = timer.time
 
         # gradient scaler
-        self.gscaler = amp.GradScaler("cuda", enabled=(self.amp_dtype == torch.float16))
+        self.gscaler = amp.GradScaler("cuda", enabled=self.autocast.grad_scaler_enabled)
 
         # gradient clipping
         self.max_grad_norm = self.params.get("optimizer_max_grad_norm", -1.0)
@@ -523,7 +517,7 @@ class EnsembleTrainer(Trainer):
                 loss_scaling_fact = 1.0 / np.float32(self.params["gradient_accumulation_steps"])
 
             # accumulate loss into this tensor
-            with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+            with self.autocast():
 
                 if do_update:
                     pred, loss = self._ensemble_step(inp, tar)
@@ -675,7 +669,7 @@ class EnsembleTrainer(Trainer):
                         # flatten history of the target
                         targ = self.preprocessor.flatten_history(targ)
 
-                        with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+                        with self.autocast():
                             # single forward on the folded batch: at idt==0 the noise state was
                             # just drawn fresh, so skip the stepper's internal update; for
                             # subsequent steps run the standard AR update.

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -40,6 +40,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils import comm
+from makani.utils.precision import AutocastManager
 from makani.utils import visualize
 
 from makani.mpu.mappings import init_gradient_reduction_hooks
@@ -80,21 +81,14 @@ class StochasticTrainer(Driver):
             tens = torch.ones(1, device=self.device)
             dist.all_reduce(tens, group=comm.get_group("data"))
 
-        # set amp_parameters
-        if hasattr(self.params, "amp_mode") and (self.params.amp_mode != "none"):
-            self.amp_enabled = True
-            if self.params.amp_mode == "fp16":
-                self.amp_dtype = torch.float16
-            elif self.params.amp_mode == "bf16":
-                self.amp_dtype = torch.bfloat16
-            else:
-                raise ValueError(f"Unknown amp mode {self.params.amp_mode}")
-
-            if self.log_to_screen:
-                self.logger.info(f"Enabling automatic mixed precision in {self.params.amp_mode}.")
-        else:
-            self.amp_enabled = False
-            self.amp_dtype = torch.float32
+        # set up mixed precision (amp dtype + optional transformer-engine fp8 recipe).
+        # the manager parses the mode once and hands out a single nested autocast cm.
+        amp_mode = self.params.amp_mode if hasattr(self.params, "amp_mode") else "none"
+        self.autocast = AutocastManager(amp_mode, device_type="cuda", fp8_group=comm.get_group("data"))
+        self.amp_dtype = self.autocast.amp_dtype
+        self.amp_enabled = self.autocast.amp_enabled
+        if self.amp_enabled and self.log_to_screen:
+            self.logger.info(f"Enabling automatic mixed precision in '{amp_mode}'.")
 
         # initialize data loader
         if self.log_to_screen:
@@ -168,7 +162,7 @@ class StochasticTrainer(Driver):
         self.scheduler = self.get_scheduler(self.optimizer, self.params)
 
         # gradient scaler
-        self.gscaler = amp.GradScaler(enabled=(self.amp_dtype == torch.float16))
+        self.gscaler = amp.GradScaler("cuda", enabled=self.autocast.grad_scaler_enabled)
 
         # weight normalization
         self.normalize_weights = self.params.get("normalize_weights", False)
@@ -460,7 +454,7 @@ class StochasticTrainer(Driver):
             if self.params["gradient_accumulation_steps"] > 1:
                 loss_scaling_fact = 1.0 / np.float32(self.params["gradient_accumulation_steps"])
 
-            with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+            with self.autocast():
                 if do_update:
                     pred, tar = self.model_train(inp, tar, n_samples=self.params.stochastic_size)
                     loss = self.loss_obj(pred, tar, inp=inp)
@@ -607,7 +601,7 @@ class StochasticTrainer(Driver):
                         # flatten history of the target
                         targ = self.preprocessor.flatten_history(targ)
 
-                        with amp.autocast(device_type="cuda", enabled=self.amp_enabled, dtype=self.amp_dtype):
+                        with self.autocast():
                             # single forward on the folded batch; StochasticInterpolant.forward
                             # handles the batch-resize of both the preprocessor's input_noise
                             # and its own noise_module internally.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Top-level pytest config for the makani test suite.
+
+Forces the multiprocessing start method to ``forkserver`` for the whole session.
+The default ``fork`` start method is not safe in our runtime image: the parent
+process has the GPU stack (CUDA/XPU, RAPIDS, DALI) loaded, and forking a
+``torch.utils.data.DataLoader`` worker out of that state aborts the child with a
+fatal ``Aborted`` (e.g. ``torch.xpu.random.manual_seed_all`` on the seed, or
+DALI's ``isinstance`` import hook during collate).
+
+``forkserver`` launches a clean, lightweight server process (via a fresh exec,
+so it never inherits the parent's CUDA/XPU/DALI state) and forks workers from
+*that*. Workers therefore start from a clean state -- the XPU lazy-init is a
+from-scratch no-op instead of a bad-fork abort -- while keeping fork's cheap
+worker startup. We preload ``torch`` into the server to warm it (importing torch
+does not initialize any GPU backend, so the server stays clean). This is in the
+same spirit as the DALI dataloader, which already runs its workers with
+``py_start_method="spawn"``, and lets us exercise the ``num_data_workers > 0``
+case.
+
+Override with ``MAKANI_TEST_START_METHOD`` (e.g. ``spawn`` or ``fork``) to debug.
+"""
+
+import os
+import multiprocessing as mp
+
+
+def pytest_configure(config):
+    # must run before any worker process is created (DataLoader workers are
+    # started during test execution, well after pytest_configure)
+    method = os.environ.get("MAKANI_TEST_START_METHOD", "forkserver")
+    try:
+        mp.set_start_method(method, force=True)
+    except (RuntimeError, ValueError):
+        # set_start_method raises if the method is unknown on this platform;
+        # leave the default in place rather than failing collection
+        return
+
+    # warm the forkserver so workers fork from a server that already has torch
+    # imported (cheaper worker startup); importing torch does not init CUDA/XPU,
+    # so the server stays clean for fork purposes
+    if method == "forkserver":
+        try:
+            mp.set_forkserver_preload(["torch"])
+        except (RuntimeError, ValueError, ImportError):
+            pass

--- a/tests/distributed/distributed_helpers.py
+++ b/tests/distributed/distributed_helpers.py
@@ -111,13 +111,14 @@ def _init_grid(cls):
     # set up distributed
     cls.grid_size_h = int(os.getenv("GRID_H", 1))
     cls.grid_size_w = int(os.getenv("GRID_W", 1))
+    cls.grid_size_m = int(os.getenv("GRID_M", 1))
     cls.grid_size_e = int(os.getenv("GRID_E", 1))
-    cls.world_size = cls.grid_size_h * cls.grid_size_w * cls.grid_size_e
+    cls.world_size = cls.grid_size_h * cls.grid_size_w * cls.grid_size_m * cls.grid_size_e
 
     # init groups
     comm.init(
-        model_parallel_sizes=[cls.grid_size_h, cls.grid_size_w, 1, 1],
-        model_parallel_names=["h", "w", "fin", "fout"],
+        model_parallel_sizes=[cls.grid_size_h, cls.grid_size_w, cls.grid_size_m],
+        model_parallel_names=["h", "w", "matmul"],
         data_parallel_sizes=[cls.grid_size_e, -1],
         data_parallel_names=["ensemble", "batch"],
     )
@@ -139,9 +140,11 @@ def _init_grid(cls):
     # store comm group parameters
     cls.wrank = comm.get_rank("w")
     cls.hrank = comm.get_rank("h")
+    cls.mrank = comm.get_rank("matmul")
     cls.erank = comm.get_rank("ensemble")
     cls.w_group = comm.get_group("w")
     cls.h_group = comm.get_group("h")
+    cls.matmul_group = comm.get_group("matmul")
     cls.e_group = comm.get_group("ensemble")
 
     # initializing sht process groups just to be sure

--- a/tests/distributed/tests_distributed_layers.py
+++ b/tests/distributed/tests_distributed_layers.py
@@ -503,7 +503,7 @@ class TestDistributedLayers(unittest.TestCase):
             output_bias=bias,
             input_format=input_format,
             act_layer=nn.GELU,
-            drop_rate=0.0,
+            drop_rate=0.0, # this is important, otherwise RNG differences will spoil the test
             drop_type="iid",
             comm_name="matmul",
         )
@@ -512,15 +512,16 @@ class TestDistributedLayers(unittest.TestCase):
 
         # copy the native weights/biases into the te module so the only difference is the
         # GEMM implementation. params stay fp32; autocast casts them on the fly. the te
-        # weight is always 2D (out_local, in_local); the native nchw weight has trailing
-        # singleton dims.
+        # path runs channels-last ("traditional"), so its weight is 2D (out_local, in_local)
+        # and its bias is 1D (out_local,); the native nchw weight/bias carry trailing
+        # singleton dims -- reshape into the target shape on copy.
         with torch.no_grad():
             mlp_te.fc1.weight.copy_(mlp_native.fc1.weight.reshape(mlp_te.fc1.weight.shape))
             mlp_te.fc2.weight.copy_(mlp_native.fc2.weight.reshape(mlp_te.fc2.weight.shape))
             if mlp_native.fc1.bias is not None:
-                mlp_te.fc1.bias.copy_(mlp_native.fc1.bias)
+                mlp_te.fc1.bias.copy_(mlp_native.fc1.bias.reshape(mlp_te.fc1.bias.shape))
             if mlp_native.fc2.bias is not None:
-                mlp_te.fc2.bias.copy_(mlp_native.fc2.bias)
+                mlp_te.fc2.bias.copy_(mlp_native.fc2.bias.reshape(mlp_te.fc2.bias.shape))
 
         # identical input to both modules
         if input_format == "nchw":
@@ -559,7 +560,8 @@ class TestDistributedLayers(unittest.TestCase):
 
         if bias:
             with self.subTest(desc="te fc2 bias gradients"):
-                self.assertTrue(reduce_success(compare_tensors("te fc2 bias gradients", mlp_te.fc2.bias.grad, mlp_native.fc2.bias.grad, atol, rtol, verbose=verbose), self.device))
+                te_bgrad = mlp_te.fc2.bias.grad.reshape(mlp_native.fc2.bias.grad.shape)
+                self.assertTrue(reduce_success(compare_tensors("te fc2 bias gradients", te_bgrad, mlp_native.fc2.bias.grad, atol, rtol, verbose=verbose), self.device))
 
 
 if __name__ == '__main__':

--- a/tests/distributed/tests_distributed_layers.py
+++ b/tests/distributed/tests_distributed_layers.py
@@ -30,6 +30,9 @@ from makani.utils import comm
 
 from makani.mpu.mappings import init_gradient_reduction_hooks
 
+# distributed mlp + transformer engine availability flag
+from makani.mpu.layers import DistributedMLP, _TE_AVAILABLE
+
 # layer norm imports
 from makani.models.common.layer_norm import GeometricInstanceNormS2
 from makani.mpu.layer_norm import DistributedGeometricInstanceNormS2, DistributedInstanceNorm2d
@@ -457,6 +460,96 @@ class TestDistributedLayers(unittest.TestCase):
                 dist.all_gather(bgrad_gather_list, bgrad_local, group=None)
                 for idb, bgrad_gather_full in enumerate(bgrad_gather_list):
                     self.assertTrue(reduce_success(compare_tensors(f"bias gradient {idb}", bgrad_gather_full, bgrad_full, tol, tol, verbose=verbose), self.device))
+
+    @unittest.skipUnless(_TE_AVAILABLE and torch.cuda.is_available(), "transformer_engine (with CUDA) is not available")
+    @parameterized.expand(
+        [
+            # nlat, nlon, batch, channels, hidden, input_format, bias, tol
+            [32, 64, 2, 16, 64, "nchw", True, 1e-3],
+            [32, 64, 2, 16, 64, "nchw", False, 1e-3],
+            [1, 64, 2, 16, 64, "traditional", True, 1e-3],
+        ],
+        skip_on_empty=True,
+    )
+    def test_distributed_mlp_te(self, nlat, nlon, batch_size, num_chan, hidden_dim, input_format, bias, tol, verbose=True):
+        """The transformer-engine MLP path must match the native distributed MLP.
+
+        ``use_te`` only swaps the local GEMM for a ``te.Linear`` (FP8 disabled here,
+        so it runs in fp32) while the column/row tensor-parallel communication and
+        the bias-after-reduce semantics stay in makani. We therefore compare the TE
+        and native ``DistributedMLP`` rank-locally (same comm setup, same weights):
+        output, input grad and per-layer weight grad must agree. This exercises the
+        nchw channels-last transpose, the row-parallel bias placement and the
+        ``weight`` property wiring under whatever h x w x matmul grid is launched.
+        """
+        # column-parallel fc1 shards the hidden dim over the matmul group
+        if hidden_dim % comm.get_size("matmul") != 0:
+            self.skipTest(f"hidden_dim {hidden_dim} not divisible by matmul size {comm.get_size('matmul')}")
+
+        B, C, H, W = batch_size, num_chan, nlat, nlon
+
+        set_seed(333)
+
+        common = dict(
+            in_features=C,
+            hidden_features=hidden_dim,
+            out_features=C,
+            output_bias=bias,
+            input_format=input_format,
+            act_layer=nn.GELU,
+            drop_rate=0.0,
+            drop_type="iid",
+            comm_name="matmul",
+        )
+        mlp_native = DistributedMLP(**common, use_te=False).to(self.device)
+        mlp_te = DistributedMLP(**common, use_te=True).to(self.device)
+
+        # copy the native weights/biases into the te module so the only difference
+        # is the GEMM implementation. the te weight is always 2D (out_local, in_local);
+        # the native nchw weight is the same values with trailing singleton dims.
+        with torch.no_grad():
+            mlp_te.fc1.weight.copy_(mlp_native.fc1.weight.reshape(mlp_te.fc1.weight.shape))
+            mlp_te.fc2.weight.copy_(mlp_native.fc2.weight.reshape(mlp_te.fc2.weight.shape))
+            if mlp_native.fc1.bias is not None:
+                mlp_te.fc1.bias.copy_(mlp_native.fc1.bias)
+            if mlp_native.fc2.bias is not None:
+                mlp_te.fc2.bias.copy_(mlp_native.fc2.bias)
+
+        # identical input to both modules
+        if input_format == "nchw":
+            inp = torch.randn((B, C, H, W), dtype=torch.float32, device=self.device)
+        else:
+            inp = torch.randn((B, H * W, C), dtype=torch.float32, device=self.device)
+
+        inp_native = inp.clone().requires_grad_(True)
+        inp_te = inp.clone().requires_grad_(True)
+
+        # FWD
+        out_native = mlp_native(inp_native)
+        out_te = mlp_te(inp_te)
+
+        # BWD with identical upstream grad
+        ograd = torch.randn_like(out_native)
+        out_native.backward(ograd)
+        out_te.backward(ograd.clone())
+
+        with self.subTest(desc="te output"):
+            self.assertTrue(reduce_success(compare_tensors("te output", out_te, out_native, tol, tol, verbose=verbose), self.device))
+
+        with self.subTest(desc="te input gradients"):
+            self.assertTrue(reduce_success(compare_tensors("te input gradients", inp_te.grad, inp_native.grad, tol, tol, verbose=verbose), self.device))
+
+        with self.subTest(desc="te fc1 weight gradients"):
+            te_wgrad = mlp_te.fc1.weight.grad.reshape(mlp_native.fc1.weight.grad.shape)
+            self.assertTrue(reduce_success(compare_tensors("te fc1 weight gradients", te_wgrad, mlp_native.fc1.weight.grad, tol, tol, verbose=verbose), self.device))
+
+        with self.subTest(desc="te fc2 weight gradients"):
+            te_wgrad = mlp_te.fc2.weight.grad.reshape(mlp_native.fc2.weight.grad.shape)
+            self.assertTrue(reduce_success(compare_tensors("te fc2 weight gradients", te_wgrad, mlp_native.fc2.weight.grad, tol, tol, verbose=verbose), self.device))
+
+        if bias:
+            with self.subTest(desc="te fc2 bias gradients"):
+                self.assertTrue(reduce_success(compare_tensors("te fc2 bias gradients", mlp_te.fc2.bias.grad, mlp_native.fc2.bias.grad, tol, tol, verbose=verbose), self.device))
 
 
 if __name__ == '__main__':

--- a/tests/distributed/tests_distributed_layers.py
+++ b/tests/distributed/tests_distributed_layers.py
@@ -464,29 +464,35 @@ class TestDistributedLayers(unittest.TestCase):
     @unittest.skipUnless(_TE_AVAILABLE and torch.cuda.is_available(), "transformer_engine (with CUDA) is not available")
     @parameterized.expand(
         [
-            # nlat, nlon, batch, channels, hidden, input_format, bias, tol
-            [32, 64, 2, 16, 64, "nchw", True, 1e-3],
-            [32, 64, 2, 16, 64, "nchw", False, 1e-3],
-            [1, 64, 2, 16, 64, "traditional", True, 1e-3],
+            # nlat, nlon, batch, channels, hidden, input_format, bias, amp_mode, atol, rtol
+            [32, 64, 2, 16, 64, "nchw", True, "bf16", 4e-2, 4e-2],
+            [32, 64, 2, 16, 64, "nchw", True, "fp16", 2e-2, 2e-2],
+            [32, 64, 2, 16, 64, "nchw", False, "bf16", 4e-2, 4e-2],
+            [1, 64, 2, 16, 64, "traditional", True, "bf16", 4e-2, 4e-2],
+            [1, 64, 2, 16, 64, "traditional", True, "fp16", 2e-2, 2e-2],
         ],
         skip_on_empty=True,
     )
-    def test_distributed_mlp_te(self, nlat, nlon, batch_size, num_chan, hidden_dim, input_format, bias, tol, verbose=True):
-        """The transformer-engine MLP path must match the native distributed MLP.
+    def test_distributed_mlp_te(self, nlat, nlon, batch_size, num_chan, hidden_dim, input_format, bias, amp_mode, atol, rtol, verbose=True):
+        """The transformer-engine MLP path must match the native distributed MLP under
+        the same (reduced) precision.
 
-        ``use_te`` only swaps the local GEMM for a ``te.Linear`` (FP8 disabled here,
-        so it runs in fp32) while the column/row tensor-parallel communication and
-        the bias-after-reduce semantics stay in makani. We therefore compare the TE
-        and native ``DistributedMLP`` rank-locally (same comm setup, same weights):
-        output, input grad and per-layer weight grad must agree. This exercises the
-        nchw channels-last transpose, the row-parallel bias placement and the
-        ``weight`` property wiring under whatever h x w x matmul grid is launched.
+        ``use_te`` only swaps the local GEMM for a ``te.Linear`` while the column/row
+        tensor-parallel communication and the bias-after-reduce semantics stay in
+        makani. We build the TE and native ``DistributedMLP`` with identical weights and
+        run both forward passes inside the SAME ``autocast(bf16/fp16)`` context, then
+        compare rank-locally: output, input grad and per-layer weight grad must agree.
+        Running both sides at the same precision is the fair comparison (te.Linear has no
+        fp32 compute path); the residual gap is the te.Linear-vs-conv2d/linear kernel
+        difference at bf16/fp16, hence the loose, precision-appropriate tolerances. A
+        wiring bug (bad transpose/bias/reduction) would produce O(1) errors instead.
         """
         # column-parallel fc1 shards the hidden dim over the matmul group
         if hidden_dim % comm.get_size("matmul") != 0:
             self.skipTest(f"hidden_dim {hidden_dim} not divisible by matmul size {comm.get_size('matmul')}")
 
         B, C, H, W = batch_size, num_chan, nlat, nlon
+        amp_dtype = torch.bfloat16 if amp_mode == "bf16" else torch.float16
 
         set_seed(333)
 
@@ -504,9 +510,10 @@ class TestDistributedLayers(unittest.TestCase):
         mlp_native = DistributedMLP(**common, use_te=False).to(self.device)
         mlp_te = DistributedMLP(**common, use_te=True).to(self.device)
 
-        # copy the native weights/biases into the te module so the only difference
-        # is the GEMM implementation. the te weight is always 2D (out_local, in_local);
-        # the native nchw weight is the same values with trailing singleton dims.
+        # copy the native weights/biases into the te module so the only difference is the
+        # GEMM implementation. params stay fp32; autocast casts them on the fly. the te
+        # weight is always 2D (out_local, in_local); the native nchw weight has trailing
+        # singleton dims.
         with torch.no_grad():
             mlp_te.fc1.weight.copy_(mlp_native.fc1.weight.reshape(mlp_te.fc1.weight.shape))
             mlp_te.fc2.weight.copy_(mlp_native.fc2.weight.reshape(mlp_te.fc2.weight.shape))
@@ -524,32 +531,35 @@ class TestDistributedLayers(unittest.TestCase):
         inp_native = inp.clone().requires_grad_(True)
         inp_te = inp.clone().requires_grad_(True)
 
-        # FWD
-        out_native = mlp_native(inp_native)
-        out_te = mlp_te(inp_te)
+        # FWD under a shared bf16/fp16 autocast so both GEMMs run at the same precision
+        with torch.autocast(device_type="cuda", dtype=amp_dtype):
+            out_native = mlp_native(inp_native)
+        with torch.autocast(device_type="cuda", dtype=amp_dtype):
+            out_te = mlp_te(inp_te)
 
-        # BWD with identical upstream grad
+        # BWD with identical upstream grad (backward runs outside autocast)
         ograd = torch.randn_like(out_native)
         out_native.backward(ograd)
         out_te.backward(ograd.clone())
 
+        # cast to fp32 for the comparison (grads are fp32 already; outputs are low precision)
         with self.subTest(desc="te output"):
-            self.assertTrue(reduce_success(compare_tensors("te output", out_te, out_native, tol, tol, verbose=verbose), self.device))
+            self.assertTrue(reduce_success(compare_tensors("te output", out_te.float(), out_native.float(), atol, rtol, verbose=verbose), self.device))
 
         with self.subTest(desc="te input gradients"):
-            self.assertTrue(reduce_success(compare_tensors("te input gradients", inp_te.grad, inp_native.grad, tol, tol, verbose=verbose), self.device))
+            self.assertTrue(reduce_success(compare_tensors("te input gradients", inp_te.grad, inp_native.grad, atol, rtol, verbose=verbose), self.device))
 
         with self.subTest(desc="te fc1 weight gradients"):
             te_wgrad = mlp_te.fc1.weight.grad.reshape(mlp_native.fc1.weight.grad.shape)
-            self.assertTrue(reduce_success(compare_tensors("te fc1 weight gradients", te_wgrad, mlp_native.fc1.weight.grad, tol, tol, verbose=verbose), self.device))
+            self.assertTrue(reduce_success(compare_tensors("te fc1 weight gradients", te_wgrad, mlp_native.fc1.weight.grad, atol, rtol, verbose=verbose), self.device))
 
         with self.subTest(desc="te fc2 weight gradients"):
             te_wgrad = mlp_te.fc2.weight.grad.reshape(mlp_native.fc2.weight.grad.shape)
-            self.assertTrue(reduce_success(compare_tensors("te fc2 weight gradients", te_wgrad, mlp_native.fc2.weight.grad, tol, tol, verbose=verbose), self.device))
+            self.assertTrue(reduce_success(compare_tensors("te fc2 weight gradients", te_wgrad, mlp_native.fc2.weight.grad, atol, rtol, verbose=verbose), self.device))
 
         if bias:
             with self.subTest(desc="te fc2 bias gradients"):
-                self.assertTrue(reduce_success(compare_tensors("te fc2 bias gradients", mlp_te.fc2.bias.grad, mlp_native.fc2.bias.grad, tol, tol, verbose=verbose), self.device))
+                self.assertTrue(reduce_success(compare_tensors("te fc2 bias gradients", mlp_te.fc2.bias.grad, mlp_native.fc2.bias.grad, atol, rtol, verbose=verbose), self.device))
 
 
 if __name__ == '__main__':

--- a/tests/distributed/tests_distributed_metrics.py
+++ b/tests/distributed/tests_distributed_metrics.py
@@ -92,8 +92,8 @@ class TestDistributedMetricHandler(unittest.TestCase):
 
         # init groups
         comm.init(
-            model_parallel_sizes=[self.grid_size_h, self.grid_size_w, 1, 1],
-            model_parallel_names=["h", "w", "fin", "fout"],
+            model_parallel_sizes=[self.grid_size_h, self.grid_size_w, 1],
+            model_parallel_names=["h", "w", "matmul"],
             data_parallel_sizes=[self.grid_size_e, self.grid_size_b],
             data_parallel_names=["ensemble", "batch"],
         )

--- a/tests/distributed/tests_distributed_model.py
+++ b/tests/distributed/tests_distributed_model.py
@@ -91,13 +91,14 @@ class TestDistributedModel(unittest.TestCase):
         # set up distributed
         self.grid_size_h = int(os.getenv("GRID_H", 1))
         self.grid_size_w = int(os.getenv("GRID_W", 1))
+        self.grid_size_m = int(os.getenv("GRID_M", 1))
         self.grid_size_e = int(os.getenv("GRID_E", 1))
-        self.world_size = self.grid_size_h * self.grid_size_w * self.grid_size_e
+        self.world_size = self.grid_size_h * self.grid_size_w * self.grid_size_m * self.grid_size_e
 
         # init groups
         comm.init(
-            model_parallel_sizes=[self.grid_size_h, self.grid_size_w, 1, 1],
-            model_parallel_names=["h", "w", "fin", "fout"],
+            model_parallel_sizes=[self.grid_size_h, self.grid_size_w, self.grid_size_m],
+            model_parallel_names=["h", "w", "matmul"],
             data_parallel_sizes=[self.grid_size_e, -1],
             data_parallel_names=["ensemble", "batch"],
         )


### PR DESCRIPTION
This MR does the following things:

- it retires the fin-fout matmul parallelization in favor of a more restrictive but much more simple Megatron style fork-join parallelism. The only network which supported the former (SFNO) was reworked to support the Megatron formalism.
- this change allows us to use transformer engine as drop-in replacement for MLP
- this allows us to add auto casting for FP8 and lower precision. This is handled by the new precision context managers.