### PR TITLE
Fall back to unresampled shapes when img_shape_*_resampled is absent

### DIFF
--- a/makani/models/model_package.py
+++ b/makani/models/model_package.py
@@ -22,7 +22,7 @@ import shutil
 import json
 import numpy as np
 import torch
-from makani.utils.YParams import ParamsBase
+from makani.utils.YParams import ParamsBase, ensure_resampled_shapes
 from makani.utils.driver import Driver
 from makani.third_party.climt.zenith_angle_v2 import cos_zenith_angle
 from makani.utils.dataloaders.data_helpers import get_data_normalization
@@ -98,6 +98,9 @@ class ModelWrapper(torch.nn.Module):
         super().__init__()
         self.model = model
         self.params = params
+        # tolerate params assembled outside load_model_package (e.g. earth2studio),
+        # which need not carry the resampled shapes
+        ensure_resampled_shapes(params)
         nlat = params.img_shape_x_resampled
         nlon = params.img_shape_y_resampled
 
@@ -222,11 +225,9 @@ def load_model_package(package, pretrained=True, device="cpu", multistep=False):
     """
     path = package.get("config.json")
     params = ParamsBase.from_json(path)
-    # ensure resampled shapes exist (set at runtime from dataset in training; missing when loading from package)
-    if not hasattr(params, "img_shape_x_resampled") or params.img_shape_x_resampled is None:
-        params.img_shape_x_resampled = params.img_shape_x
-    if not hasattr(params, "img_shape_y_resampled") or params.img_shape_y_resampled is None:
-        params.img_shape_y_resampled = params.img_shape_y
+    # resampled shapes are set at runtime from the dataset during training and are
+    # absent from packages written before resampling existed
+    ensure_resampled_shapes(params)
     LocalPackage._load_static_data(package, params)
 
     # assume we are not distributed

--- a/makani/models/model_registry.py
+++ b/makani/models/model_registry.py
@@ -27,7 +27,7 @@ from functools import partial
 import torch
 import torch.nn as nn
 
-from makani.utils.YParams import ParamsBase
+from makani.utils.YParams import ParamsBase, ensure_resampled_shapes
 from makani.models import SingleStepWrapper, MultiStepWrapper
 from makani.models import StochasticInterpolantWrapper
 from makani.utils.dataloaders.data_helpers import get_data_normalization
@@ -154,6 +154,12 @@ def get_model(params: ParamsBase, use_stochastic_interpolation: bool = False, mu
         from makani.models.parametrizations import ConstraintsWrapper
 
     if params is not None:
+        # callers outside training (model packages predating resampling, earth2studio)
+        # may not carry the resampled shapes; fall back to the unresampled ones. This
+        # also covers Preprocessor2D, which is constructed further down from this same
+        # params object.
+        ensure_resampled_shapes(params)
+
         # makani requires that these entries are set in params for now
         inp_shape = (params.img_shape_x_resampled, params.img_shape_y_resampled)
         out_shape = (params.out_shape_x, params.out_shape_y) if hasattr(params, "out_shape_x") and hasattr(params, "out_shape_y") else inp_shape

--- a/makani/utils/YParams.py
+++ b/makani/utils/YParams.py
@@ -113,3 +113,34 @@ class YParams(ParamsBase):
         for key, val in self.to_dict().items():
             logger.info(str(key) + " " + str(val))
         logger.info("---------------------------------------------------")
+
+
+def ensure_resampled_shapes(params):
+    """Fill in ``img_shape_{x,y}_resampled`` from the unresampled shapes if absent.
+
+    The resampled shapes are a training-time concept: the dataloader sets them and
+    ``Driver`` copies them into params, so they differ from ``img_shape_{x,y}`` only
+    when resampling is actually configured. They are therefore missing from any
+    model package written before resampling existed, and from params assembled by
+    external callers such as earth2studio, which do not pass input shapes.
+
+    Consumers on the inference path (``model_registry.get_model``,
+    ``Preprocessor2D``, ``ModelWrapper``) read them unconditionally, so normalize
+    once here rather than patching each call site. Falling back to the unresampled
+    shape is exactly right in both cases above, since no resampling took place.
+
+    Mutates and returns ``params`` for convenience. A no-op when the values are
+    already set.
+    """
+    for axis in ("x", "y"):
+        resampled = f"img_shape_{axis}_resampled"
+        if getattr(params, resampled, None) is None:
+            base = getattr(params, f"img_shape_{axis}", None)
+            if base is None:
+                raise AttributeError(
+                    f"cannot determine {resampled}: neither it nor img_shape_{axis} is set on the parameters. "
+                    f"Pass the input shape explicitly."
+                )
+            params[resampled] = base
+
+    return params

--- a/tests/test_resampled_shapes.py
+++ b/tests/test_resampled_shapes.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from makani.utils.YParams import ParamsBase, ensure_resampled_shapes
+from makani.models import model_registry
+
+from .testutils import set_seed, get_default_parameters
+
+
+class TestResampledShapeFallback(unittest.TestCase):
+    """``img_shape_{x,y}_resampled`` must be optional outside training.
+
+    The resampled shapes are populated at runtime from the dataset (Driver copies
+    them from the dataloader), so they are absent from model packages written
+    before resampling existed and from params assembled by external callers such
+    as earth2studio, which do not pass input shapes at all.
+
+    Consumers read them unconditionally -- ``model_registry.get_model``,
+    ``Preprocessor2D`` and ``ModelWrapper`` -- so without a fallback loading an
+    older SFNO package fails with
+
+        AttributeError: 'ParamsBase' object has no attribute 'img_shape_x_resampled'
+
+    Falling back to the unresampled shape is correct in exactly these cases,
+    since no resampling took place.
+    """
+
+    def setUp(self):
+        set_seed(333)
+
+    def _params_without_resampled(self, nettype):
+        """Params as an older package / an external caller would supply them."""
+        params = get_default_parameters()
+        params.nettype = nettype
+        params.img_shape_x = 36
+        params.img_shape_y = 72
+        params.img_local_shape_x = params.img_crop_shape_x = params.img_shape_x
+        params.img_local_shape_y = params.img_crop_shape_y = params.img_shape_y
+        # deliberately NOT set: img_shape_x_resampled / img_shape_y_resampled
+        for key in ("img_shape_x_resampled", "img_shape_y_resampled"):
+            if hasattr(params, key):
+                delattr(params, key)
+            params.params.pop(key, None)
+        return params
+
+    # -- the helper itself ---------------------------------------------------
+
+    def test_fills_from_unresampled(self):
+        params = self._params_without_resampled("SFNO")
+        ensure_resampled_shapes(params)
+        self.assertEqual(params.img_shape_x_resampled, 36)
+        self.assertEqual(params.img_shape_y_resampled, 72)
+
+    def test_does_not_overwrite_explicit_values(self):
+        """A genuinely resampled config must survive untouched."""
+        params = self._params_without_resampled("SFNO")
+        params.img_shape_x_resampled = 18
+        params.img_shape_y_resampled = 36
+        ensure_resampled_shapes(params)
+        self.assertEqual(params.img_shape_x_resampled, 18)
+        self.assertEqual(params.img_shape_y_resampled, 36)
+
+    def test_is_idempotent(self):
+        params = self._params_without_resampled("SFNO")
+        ensure_resampled_shapes(params)
+        ensure_resampled_shapes(params)
+        self.assertEqual(params.img_shape_x_resampled, 36)
+
+    def test_none_is_treated_as_absent(self):
+        """Driver leaves these as None when no dataset is attached."""
+        params = self._params_without_resampled("SFNO")
+        params.img_shape_x_resampled = None
+        params.img_shape_y_resampled = None
+        ensure_resampled_shapes(params)
+        self.assertEqual(params.img_shape_x_resampled, 36)
+        self.assertEqual(params.img_shape_y_resampled, 72)
+
+    def test_missing_both_raises_clearly(self):
+        """With no shape at all, fail with an actionable message rather than an
+        AttributeError from deep inside model construction."""
+        params = ParamsBase()
+        params.update_params({"nettype": "SFNO"})
+        with self.assertRaises(AttributeError) as cm:
+            ensure_resampled_shapes(params)
+        self.assertIn("img_shape_x", str(cm.exception))
+
+    # -- the reported failure ------------------------------------------------
+
+    @parameterized.expand([("SFNO",), ("FNO",), ("FCN3",)])
+    def test_get_model_without_resampled_shapes(self, nettype):
+        """Regression: this is the exact path that raised for older packages."""
+        params = self._params_without_resampled(nettype)
+        model = model_registry.get_model(params, multistep=False)
+
+        # the fallback must have populated params for the downstream consumers
+        # (Preprocessor2D reads them from this same object)
+        self.assertEqual(params.img_shape_x_resampled, params.img_shape_x)
+        self.assertEqual(params.img_shape_y_resampled, params.img_shape_y)
+
+        inp = torch.randn(1, params.N_in_channels, params.img_shape_x, params.img_shape_y)
+        out = model(inp)
+        self.assertEqual(out.shape, (1, params.N_out_channels, params.img_shape_x, params.img_shape_y))
+        self.assertTrue(torch.isfinite(out).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Loading an older model package (e.g. SFNO) raised

    AttributeError: 'ParamsBase' object has no attribute 'img_shape_x_resampled'

The resampled shapes were introduced with resampling support in 1c27286 (#79). They are populated at runtime from the dataset -- the dataloader sets them and Driver copies them into params -- so they are missing from any package written before that, and from params assembled by external callers such as earth2studio, which do not pass input shapes at all.

The existing fallback lived in load_model_package, patching a single call site rather than the definition, so it did not cover model_registry.get_model, which is what actually raises (reproduced at model_registry.py:158). Preprocessor2D and ModelWrapper read the same fields.

Add ensure_resampled_shapes() next to ParamsBase and apply it at the entry points that can receive externally-built params: get_model (which also covers Preprocessor2D, constructed from the same object) and ModelWrapper, replacing the one-site shim in load_model_package. Falling back to the unresampled shape is exactly right in these cases since no resampling took place; explicitly set values are left untouched, and if neither field is available the failure is an actionable message rather than an AttributeError from deep inside construction.

Verified SFNO, FNO and FCN3 all build and run a forward pass from params lacking the resampled shapes. Note test_models.py::test_gradient_accumulation_0_AFNO fails identically with and without this change; it is pre-existing.