### PR TITLE
Resolve all anchors when loading YAML

### DIFF
--- a/config/pangu.yaml
+++ b/config/pangu.yaml
@@ -27,9 +27,9 @@ base_config: &BASE_CONFIG
     num_atmospheric: 5
     num_levels: 13
     embed_dim: 96
-    patch_size: !!python/tuple [2,4,4]
-    depth_layers: !!python/tuple [2,6,6,2]
-    num_heads: !!python/tuple [6,12,12,6]
+    patch_size: [2,4,4]
+    depth_layers: [2,6,6,2]
+    num_heads: [6,12,12,6]
 
     # training parameters
     losses:

--- a/makani/utils/YParams.py
+++ b/makani/utils/YParams.py
@@ -92,7 +92,7 @@ class YParams(ParamsBase):
             print("------------------ Configuration ------------------")
 
         with open(yaml_filename) as _file:
-            token = YAML().load(_file)
+            token = YAML(typ="safe").load(_file)
             if config_name is not None:
                 d = token[config_name]
             else:


### PR DESCRIPTION
This is a small one, may be useful for complex config files.

The default way of loading the config YAML preserves the YAML anchors in the data structure. However, if you’re nesting YAML anchors deep enough, the serialiser sometimes produces invalid YAML files with incorrect anchors. This is not great when trying to resume a training run from the config file saved alongside checkpoints.

This change makes the YAML parser resolve all anchors when _reading_ the file, which results in a plain data structure without anchors, and that gets serialised correctly in all cases. That’s probably what you’d want anyway for training runs – a fully instantiated yaml config for that run.