### PR TITLE
Zero the spread term at E=1 for the energy-score losses (#96)

### DIFF
--- a/makani/utils/losses/energy_score.py
+++ b/makani/utils/losses/energy_score.py
@@ -209,7 +209,15 @@ class LpEnergyScoreLoss(GeometricBaseLoss):
         # mask and sum; factor of 2 accounts for symmetric (j,i) counterparts
         diff = torch.where(diff_mask, 0.0, diff)
         eskill = torch.where(eskill_mask, 0.0, eskill)
-        espread = diff.sum(dim=0) * 2.0 * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        # The spread is a sum over member pairs. With a single member that sum is empty
+        # and therefore zero, but the 1/(N^2 (N-1)) normalization is 0/0 and would turn
+        # the whole score into NaN. Degrade to the skill term instead, matching
+        # GaussianMMDLoss and the E=1 short-circuit in the CRPS losses.
+        espread = diff.sum(dim=0)
+        if num_ensemble > 1:
+            espread = espread * 2.0 * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        else:
+            espread = torch.zeros_like(espread)
 
         # sum over ensemble
         eskill = eskill.sum(dim=0) / float(num_ensemble)
@@ -407,7 +415,13 @@ class SobolevEnergyScoreLoss(SpectralBaseLoss):
         # mask espread and sum
         espread = torch.where(espread_mask, 0.0, espread)
         eskill = torch.where(eskill_mask, 0.0, eskill)
-        espread = espread.sum(dim=(0,1)) * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        # single member: the pair sum is empty, so the spread term vanishes rather than
+        # dividing 0/0. See the note in LpEnergyScoreLoss.forward.
+        espread = espread.sum(dim=(0,1))
+        if num_ensemble > 1:
+            espread = espread * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        else:
+            espread = torch.zeros_like(espread)
 
         # compute the skill term
         eskill = eskill.sum(dim=0) / float(num_ensemble)
@@ -572,7 +586,13 @@ class SpectralL2EnergyScoreLoss(SpectralBaseLoss):
         eskill = torch.where(eskill_mask, 0.0, eskill)
 
         # now we have reduced everything and need to sum appropriately (B, C, H)
-        espread = espread.sum(dim=(0,1)) * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        # single member: the pair sum is empty, so the spread term vanishes rather than
+        # dividing 0/0. See the note in LpEnergyScoreLoss.forward.
+        espread = espread.sum(dim=(0,1))
+        if num_ensemble > 1:
+            espread = espread * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        else:
+            espread = torch.zeros_like(espread)
         eskill = eskill.sum(dim=0) / float(num_ensemble)
 
         # we now have the loss per wavenumber, which we can normalize
@@ -744,7 +764,13 @@ class SpectralCoherenceLoss(SpectralBaseLoss):
 
         # mask the diagonal of coherence_spread with 0.0
         coherence_spread = torch.where(torch.eye(num_ensemble, device=coherence_forecasts.device).bool().reshape(num_ensemble, num_ensemble, 1, 1, 1), 0.0, 1.0 - coherence_forecasts)
-        coherence_spread = coherence_spread.sum(dim=(0, 1)) / float(num_ensemble * (num_ensemble - 1))
+        # single member: only the diagonal exists and it is masked out, so the spread is
+        # an empty sum. Guard the 1/(N (N-1)) normalization. See LpEnergyScoreLoss.forward.
+        coherence_spread = coherence_spread.sum(dim=(0, 1))
+        if num_ensemble > 1:
+            coherence_spread = coherence_spread / float(num_ensemble * (num_ensemble - 1))
+        else:
+            coherence_spread = torch.zeros_like(coherence_spread)
 
         # compute the loss
         if self.relative:
@@ -916,7 +942,13 @@ class CorrectedSpectralL2EnergyScoreLoss(SpectralBaseLoss):
         espread = torch.where(espread_mask, 0.0, espread)
         eskill = torch.where(eskill_mask, 0.0, eskill)
 
-        espread = espread.sum(dim=(0, 1)) * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        # single member: the pair sum is empty, so the spread term vanishes rather than
+        # dividing 0/0. See the note in LpEnergyScoreLoss.forward.
+        espread = espread.sum(dim=(0, 1))
+        if num_ensemble > 1:
+            espread = espread * (float(num_ensemble) - 1.0 + self.alpha) / float(num_ensemble * num_ensemble * (num_ensemble - 1))
+        else:
+            espread = torch.zeros_like(espread)
         eskill = eskill.sum(dim=0) / float(num_ensemble)
 
         # Option 2: spread term = P_true * (1 - Coh^ens) = (P_true / P_pred) * [P_pred * (1 - Coh^ens)]

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -3270,11 +3270,18 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
       - perfect prediction (single member == observation) gives zero loss
       - backward through the E=1 path produces finite gradients
 
-    Note: the energy-score family (LpEnergyScore, SobolevEnergyScore,
-    SpectralL2EnergyScore, CorrectedSpectralL2EnergyScore, SpectralCoherence)
-    and MMD do *not* have an E=1 fast-path — their spread terms divide by
-    N(N-1), so calling them with E=1 hits division-by-zero. That's a separate
-    concern (whether to add explicit guards or accept E>=2 as a precondition).
+    The energy-score family and the coherence losses are covered here too. They
+    have no fast path -- their structure is skill minus spread -- but their
+    spread terms divide by N(N-1), which is 0/0 at E=1 and used to make the whole
+    score NaN. Per issue #96 they now zero the spread instead, since a sum over
+    member pairs is empty when there is only one member, so the score degrades to
+    the skill term. GaussianMMDLoss already did this.
+
+    For those, ``test_e1_spread_term_vanishes`` is the semantic check: E=1 must
+    agree with a two-member ensemble of *identical* members, whose pairwise
+    spread is also zero. MMD is excluded from it because its spread is a kernel
+    sum rather than a difference sum -- k(x,x)=1, so identical members carry a
+    non-zero spread by construction, and only the E=1 empty-sum case is zero.
     """
 
     def setUp(self):
@@ -3313,6 +3320,36 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
             spatial_distributed=False, ensemble_distributed=False,
         )
 
+    # -- factories: the skill-minus-spread family (issue #96) ---------------
+    #
+    # eps is shrunk from its 1e-6 default for the two coherence losses: their
+    # spread is a ratio, and the eps floor keeps (1 - Coh) slightly above zero for
+    # identical members, which would otherwise mask the property under test.
+
+    def _lp_energy_score(self):
+        return LpEnergyScoreLoss(**_GEOM_KWARGS, p=2.0, spatial_distributed=False, ensemble_distributed=False)
+
+    def _sobolev_energy_score(self):
+        return SobolevEnergyScoreLoss(**_SPEC_KWARGS, spatial_distributed=False, ensemble_distributed=False)
+
+    def _spectral_l2_energy_score(self):
+        return SpectralL2EnergyScoreLoss(**_SPEC_KWARGS, spatial_distributed=False, ensemble_distributed=False)
+
+    def _corrected_spectral_l2_energy_score(self):
+        return CorrectedSpectralL2EnergyScoreLoss(**_SPEC_KWARGS, spatial_distributed=False, ensemble_distributed=False)
+
+    def _spectral_coherence(self):
+        return SpectralCoherenceLoss(**_SPEC_KWARGS, eps=1e-16, spatial_distributed=False, ensemble_distributed=False)
+
+    def _coherence_regularization(self):
+        return CoherenceRegularization(
+            **_SPEC_KWARGS, eps=1e-16, ensemble_coherence_weight=0.5,
+            spatial_distributed=False, ensemble_distributed=False,
+        )
+
+    def _gaussian_mmd(self):
+        return GaussianMMDLoss(**_GEOM_KWARGS, spatial_distributed=False, ensemble_distributed=False)
+
     def _make(self, name):
         return {
             "CRPSLoss": (self._crps, _NUM_CH),
@@ -3320,6 +3357,13 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
             "GradientCRPSLoss": (self._gradient_crps, _NUM_CH),
             "VortDivCRPSLoss": (self._vortdiv_crps, _NUM_WIND_CH),
             "KernelScoreLoss": (self._kernel_score, _NUM_CH),
+            "LpEnergyScoreLoss": (self._lp_energy_score, _NUM_CH),
+            "SobolevEnergyScoreLoss": (self._sobolev_energy_score, _NUM_CH),
+            "SpectralL2EnergyScoreLoss": (self._spectral_l2_energy_score, _NUM_CH),
+            "CorrectedSpectralL2EnergyScoreLoss": (self._corrected_spectral_l2_energy_score, _NUM_CH),
+            "SpectralCoherenceLoss": (self._spectral_coherence, _NUM_CH),
+            "CoherenceRegularization": (self._coherence_regularization, _NUM_CH),
+            "GaussianMMDLoss": (self._gaussian_mmd, _NUM_CH),
         }[name]
 
     # -- tests --------------------------------------------------------------
@@ -3330,6 +3374,13 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
         ("GradientCRPSLoss",),
         ("VortDivCRPSLoss",),
         ("KernelScoreLoss",),
+        ("LpEnergyScoreLoss",),
+        ("SobolevEnergyScoreLoss",),
+        ("SpectralL2EnergyScoreLoss",),
+        ("CorrectedSpectralL2EnergyScoreLoss",),
+        ("SpectralCoherenceLoss",),
+        ("CoherenceRegularization",),
+        ("GaussianMMDLoss",),
     ])
     def test_e1_output_shape_and_finite(self, name):
         """E=1 path produces (B, n_channels) and finite values."""
@@ -3348,6 +3399,10 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
         ("GradientCRPSLoss",),
         ("VortDivCRPSLoss",),
         ("KernelScoreLoss",),
+        ("LpEnergyScoreLoss",),
+        ("SobolevEnergyScoreLoss",),
+        ("SpectralL2EnergyScoreLoss",),
+        ("CorrectedSpectralL2EnergyScoreLoss",),
     ])
     def test_e1_zero_on_perfect_prediction(self, name, verbose=False):
         """At E=1, fc[:,0] == obs reduces to |obs - obs| = 0; loss must be (near) zero."""
@@ -3368,6 +3423,13 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
         ("GradientCRPSLoss",),
         ("VortDivCRPSLoss",),
         ("KernelScoreLoss",),
+        ("LpEnergyScoreLoss",),
+        ("SobolevEnergyScoreLoss",),
+        ("SpectralL2EnergyScoreLoss",),
+        ("CorrectedSpectralL2EnergyScoreLoss",),
+        ("SpectralCoherenceLoss",),
+        ("CoherenceRegularization",),
+        ("GaussianMMDLoss",),
     ])
     def test_e1_backward_finite(self, name):
         """Gradient through the E=1 path must be finite — no NaN/Inf even though
@@ -3380,6 +3442,58 @@ class TestEnsembleLossE1FastPath(unittest.TestCase):
         self.assertIsNotNone(fc.grad)
         self.assertFalse(torch.isnan(fc.grad).any(), f"{name}: NaN grad in E=1 backward")
         self.assertFalse(torch.isinf(fc.grad).any(), f"{name}: Inf grad in E=1 backward")
+
+    @parameterized.expand([
+        ("LpEnergyScoreLoss",),
+        ("SobolevEnergyScoreLoss",),
+        ("SpectralL2EnergyScoreLoss",),
+        ("CorrectedSpectralL2EnergyScoreLoss",),
+        ("SpectralCoherenceLoss",),
+        ("CoherenceRegularization",),
+    ])
+    def test_e1_spread_term_vanishes(self, name, verbose=False):
+        """Issue #96: at E=1 the spread is an empty sum and must contribute nothing.
+
+        Rather than reimplementing each score's formula, compare against a
+        two-member ensemble whose members are identical: its pairwise spread is
+        zero as well, so the two must agree exactly. If the E=1 guard instead
+        returned NaN, or dropped the skill term, this would catch it.
+
+        GaussianMMDLoss is excluded: its spread is a kernel sum with k(x,x)=1, so
+        identical members have a non-zero spread by construction and only the
+        genuinely empty E=1 sum is zero.
+        """
+        builder, n_ch = self._make(name)
+        fn = builder()
+        obs = torch.randn(_BATCH, n_ch, _IMG_H, _IMG_W)
+        fc1 = torch.randn(_BATCH, 1, n_ch, _IMG_H, _IMG_W)
+
+        out_e1 = fn(fc1, obs)
+        out_e2 = fn(fc1.repeat(1, 2, 1, 1, 1), obs)
+
+        self.assertTrue(torch.isfinite(out_e1).all(), f"{name}: non-finite E=1 output")
+        self.assertTrue(
+            compare_tensors(f"{name} E=1 vs E=2-identical", out_e1, out_e2, atol=1e-4, verbose=verbose)
+        )
+
+    @parameterized.expand([
+        ("LpEnergyScoreLoss",),
+        ("SobolevEnergyScoreLoss",),
+        ("SpectralL2EnergyScoreLoss",),
+        ("CorrectedSpectralL2EnergyScoreLoss",),
+        ("SpectralCoherenceLoss",),
+        ("CoherenceRegularization",),
+        ("GaussianMMDLoss",),
+    ])
+    def test_e1_matches_larger_ensemble_shape(self, name):
+        """The E=1 guard must not change the output contract for E > 1."""
+        builder, n_ch = self._make(name)
+        fn = builder()
+        obs = torch.randn(_BATCH, n_ch, _IMG_H, _IMG_W)
+        out1 = fn(torch.randn(_BATCH, 1, n_ch, _IMG_H, _IMG_W), obs)
+        out4 = fn(torch.randn(_BATCH, 4, n_ch, _IMG_H, _IMG_W), obs)
+        self.assertEqual(out1.shape, out4.shape)
+        self.assertTrue(torch.isfinite(out4).all(), f"{name}: non-finite E=4 output")
 
 
 class TestCoherenceRegularization(unittest.TestCase):


### PR DESCRIPTION
LpEnergyScoreLoss, SobolevEnergyScoreLoss, SpectralL2EnergyScoreLoss, CorrectedSpectralL2EnergyScoreLoss and SpectralCoherenceLoss normalized their spread term by N^2(N-1) or N(N-1). At E=1 that denominator is 0 while the numerator is an empty pair sum, so the term evaluated to 0/0 and turned the entire score into NaN -- verified: the old expression returns tensor([nan, ...]).

A sum over member pairs is empty with a single member, so the spread is zero and the score degrades to the skill term. Guard the normalization accordingly. GaussianMMDLoss already did exactly this (mmd_loss.py:195-198) and is the pattern followed here; the CRPS family reaches the same end via an explicit E=1 short-circuit.

num_ensemble is read after the distributed transpose, which gathers the ensemble dimension, so it is the global member count and the plain `num_ensemble > 1` guard is correct under ensemble parallelism too.

Extends TestEnsembleLossE1FastPath to the whole family and adds test_e1_spread_term_vanishes, which pins the semantics without reimplementing each formula: E=1 must equal a two-member ensemble of identical members, whose pairwise spread is also zero. Verified exact for the four energy scores and, once eps no longer floors the ratio, for both coherence losses. GaussianMMDLoss is excluded from that check because its spread is a kernel sum with k(x,x)=1, so identical members carry non-zero spread by construction.

Also corrects the class docstring, which claimed this family was unguarded and that MMD was affected.