### PR TITLE
Tkurth/fix coherence regularization

### DIFF
--- a/makani/utils/losses/energy_score.py
+++ b/makani/utils/losses/energy_score.py
@@ -634,9 +634,13 @@ class SpectralCoherenceLoss(SpectralBaseLoss):
         lm_weights = torch.ones((self.sht.lmax, self.sht.mmax))
         lm_weights[:, 1:] *= 2.0
         lm_weights = torch.where(ms > ls, 0.0, lm_weights)
-        if comm.get_size("h") > 1:
+        # Guard on spatial_distributed, not just the group size: the SHT above is only
+        # the distributed one when spatial_distributed is set, so slicing the weights
+        # whenever an h/w group happens to exist would pair local weights with
+        # full-size coefficients. forward() reduces under the same condition.
+        if self.spatial_distributed and comm.get_size("h") > 1:
             lm_weights = split_tensor_along_dim(lm_weights, dim=-2, num_chunks=comm.get_size("h"))[comm.get_rank("h")]
-        if comm.get_size("w") > 1:
+        if self.spatial_distributed and comm.get_size("w") > 1:
             lm_weights = split_tensor_along_dim(lm_weights, dim=-1, num_chunks=comm.get_size("w"))[comm.get_rank("w")]
         lm_weights = lm_weights.contiguous()
 

--- a/makani/utils/losses/regularization.py
+++ b/makani/utils/losses/regularization.py
@@ -202,21 +202,33 @@ class CoherenceRegularization(SpectralBaseLoss):
     """
     Mesoscale spectral coherence regularization for ensemble forecasts.
 
-    Penalizes low squared coherence between each ensemble member and the
-    observation in a configurable wavenumber band [l_min, l_max], targeting
-    the mesoscale range where decorrelated noise tends to appear.
+    Penalizes low coherence between each ensemble member and the observation in
+    a configurable wavenumber band [lmin, lmax], targeting the mesoscale range
+    where decorrelated noise tends to appear.
 
-    For each wavenumber l in the band, the multivariate squared coherence is:
+    For each wavenumber l in the band, the coherence is:
 
-        CrossPSD_l  = sum_{c,m} w_m * Re( f^(e)_{c,l,m} * conj(y_{c,l,m}) )
-        PSD^f_l     = sum_{c,m} w_m * |f^(e)_{c,l,m}|^2
-        PSD^y_l     = sum_{c,m} w_m * |y_{c,l,m}|^2
-        Coh_l       = CrossPSD_l^2 / (PSD^f_l * PSD^y_l + eps)
+        CrossPSD_l  = sum_{m} w_m * Re( f^(e)_{c,l,m} * conj(y_{c,l,m}) )
+        PSD^f_l     = sum_{m} w_m * |f^(e)_{c,l,m}|^2
+        PSD^y_l     = sum_{m} w_m * |y_{c,l,m}|^2
+        Coh_l       = CrossPSD_l / sqrt(PSD^f_l * PSD^y_l + eps)
 
     Loss = (1 / |band|) * sum_{l in band} (1 - mean_{e} Coh_l^(e))
 
-    Optionally adds an inter-member coherence penalty (ensemble-ensemble)
-    to discourage fully independent phases between members.
+    The coherence is signed and lies in [-1, 1], so the loss is 0 for a member
+    that matches the observation, 1 for an uncorrelated one, and 2 for a
+    sign-flipped one. This deliberately follows SpectralCoherenceLoss rather
+    than the sign-blind magnitude-squared convention: squaring would score a
+    perfectly anti-correlated forecast as well as a perfect one.
+
+    Sums run over m only, not over channels: the loss framework expects one
+    value per channel (see ``SpectralBaseLoss.n_channels``) so that channel
+    weighting can be applied downstream.
+
+    When ``ensemble_coherence_weight`` is non-zero, an inter-member term
+    ``w * mean_{e != e'} (1 - Coh^(e,e'))`` is added to discourage fully
+    independent phases between members. It requires at least two members and is
+    skipped otherwise.
     """
 
     def __init__(
@@ -255,8 +267,12 @@ class CoherenceRegularization(SpectralBaseLoss):
         else:
             self.ensemble_weights = ensemble_weights
 
-        # clamp band to available wavenumbers
+        # clamp band to available wavenumbers. The upper edge is enforced by the SHT
+        # itself: lmax is passed to super().__init__, so self.sht.lmax is already the
+        # truncation. Only the lower edge needs an explicit mask.
         self.lmin = lmin if lmin is not None else 0
+        if self.lmin >= self.sht.lmax:
+            raise ValueError(f"Error, lmin ({self.lmin}) must be smaller than the SHT truncation lmax ({self.sht.lmax}), otherwise the band is empty.")
 
         # m-summation weights: 1 for m=0, 2 for m>0, 0 for m>l
         ls = torch.arange(self.sht.lmax).reshape(-1, 1)
@@ -270,6 +286,11 @@ class CoherenceRegularization(SpectralBaseLoss):
         l_band = torch.zeros(self.sht.lmax)
         l_band[self.lmin : self.sht.lmax] = 1.0
 
+        # Number of wavenumbers in the band, captured BEFORE the spatial split so it is
+        # the global width. Normalizing by this makes the loss a mean over the band and
+        # therefore independent of both the band width and the h-decomposition.
+        band_size = l_band.sum().clamp(min=1.0)
+
         # split for spatial distribution (l -> h, m -> w)
         if self.spatial_distributed and comm.get_size("h") > 1:
             m_weights = split_tensor_along_dim(m_weights, dim=-2, num_chunks=comm.get_size("h"))[comm.get_rank("h")]
@@ -279,6 +300,7 @@ class CoherenceRegularization(SpectralBaseLoss):
 
         self.register_buffer("m_weights", m_weights.contiguous(), persistent=False)
         self.register_buffer("l_band", l_band.contiguous(), persistent=False)
+        self.register_buffer("band_size", band_size, persistent=False)
 
     @property
     def type(self):
@@ -312,38 +334,57 @@ class CoherenceRegularization(SpectralBaseLoss):
 
         num_ensemble = forecasts.shape[0]
 
-        # PSD per member: sum over c and m -> (E, B, C, L)
+        # per-member PSD, observation PSD and the forecast-observation cross-PSD.
+        # Summing over m only leaves (E, B, C, L); channels are kept so that the
+        # framework can weight them downstream.
         psd_fcasts = (m_weights_local * forecasts.abs().square()).sum(dim=-1)
         psd_obs = (m_weights_local * observations.abs().square()).sum(dim=-1)
+        cross_psd = (m_weights_local * (forecasts.conj() * observations).real).sum(dim=-1)
 
-        # compute inter-member coherence (E, E, B, C, L)
-        coh_fcasts = (m_weights_local * (forecasts.unsqueeze(0).conj() * forecasts.unsqueeze(1)).real).sum(dim=-1)
+        # the inter-member term is optional and undefined for a single member
+        compute_inter = (self.ensemble_coherence_weight != 0.0) and (num_ensemble > 1)
+        if compute_inter:
+            coh_inter = (m_weights_local * (forecasts.unsqueeze(0).conj() * forecasts.unsqueeze(1)).real).sum(dim=-1)
 
-        # do the reduction over the distributed m dimensions
+        # do the reduction over the distributed m dimensions. This has to happen before
+        # the normalization below, since a ratio of partial sums is not the partial sum
+        # of ratios.
         if self.spatial_distributed and comm.get_size("w") > 1:
             psd_fcasts = reduce_from_parallel_region(psd_fcasts, "w")
             psd_obs = reduce_from_parallel_region(psd_obs, "w")
-            coh_fcasts = reduce_from_parallel_region(coh_fcasts, "w")
+            cross_psd = reduce_from_parallel_region(cross_psd, "w")
+            if compute_inter:
+                coh_inter = reduce_from_parallel_region(coh_inter, "w")
 
         if self.ensemble_distributed:
             psd_fcasts = reduce_from_parallel_region(psd_fcasts, "ensemble")
             psd_obs = reduce_from_parallel_region(psd_obs, "ensemble")
-            coh_fcasts = reduce_from_parallel_region(coh_fcasts, "ensemble")
+            cross_psd = reduce_from_parallel_region(cross_psd, "ensemble")
+            if compute_inter:
+                coh_inter = reduce_from_parallel_region(coh_inter, "ensemble")
 
-        # normalize by the power-spectral densities
-        coh_fcasts = 1.0 - coh_fcasts / torch.sqrt(psd_fcasts.unsqueeze(0) * psd_fcasts.unsqueeze(1) + self.eps)
+        # signed coherence in [-1, 1] against the observation
+        coh_obs = cross_psd / torch.sqrt(psd_fcasts * psd_obs + self.eps)
 
-        # just to be sure, mask the diagonal of the coherence with 0.0
-        coh_fcasts = psd_obs.unsqueeze(0) * torch.where(torch.eye(num_ensemble, device=coh_fcasts.device).bool().reshape(num_ensemble, num_ensemble, 1, 1, 1), 0.0, coh_fcasts)
+        # (1 - Coh) averaged over the ensemble -> (B, C, L)
+        loss = (1.0 - coh_obs).sum(dim=0) / float(num_ensemble)
 
-        # reduce over the leading ensemble dims to compute the mean coherence
-        coh_fcasts = coh_fcasts.sum(dim=(0, 1)) / float(num_ensemble * (num_ensemble - 1))
+        # optional inter-member decoherence penalty, diagonal excluded
+        if compute_inter:
+            coh_inter = coh_inter / torch.sqrt(psd_fcasts.unsqueeze(0) * psd_fcasts.unsqueeze(1) + self.eps)
+            eye = torch.eye(num_ensemble, device=coh_inter.device).bool().reshape(num_ensemble, num_ensemble, 1, 1, 1)
+            coh_inter = torch.where(eye, 0.0, 1.0 - coh_inter)
+            coh_inter = coh_inter.sum(dim=(0, 1)) / float(num_ensemble * (num_ensemble - 1))
+            loss = loss + self.ensemble_coherence_weight * coh_inter
 
-        # finally do the reduction over the l dimensions
-        coh_fcasts = coh_fcasts.sum(dim=-1)
+        # restrict to the configured wavenumber band and reduce over l
+        loss = (self.l_band * loss).sum(dim=-1)
 
         # reduce over the spatial dimensions
         if self.spatial_distributed and comm.get_size("h") > 1:
-            coh_fcasts = reduce_from_parallel_region(coh_fcasts, "h")
+            loss = reduce_from_parallel_region(loss, "h")
 
-        return coh_fcasts
+        # normalize to a mean over the band
+        loss = loss / self.band_size
+
+        return loss

--- a/makani/utils/losses/regularization.py
+++ b/makani/utils/losses/regularization.py
@@ -126,10 +126,14 @@ class SpectralRegularization(SpectralBaseLoss):
         lm_weights[:, 1:] *= 2.0
         lm_weights = torch.where(ms > ls, 0.0, lm_weights)
 
-        if comm.get_size("h") > 1:
+        # Guard on spatial_distributed, not just the group size: the SHT above is only
+        # the distributed one when spatial_distributed is set, so slicing the weights
+        # whenever an h/w group happens to exist would pair local weights with
+        # full-size coefficients. forward() reduces under the same condition.
+        if self.spatial_distributed and comm.get_size("h") > 1:
             lm_weights = split_tensor_along_dim(lm_weights, dim=-2, num_chunks=comm.get_size("h"))[comm.get_rank("h")]
 
-        if comm.get_size("w") > 1:
+        if self.spatial_distributed and comm.get_size("w") > 1:
             lm_weights = split_tensor_along_dim(lm_weights, dim=-1, num_chunks=comm.get_size("w"))[comm.get_rank("w")]
 
         self.register_buffer("lm_weights", lm_weights, persistent=False)

--- a/tests/distributed/tests_distributed_losses.py
+++ b/tests/distributed/tests_distributed_losses.py
@@ -32,7 +32,9 @@ from makani.utils.losses import (
     LpEnergyScoreLoss,
     SpectralL2EnergyScoreLoss,
     SobolevEnergyScoreLoss,
+    CoherenceRegularization,
 )
+from makani.utils.losses.energy_score import SpectralCoherenceLoss
 
 # Add parent directory to path for testutils import
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
@@ -621,6 +623,220 @@ class TestDistributedLoss(unittest.TestCase):
             fraction=fraction,
             eps=1.0e-6,
         ).to(self.device)
+
+        #############################################################
+        # local loss
+        #############################################################
+        forecasts_full.requires_grad = True
+        obs_full.requires_grad = True
+        loss_full = loss_fn_local(forecasts_full, obs_full)
+
+        with torch.no_grad():
+            ograd_full = torch.randn_like(loss_full)
+            ograd_local = ograd_full.clone()
+
+        loss_full.backward(ograd_full)
+        fgrad_full = forecasts_full.grad.clone()
+        obsgrad_full = obs_full.grad.clone()
+
+        #############################################################
+        # distributed loss
+        #############################################################
+        forecasts_local = self._split_helper(forecasts_full.clone())
+        obs_local = self._split_helper(obs_full.clone())
+        forecasts_local.requires_grad = True
+        obs_local.requires_grad = True
+
+        loss_local = loss_fn_dist(forecasts_local, obs_local)
+        loss_local.backward(ograd_local)
+        fgrad_local = forecasts_local.grad.clone()
+        obsgrad_local = obs_local.grad.clone()
+
+        #############################################################
+        # evaluate FWD pass
+        #############################################################
+        with self.subTest(desc="outputs"):
+            self.assertTrue(reduce_success(compare_tensors("outputs", loss_local, loss_full, tol, tol, verbose=verbose), self.device))
+
+        #############################################################
+        # evaluate BWD pass
+        #############################################################
+        with self.subTest(desc="forecast gradients"):
+            fgrad_gather_full = self._gather_helper_bwd(fgrad_local, True)
+            self.assertTrue(reduce_success(compare_tensors("forecast gradients", fgrad_gather_full, fgrad_full, tol, tol, verbose=verbose), self.device))
+
+        with self.subTest(desc="observation gradients"):
+            obsgrad_gather_full = self._gather_helper_bwd(obsgrad_local, False)
+            self.assertTrue(reduce_success(compare_tensors("observation gradients", obsgrad_gather_full, obsgrad_full, tol, tol, verbose=verbose), self.device))
+
+
+    @parameterized.expand(
+        [
+            # nlat, nlon, batch, chans, ens, lmin, ens_coh_weight, tol
+            [128, 256, 8, 13, 4, 0, 0.0, 1e-4],
+            [129, 256, 2, 12, 4, 16, 0.0, 1e-4],
+            [129, 256, 2, 12, 4, 16, 0.5, 1e-4],
+        ], skip_on_empty=True
+    )
+    def test_distributed_coherence_regularization(self, nlat, nlon, batch_size, num_chan, ens_size, lmin, ens_coh_weight, tol, verbose=True):
+        """Local vs distributed equivalence for CoherenceRegularization.
+
+        The lmin > 0 cases matter most: the wavenumber-band mask is split along h
+        exactly like the SHT's l dimension, and the band width used to normalize
+        is the global one, so a mismatch between the two would show up here as a
+        forward discrepancy. The ens_coh_weight case additionally exercises the
+        inter-member term, which is formed after the ensemble transpose.
+        """
+
+        # disable tf32 for deterministic comparison
+        disable_tf32()
+
+        # shapes
+        B, E, C, H, W = batch_size, ens_size, num_chan, nlat, nlon
+
+        mean, sigma = (1.0, 2.0)
+        forecasts_full = torch.randn((B, E, C, H, W), dtype=torch.float32, device=self.device) * sigma + mean
+        obs_full = torch.randn((B, C, H, W), dtype=torch.float32, device=self.device) * sigma * 0.01 + mean
+
+        # local loss
+        loss_fn_local = CoherenceRegularization(
+            img_shape=(H, W),
+            crop_shape=None,
+            crop_offset=(0, 0),
+            channel_names=(),
+            grid_type="equiangular",
+            lmin=lmin,
+            ensemble_coherence_weight=ens_coh_weight,
+            eps=1.0e-3,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            ensemble_weights=None,
+        ).to(self.device)
+
+        # distributed loss
+        loss_fn_dist = CoherenceRegularization(
+            img_shape=(H, W),
+            crop_shape=None,
+            crop_offset=(0, 0),
+            channel_names=(),
+            grid_type="equiangular",
+            lmin=lmin,
+            ensemble_coherence_weight=ens_coh_weight,
+            eps=1.0e-3,
+            spatial_distributed=(comm.is_distributed("spatial") and (comm.get_size("spatial") > 1)),
+            ensemble_distributed=(comm.is_distributed("ensemble") and (comm.get_size("ensemble") > 1)),
+            ensemble_weights=None,
+        ).to(self.device)
+
+        # the band width is a global quantity and must agree across the decomposition
+        with self.subTest(desc="band size"):
+            self.assertEqual(loss_fn_local.band_size.item(), loss_fn_dist.band_size.item())
+
+        #############################################################
+        # local loss
+        #############################################################
+        forecasts_full.requires_grad = True
+        obs_full.requires_grad = True
+        loss_full = loss_fn_local(forecasts_full, obs_full)
+
+        with torch.no_grad():
+            ograd_full = torch.randn_like(loss_full)
+            ograd_local = ograd_full.clone()
+
+        loss_full.backward(ograd_full)
+        fgrad_full = forecasts_full.grad.clone()
+        obsgrad_full = obs_full.grad.clone()
+
+        #############################################################
+        # distributed loss
+        #############################################################
+        forecasts_local = self._split_helper(forecasts_full.clone())
+        obs_local = self._split_helper(obs_full.clone())
+        forecasts_local.requires_grad = True
+        obs_local.requires_grad = True
+
+        loss_local = loss_fn_dist(forecasts_local, obs_local)
+        loss_local.backward(ograd_local)
+        fgrad_local = forecasts_local.grad.clone()
+        obsgrad_local = obs_local.grad.clone()
+
+        #############################################################
+        # evaluate FWD pass
+        #############################################################
+        with self.subTest(desc="outputs"):
+            self.assertTrue(reduce_success(compare_tensors("outputs", loss_local, loss_full, tol, tol, verbose=verbose), self.device))
+
+        #############################################################
+        # evaluate BWD pass
+        #############################################################
+        with self.subTest(desc="forecast gradients"):
+            fgrad_gather_full = self._gather_helper_bwd(fgrad_local, True)
+            self.assertTrue(reduce_success(compare_tensors("forecast gradients", fgrad_gather_full, fgrad_full, tol, tol, verbose=verbose), self.device))
+
+        with self.subTest(desc="observation gradients"):
+            obsgrad_gather_full = self._gather_helper_bwd(obsgrad_local, False)
+            self.assertTrue(reduce_success(compare_tensors("observation gradients", obsgrad_gather_full, obsgrad_full, tol, tol, verbose=verbose), self.device))
+
+
+    @parameterized.expand(
+        [
+            [128, 256, 8, 13, 4, False, 1e-4],
+            [129, 256, 2, 12, 4, True, 1e-4],
+        ], skip_on_empty=True
+    )
+    def test_distributed_spectral_coherence_loss(self, nlat, nlon, batch_size, num_chan, ens_size, relative, tol, verbose=True):
+        """Local vs distributed equivalence for SpectralCoherenceLoss.
+
+        This could not be written before: the reference instance is built with
+        spatial_distributed=False while h/w groups are >1, and __init__ used to
+        slice lm_weights on group size alone, pairing local weights with the
+        full-size coefficients of the non-distributed SHT.
+        """
+
+        # disable tf32 for deterministic comparison
+        disable_tf32()
+
+        # shapes
+        B, E, C, H, W = batch_size, ens_size, num_chan, nlat, nlon
+
+        mean, sigma = (1.0, 2.0)
+        forecasts_full = torch.randn((B, E, C, H, W), dtype=torch.float32, device=self.device) * sigma + mean
+        obs_full = torch.randn((B, C, H, W), dtype=torch.float32, device=self.device) * sigma * 0.01 + mean
+
+        # local loss
+        loss_fn_local = SpectralCoherenceLoss(
+            img_shape=(H, W),
+            crop_shape=None,
+            crop_offset=(0, 0),
+            channel_names=(),
+            grid_type="equiangular",
+            relative=relative,
+            channel_reduction=False,
+            eps=1.0e-3,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            ensemble_weights=None,
+        ).to(self.device)
+
+        # distributed loss
+        loss_fn_dist = SpectralCoherenceLoss(
+            img_shape=(H, W),
+            crop_shape=None,
+            crop_offset=(0, 0),
+            channel_names=(),
+            grid_type="equiangular",
+            relative=relative,
+            channel_reduction=False,
+            eps=1.0e-3,
+            spatial_distributed=(comm.is_distributed("spatial") and (comm.get_size("spatial") > 1)),
+            ensemble_distributed=(comm.is_distributed("ensemble") and (comm.get_size("ensemble") > 1)),
+            ensemble_weights=None,
+        ).to(self.device)
+
+        # the non-distributed instance must keep full-size weights regardless of
+        # whether h/w groups exist; this is the regression guard for the split
+        with self.subTest(desc="local weights are not split"):
+            self.assertEqual(tuple(loss_fn_local.lm_weights.shape), (loss_fn_local.sht.lmax, loss_fn_local.sht.mmax))
 
         #############################################################
         # local loss

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -37,6 +37,7 @@ from makani.utils.losses import (
     SpectralAMSELoss,
     DriftRegularization,
     SpectralRegularization,
+    CoherenceRegularization,
     EnsembleNLLLoss,
     LpEnergyScoreLoss,
     SpectralL2EnergyScoreLoss,
@@ -3379,6 +3380,187 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
         self.assertIsNotNone(fc.grad)
         self.assertFalse(torch.isnan(fc.grad).any(), f"{name}: NaN grad in E=1 backward")
         self.assertFalse(torch.isinf(fc.grad).any(), f"{name}: Inf grad in E=1 backward")
+
+
+class TestCoherenceRegularization(unittest.TestCase):
+    """Tests for CoherenceRegularization.
+
+    The loss penalizes low spectral coherence between each ensemble member and
+    the observation over a wavenumber band:
+
+        Coh_l = CrossPSD_l / sqrt(PSD^f_l * PSD^y_l + eps)
+        Loss  = mean_{l in band} (1 - mean_e Coh_l)
+
+    Coherence is signed, so the loss has three reference points that anchor most
+    of the tests below:
+
+        f = +y  -> Coh = +1 -> loss 0    (perfectly correlated)
+        f random-> Coh ~  0 -> loss 1    (uncorrelated)
+        f = -y  -> Coh = -1 -> loss 2    (anti-correlated)
+
+    Several tests use a tiny eps. The default eps=1e-6 is a stabilizer that
+    biases the ratio toward 0 wherever the PSD is small, which pulls the loss
+    toward the "uncorrelated" value of 1: at eps=1e-6 the perfectly-correlated
+    case scores 0.086 rather than 0. That is fine for training but makes the
+    exact reference points untestable, so the analytic tests shrink eps.
+
+    This class also serves as the regression test for the three bugs reported in
+    issue #95, each marked below.
+    """
+
+    _E = 5
+
+    def setUp(self):
+        disable_tf32()
+        set_seed(333)
+
+    def _fn(self, **kw):
+        return CoherenceRegularization(
+            **_SPEC_KWARGS,
+            spatial_distributed=False,
+            ensemble_distributed=False,
+            **kw,
+        )
+
+    @staticmethod
+    def _broadcast(obs, ensemble, scale=1.0):
+        """Build an ensemble in which every member is ``scale * obs``."""
+        return scale * obs.unsqueeze(1).repeat(1, ensemble, 1, 1, 1)
+
+    # -- output-shape contract -----------------------------------------------
+
+    def test_output_shape(self):
+        out = self._fn()(_rand_ensemble(self._E), _rand())
+        self.assertEqual(tuple(out.shape), (_BATCH, _NUM_CH))
+
+    def test_n_channels_matches_output(self):
+        fn = self._fn()
+        self.assertEqual(fn.n_channels, _NUM_CH)
+        self.assertEqual(fn(_rand_ensemble(self._E), _rand()).shape[-1], fn.n_channels)
+
+    def test_wrong_forecast_dims_raises(self):
+        with self.assertRaises(ValueError):
+            self._fn()(_rand(), _rand())  # 4-D, missing ensemble dim
+
+    # -- analytic reference points -------------------------------------------
+
+    def test_fully_correlated_is_zero(self):
+        """f = y is perfect coherence, so the loss must vanish."""
+        obs = _rand()
+        out = self._fn(eps=1e-16)(self._broadcast(obs, self._E), obs)
+        self.assertTrue(torch.allclose(out, torch.zeros_like(out), atol=1e-3), f"expected 0, got mean {out.mean().item()}")
+
+    def test_anti_correlated_is_two(self):
+        """f = -y is coherence -1, so (1 - Coh) = 2.
+
+        This is the case that distinguishes the signed coherence used here from
+        the sign-blind magnitude-squared convention, which would score this
+        identically to a perfect forecast.
+        """
+        obs = _rand()
+        out = self._fn(eps=1e-16)(self._broadcast(obs, self._E, scale=-1.0), obs)
+        self.assertTrue(torch.allclose(out, 2.0 * torch.ones_like(out), atol=1e-3), f"expected 2, got mean {out.mean().item()}")
+
+    def test_uncorrelated_is_one(self):
+        """Independent forecasts have zero expected coherence, so the loss ~ 1.
+
+        This one is statistical rather than exact, hence the loose tolerance.
+        """
+        out = self._fn(eps=1e-16)(_rand_ensemble(self._E), _rand())
+        self.assertAlmostEqual(out.mean().item(), 1.0, delta=0.1)
+
+    def test_ordering_of_the_three_regimes(self):
+        """correlated < uncorrelated < anti-correlated, without tolerance games."""
+        obs = _rand()
+        fn = self._fn(eps=1e-16)
+        pos = fn(self._broadcast(obs, self._E), obs).mean().item()
+        rnd = fn(_rand_ensemble(self._E), obs).mean().item()
+        neg = fn(self._broadcast(obs, self._E, scale=-1.0), obs).mean().item()
+        self.assertLess(pos, rnd)
+        self.assertLess(rnd, neg)
+
+    def test_positive_scaling_is_invariant(self):
+        """Coherence is normalized, so f = a*y scores 0 for any a > 0."""
+        obs = _rand()
+        fn = self._fn(eps=1e-16)
+        for scale in (0.5, 1.0, 7.0):
+            out = fn(self._broadcast(obs, self._E, scale=scale), obs)
+            self.assertTrue(torch.allclose(out, torch.zeros_like(out), atol=1e-3), f"scale {scale}: expected 0, got {out.mean().item()}")
+
+    # -- issue #95 regressions ------------------------------------------------
+
+    def test_cross_psd_is_computed(self):
+        """Issue #95 bug 1: the forecast-observation cross-PSD must be used.
+
+        The previous implementation correlated forecasts with each other and
+        never formed the cross term, so flipping the sign of the forecast was
+        invisible to the loss. A sign flip must move the result by 2.
+        """
+        obs = _rand()
+        fn = self._fn(eps=1e-16)
+        pos = fn(self._broadcast(obs, self._E), obs)
+        neg = fn(self._broadcast(obs, self._E, scale=-1.0), obs)
+        self.assertTrue(torch.allclose(neg - pos, 2.0 * torch.ones_like(pos), atol=1e-3))
+
+    def test_loss_depends_on_observations(self):
+        """Issue #95 bug 1: swapping the observation must change the loss."""
+        fc = _rand_ensemble(self._E)
+        fn = self._fn()
+        self.assertFalse(torch.allclose(fn(fc, _rand()), fn(fc, _rand())))
+
+    def test_band_mask_is_applied(self):
+        """Issue #95 bug 2: lmin must restrict the wavenumber band.
+
+        Previously l_band was built and registered but never used in forward, so
+        lmin had no effect at all.
+        """
+        widths = [self._fn(lmin=lmin).band_size.item() for lmin in (0, 4, 8)]
+        self.assertEqual(widths, sorted(widths, reverse=True))
+        self.assertGreater(widths[0], widths[-1])
+
+    def test_band_mask_changes_the_loss(self):
+        """Issue #95 bug 2: a different band must give a different value."""
+        fc, obs = _rand_ensemble(self._E), _rand()
+        self.assertNotAlmostEqual(self._fn(lmin=0)(fc, obs).mean().item(), self._fn(lmin=8)(fc, obs).mean().item(), places=4)
+
+    def test_band_restricted_to_single_wavenumber(self):
+        fn = self._fn(lmin=14)
+        self.assertEqual(fn.band_size.item(), 1.0)
+        self.assertEqual(tuple(fn(_rand_ensemble(self._E), _rand()).shape), (_BATCH, _NUM_CH))
+
+    def test_empty_band_raises(self):
+        """lmin at or beyond the bandlimit would silently produce an empty band."""
+        with self.assertRaises(ValueError):
+            self._fn(lmin=10_000)
+
+    def test_ensemble_coherence_weight_is_applied(self):
+        """Issue #95 bug 3: the weight was stored but never read.
+
+        The inter-member term enters linearly, so the increment over the
+        weight=0 baseline must be proportional to the weight.
+        """
+        fc, obs = _rand_ensemble(self._E), _rand()
+        base = self._fn(ensemble_coherence_weight=0.0)(fc, obs)
+        d1 = self._fn(ensemble_coherence_weight=1.0)(fc, obs) - base
+        d2 = self._fn(ensemble_coherence_weight=2.0)(fc, obs) - base
+        self.assertFalse(torch.allclose(d1, torch.zeros_like(d1)))
+        self.assertTrue(torch.allclose(d2, 2.0 * d1, atol=1e-4))
+
+    # -- edge cases -----------------------------------------------------------
+
+    def test_single_member_skips_inter_member_term(self):
+        """E=1 would divide by E*(E-1)=0 if the inter-member term ran."""
+        out = self._fn(ensemble_coherence_weight=1.0)(_rand_ensemble(1), _rand())
+        self.assertEqual(tuple(out.shape), (_BATCH, _NUM_CH))
+        self.assertFalse(torch.isnan(out).any())
+        self.assertFalse(torch.isinf(out).any())
+
+    def test_backward_is_finite(self):
+        fc = _rand_ensemble(self._E, requires_grad=True)
+        self._fn(ensemble_coherence_weight=0.5)(fc, _rand()).sum().backward()
+        self.assertIsNotNone(fc.grad)
+        self.assertFalse(torch.isnan(fc.grad).any())
+        self.assertFalse(torch.isinf(fc.grad).any())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this fixes coherence regularization and addresses the concerns in https://github.com/NVIDIA/makani/issues/95. Also, anti-correlation will be punished more severely than uncorrelated results, which should be correct. In the old approach, perfectly anti-correlated results would minimize the loss.