### PR TITLE
ci: run tests on pull_request and allow manual dispatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: tests
 
-on: [push]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
The workflow only triggered on `push`, which fires solely for branches in this repository. Pull requests from forks push to the fork, so NVIDIA/makani never saw an event for them and no checks ran at all -- PRs #155 and #156 both report "no checks reported", and every run in the history is event=push on an internal branch.

`pull_request` checks out the merge commit and runs with a read-only token and no secrets, which is all this workflow needs (install deps, run pytest). Note this is deliberately broader than torch-harmonics' tests.yml, which is push-only; `workflow_dispatch` and the block form follow that repo's convention.