### PR TITLE
Add API documentation across models/ and mpu/, and support PhysicsNeMo 2.x

### DIFF
--- a/makani/models/common/activations.py
+++ b/makani/models/common/activations.py
@@ -18,8 +18,54 @@ from torch import nn
 
 
 class ComplexReLU(nn.Module):
-    """
-    Complex-valued variants of the ReLU activation function
+    r"""
+    Complex-valued variants of the ReLU activation function.
+
+    A complex number has no total order, so "rectification" admits several
+    inequivalent generalizations. This module implements four of them, selected
+    via ``mode``, for a complex input :math:`z = x + i y`:
+
+    * ``"real"`` -- rectify the real part only, leave the imaginary part
+      untouched: :math:`\mathrm{ReLU}(x) + i y`.
+    * ``"cartesian"`` -- rectify real and imaginary parts independently:
+      :math:`\mathrm{ReLU}(x) + i\,\mathrm{ReLU}(y)`.
+    * ``"modulus"`` -- rectify the magnitude while preserving the phase,
+
+      .. math::
+
+          z \mapsto \begin{cases}
+              (|z| + b)\, \frac{z}{|z|} & \text{if } |z| + b > 0 \\
+              0 & \text{otherwise}
+          \end{cases}
+
+      where :math:`b` is a learnable bias. This keeps the activation
+      equivariant to global phase rotations.
+    * ``"halfplane"`` -- pass :math:`z` through unchanged if its phase falls in
+      the quarter-plane :math:`[b, b + \pi/2)` and scale it by
+      ``negative_slope`` otherwise; here the learnable bias :math:`b` is an
+      angle rather than a magnitude offset.
+
+    Parameters
+    ----------
+    negative_slope : float, optional
+        Slope applied to the rejected part of the input, as in
+        :class:`torch.nn.LeakyReLU`. ``0.0`` (the default) gives a hard
+        rectifier. Used by all modes except ``"modulus"``.
+    mode : str, optional
+        One of ``"real"`` (default), ``"cartesian"``, ``"modulus"`` or
+        ``"halfplane"``. See above.
+    bias_shape : tuple of int, optional
+        Shape of the learnable bias for the ``"modulus"`` and ``"halfplane"``
+        modes. Defaults to a single shared scalar. Ignored by the other modes,
+        which use a fixed bias of ``0``.
+    scale : float, optional
+        Value the learnable bias is initialized to, by default ``1.0``.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``mode`` is not one of the four supported values. Raised on the
+        first forward pass rather than at construction time.
     """
 
     def __init__(self, negative_slope=0.0, mode="real", bias_shape=None, scale=1.0):
@@ -39,6 +85,20 @@ class ComplexReLU(nn.Module):
         self.act = nn.LeakyReLU(negative_slope=negative_slope)
 
     def forward(self, z: torch.Tensor) -> torch.Tensor:
+        r"""
+        Apply the complex rectifier elementwise.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Complex-valued input tensor of arbitrary shape. If ``bias_shape``
+            was given, it must broadcast against ``z``.
+
+        Returns
+        -------
+        torch.Tensor
+            Complex tensor of the same shape and dtype as ``z``.
+        """
         if self.mode == "cartesian":
             zr = torch.view_as_real(z)
             za = self.act(zr)
@@ -68,6 +128,39 @@ class ComplexReLU(nn.Module):
 
 
 class ComplexActivation(nn.Module):
+    r"""
+    Lift an arbitrary real-valued activation to the complex plane.
+
+    Generalizes :class:`ComplexReLU` to any pointwise nonlinearity :math:`\sigma`
+    supplied by the caller. For a complex input :math:`z = x + i y`:
+
+    * ``"cartesian"`` -- apply :math:`\sigma` to the real and imaginary parts
+      independently: :math:`\sigma(x) + i\,\sigma(y)`.
+    * ``"modulus"`` -- apply :math:`\sigma` to the magnitude and re-attach the
+      original phase,
+
+      .. math::
+
+          z \mapsto \sigma(|z| + b)\, e^{i \arg z}
+
+      with a learnable bias :math:`b`. Phase-equivariant.
+    * anything else -- identity; :math:`z` is returned unchanged and
+      ``activation`` is never called.
+
+    Parameters
+    ----------
+    activation : torch.nn.Module or callable
+        Real-valued pointwise nonlinearity. In ``"cartesian"`` mode it is
+        applied to a real view of shape ``(..., 2)``, so it must act elementwise.
+    mode : str, optional
+        One of ``"cartesian"`` (default), ``"modulus"``, or any other string for
+        the identity.
+    bias_shape : tuple of int, optional
+        Shape of the learnable bias in ``"modulus"`` mode; defaults to a single
+        shared scalar. In the other modes a zero bias is registered as a
+        non-persistent buffer and is not trained.
+    """
+
     def __init__(self, activation, mode="cartesian", bias_shape=None):
         super().__init__()
 
@@ -86,6 +179,20 @@ class ComplexActivation(nn.Module):
         self.act = activation
 
     def forward(self, z: torch.Tensor) -> torch.Tensor:
+        r"""
+        Apply the lifted activation elementwise.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Complex-valued input tensor of arbitrary shape. If ``bias_shape``
+            was given, it must broadcast against ``z``.
+
+        Returns
+        -------
+        torch.Tensor
+            Complex tensor of the same shape and dtype as ``z``.
+        """
         if self.mode == "cartesian":
             zr = torch.view_as_real(z)
             za = self.act(zr)
@@ -100,8 +207,37 @@ class ComplexActivation(nn.Module):
         return out
 
 
-# inspired from https://developer.nvidia.com/blog/rethinking-how-to-train-diffusion-models/
 class MagnitudePreservingSiLU(nn.Module):
+    r"""
+    SiLU rescaled to preserve the magnitude of unit-variance activations.
+
+    Plain SiLU shrinks the second moment of its input, so stacking many of them
+    makes activation magnitudes drift layer over layer. This variant divides by
+    a constant :math:`c` chosen so the output variance is again unity for
+    standard normal input:
+
+    .. math::
+
+        \mathrm{SiLU}_{mp}(x) = \frac{1}{c}\, x\, \sigma(x),
+        \qquad c = \sqrt{\mathbb{E}_{x \sim \mathcal{N}(0,1)}\bigl[(x \sigma(x))^2\bigr]}
+        \approx 0.596
+
+    Keeping magnitudes fixed removes the need for the normalization layers that
+    would otherwise be doing this job, which matters for diffusion-style
+    backbones trained without them.
+
+    Parameters
+    ----------
+    normalization_factor : float, optional
+        The constant :math:`c` above, by default ``0.596`` (the value for
+        standard normal input). Pass a different value if the expected input
+        distribution is not unit-variance.
+
+    References
+    ----------
+    Inspired by https://developer.nvidia.com/blog/rethinking-how-to-train-diffusion-models/
+    """
+
     def __init__(self, normalization_factor=0.596):
         super().__init__()
 
@@ -110,4 +246,17 @@ class MagnitudePreservingSiLU(nn.Module):
         self.silu = torch.nn.SiLU(inplace=False)
 
     def forward(self, x):
+        r"""
+        Apply the rescaled SiLU elementwise.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Real-valued input tensor of arbitrary shape.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape and dtype as ``x``.
+        """
         return self.norminv * self.silu(x)

--- a/makani/models/common/contractions.py
+++ b/makani/models/common/contractions.py
@@ -60,16 +60,92 @@ def _contract_dense_pytorch(x, weight, separable=False, operator_type="diagonal"
 # operator types. Restored verbatim from the pre-e59c2f4 networks/contractions.py.
 # Note these are ungrouped, unlike the _contract_* helpers above.
 def compl_mul2d_fwd(ac: torch.Tensor, bc: torch.Tensor) -> torch.Tensor:
+    r"""
+    Mix channels with a single weight matrix shared across all spectral modes.
+
+    .. math::
+
+        y_{b,o,l,m} = \sum_i x_{b,i,l,m}\, w_{i,o}
+
+    Parameters
+    ----------
+    ac : torch.Tensor
+        Input coefficients of shape ``(batch, in_channels, l, m)``.
+    bc : torch.Tensor
+        Weight of shape ``(in_channels, out_channels)``, shared over ``l`` and ``m``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(batch, out_channels, l, m)``.
+    """
     return torch.einsum("bixy,io->boxy", ac, bc)
 
 
 def compl_muladd2d_fwd(ac: torch.Tensor, bc: torch.Tensor, cc: torch.Tensor) -> torch.Tensor:
+    r"""
+    :func:`compl_mul2d_fwd` followed by a bias add.
+
+    Parameters
+    ----------
+    ac : torch.Tensor
+        Input coefficients of shape ``(batch, in_channels, l, m)``.
+    bc : torch.Tensor
+        Weight of shape ``(in_channels, out_channels)``.
+    cc : torch.Tensor
+        Bias, broadcastable to ``(batch, out_channels, l, m)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(batch, out_channels, l, m)``.
+    """
     return compl_mul2d_fwd(ac, bc) + cc
 
 
 def compl_exp_mul2d_fwd(ac: torch.Tensor, bc: torch.Tensor) -> torch.Tensor:
+    r"""
+    Mix channels with a separate weight matrix per spherical degree :math:`l`.
+
+    .. math::
+
+        y_{b,o,l,m} = \sum_i x_{b,i,l,m}\, w_{l,i,o}
+
+    The extra leading weight axis makes the channel mixing depend on the degree,
+    which lets the operator learn a scale-dependent response instead of applying
+    one matrix to every mode.
+
+    Parameters
+    ----------
+    ac : torch.Tensor
+        Input coefficients of shape ``(batch, in_channels, l, m)``.
+    bc : torch.Tensor
+        Weight of shape ``(l, in_channels, out_channels)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(batch, out_channels, l, m)``.
+    """
     return torch.einsum("bixy,xio->boxy", ac, bc)
 
 
 def compl_exp_muladd2d_fwd(ac: torch.Tensor, bc: torch.Tensor, cc: torch.Tensor) -> torch.Tensor:
+    r"""
+    :func:`compl_exp_mul2d_fwd` followed by a bias add.
+
+    Parameters
+    ----------
+    ac : torch.Tensor
+        Input coefficients of shape ``(batch, in_channels, l, m)``.
+    bc : torch.Tensor
+        Weight of shape ``(l, in_channels, out_channels)``.
+    cc : torch.Tensor
+        Bias, broadcastable to ``(batch, out_channels, l, m)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(batch, out_channels, l, m)``.
+    """
     return compl_exp_mul2d_fwd(ac, bc) + cc

--- a/makani/models/common/fft.py
+++ b/makani/models/common/fft.py
@@ -23,8 +23,27 @@ import torch.fft
 
 
 class RealFFT1(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Forward real-valued FFT along the last dimension, with mode truncation.
+
+    Wraps :func:`torch.fft.rfft` behind the same module interface the SHT
+    classes use, so a spectral layer can swap a planar transform for a spherical
+    one without changing its call sites. The transform is applied to the last
+    dimension and the output is truncated to ``mmax`` modes.
+
+    Parameters
+    ----------
+    nlon : int
+        Number of grid points along the transformed dimension.
+    lmax : int, optional
+        Upper bound on the retained mode count, clamped to ``nlon // 2 + 1``.
+        Defaults to the full ``nlon // 2 + 1``.
+    mmax : int, optional
+        Number of modes actually kept, clamped to ``lmax``. Defaults to ``lmax``.
+
+    See Also
+    --------
+    InverseRealFFT1 : the corresponding inverse transform.
     """
 
     def __init__(self, nlon: int, lmax: Optional[int] = None, mmax: Optional[int] = None):
@@ -38,6 +57,22 @@ class RealFFT1(nn.Module):
         self.mmax = min(mmax or self.nlon // 2 + 1, self.lmax)
 
     def forward(self, x: torch.Tensor, norm: Optional[str] = "ortho") -> torch.Tensor:
+        r"""
+        Transform to spectral space and truncate.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Real-valued input of shape ``(..., nlon)``.
+        norm : str, optional
+            Normalization mode forwarded to :func:`torch.fft.rfft`, by default
+            ``"ortho"`` (unitary, so forward and inverse are adjoint).
+
+        Returns
+        -------
+        torch.Tensor
+            Complex coefficients of shape ``(..., mmax)``.
+        """
         y = self.fft_handle(x, n=self.nlon, dim=-1, norm=norm)
 
         # mode truncation
@@ -47,8 +82,27 @@ class RealFFT1(nn.Module):
 
 
 class InverseRealFFT1(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Inverse real-valued FFT along the last dimension.
+
+    Counterpart to :class:`RealFFT1`. Truncated inputs are zero-padded back up
+    to ``nlon // 2 + 1`` modes implicitly by :func:`torch.fft.irfft`, so a
+    signal round-tripped through ``RealFFT1`` and this module is band-limited
+    rather than exactly recovered whenever ``mmax`` truncates.
+
+    Parameters
+    ----------
+    nlon : int
+        Number of grid points along the reconstructed dimension.
+    lmax : int, optional
+        Upper bound on the mode count, clamped to ``nlon // 2 + 1``. Defaults to
+        the full ``nlon // 2 + 1``.
+    mmax : int, optional
+        Number of input modes expected, clamped to ``lmax``. Defaults to ``lmax``.
+
+    See Also
+    --------
+    RealFFT1 : the corresponding forward transform.
     """
 
     def __init__(self, nlon: int, lmax: Optional[int] = None, mmax: Optional[int] = None):
@@ -62,6 +116,23 @@ class InverseRealFFT1(nn.Module):
         self.mmax = min(mmax or self.nlon // 2 + 1, self.lmax)
 
     def forward(self, x: torch.Tensor, norm: Optional[str] = "ortho") -> torch.Tensor:
+        r"""
+        Transform back to grid space.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Complex coefficients of shape ``(..., m)`` with ``m <= nlon // 2 + 1``.
+            Missing high modes are zero-padded.
+        norm : str, optional
+            Normalization mode forwarded to :func:`torch.fft.irfft`, by default
+            ``"ortho"``. Must match the mode used in the forward transform.
+
+        Returns
+        -------
+        torch.Tensor
+            Real-valued signal of shape ``(..., nlon)``.
+        """
         # implicit padding
         y = self.ifft_handle(x, n=self.nlon, dim=-1, norm=norm)
 
@@ -69,8 +140,37 @@ class InverseRealFFT1(nn.Module):
 
 
 class RealFFT2(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Forward real-valued 2D FFT with mode truncation, mirroring the SHT interface.
+
+    Drop-in planar replacement for a forward spherical harmonic transform: the
+    last two dimensions are treated as latitude and longitude, and the result is
+    truncated to ``lmax`` latitudinal and ``mmax`` longitudinal modes.
+
+    Truncation along the latitude axis is two-sided. The FFT along a
+    non-halved axis places positive frequencies at the front and negative
+    frequencies at the back, so keeping the ``lmax`` lowest frequencies means
+    concatenating the leading ``ceil(lmax/2)`` and trailing ``floor(lmax/2)``
+    entries; a plain ``[:lmax]`` slice would discard all negative frequencies
+    instead. The longitude axis needs no such care because ``rfft2`` already
+    returns only non-negative frequencies there. Truncation is skipped entirely
+    when ``lmax`` and ``mmax`` are at their maxima.
+
+    Parameters
+    ----------
+    nlat : int
+        Number of grid points along the second-to-last (latitude) dimension.
+    nlon : int
+        Number of grid points along the last (longitude) dimension.
+    lmax : int, optional
+        Retained latitudinal modes, clamped to ``nlat``. Defaults to ``nlat``.
+    mmax : int, optional
+        Retained longitudinal modes, clamped to ``nlon // 2 + 1``. Defaults to
+        ``nlon // 2 + 1``.
+
+    See Also
+    --------
+    InverseRealFFT2 : the corresponding inverse transform.
     """
 
     def __init__(self, nlat: int, nlon: int, lmax: Optional[int] = None, mmax: Optional[int] = None):
@@ -92,6 +192,22 @@ class RealFFT2(nn.Module):
         self.lmax_low = math.floor(self.lmax / 2)
 
     def forward(self, x: torch.Tensor, norm: Optional[str] = "ortho") -> torch.Tensor:
+        r"""
+        Transform to spectral space and truncate both spectral axes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Real-valued input of shape ``(..., nlat, nlon)``.
+        norm : str, optional
+            Normalization mode forwarded to :func:`torch.fft.rfft2`, by default
+            ``"ortho"``.
+
+        Returns
+        -------
+        torch.Tensor
+            Complex coefficients of shape ``(..., lmax, mmax)``.
+        """
         y = self.fft_handle(x, s=(self.nlat, self.nlon), dim=(-2, -1), norm=norm)
 
         if self.truncate:
@@ -101,8 +217,30 @@ class RealFFT2(nn.Module):
 
 
 class InverseRealFFT2(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Inverse real-valued 2D FFT, mirroring the inverse SHT interface.
+
+    Counterpart to :class:`RealFFT2`. Truncated coefficients are zero-padded
+    back to the full grid before the inverse transform. The padding is inserted
+    *between* the retained positive and negative latitudinal frequencies (not
+    appended at the end), which is where the missing high frequencies belong in
+    FFT layout.
+
+    Parameters
+    ----------
+    nlat : int
+        Number of grid points along the second-to-last (latitude) dimension.
+    nlon : int
+        Number of grid points along the last (longitude) dimension.
+    lmax : int, optional
+        Latitudinal modes expected on input, clamped to ``nlat``. Defaults to ``nlat``.
+    mmax : int, optional
+        Longitudinal modes expected on input, clamped to ``nlon // 2 + 1``.
+        Defaults to ``nlon // 2 + 1``.
+
+    See Also
+    --------
+    RealFFT2 : the corresponding forward transform.
     """
 
     def __init__(self, nlat: int, nlon: int, lmax: Optional[int] = None, mmax: Optional[int] = None):
@@ -124,6 +262,23 @@ class InverseRealFFT2(nn.Module):
         self.lmax_low = math.floor(self.lmax / 2)
 
     def forward(self, x: torch.Tensor, norm: Optional[str] = "ortho") -> torch.Tensor:
+        r"""
+        Zero-pad the truncated spectrum and transform back to grid space.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Complex coefficients of shape ``(..., lmax, m)`` with ``m >= mmax``;
+            anything beyond ``mmax`` is dropped.
+        norm : str, optional
+            Normalization mode forwarded to :func:`torch.fft.irfft2`, by default
+            ``"ortho"``. Must match the mode used in the forward transform.
+
+        Returns
+        -------
+        torch.Tensor
+            Real-valued field of shape ``(..., nlat, nlon)``.
+        """
         # truncation is implicit but better do it manually
         xt = x[..., : self.mmax]
 
@@ -140,8 +295,36 @@ class InverseRealFFT2(nn.Module):
 
 
 class RealFFT3(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Forward real-valued 3D FFT with truncation on all three spectral axes.
+
+    Three-dimensional analogue of :class:`RealFFT2`, used by models that treat a
+    vertical (or temporal) axis spectrally alongside the two horizontal ones.
+    The transform runs over the last three dimensions ``(d, h, w)``. As in the
+    2D case, truncation along ``d`` and ``h`` is two-sided (leading and trailing
+    frequency blocks are concatenated) while ``w`` is a simple head slice,
+    because ``rfftn`` halves only the last axis. Normalization is fixed to
+    ``"ortho"``.
+
+    Parameters
+    ----------
+    nd : int
+        Number of grid points along the third-to-last dimension.
+    nh : int
+        Number of grid points along the second-to-last dimension.
+    nw : int
+        Number of grid points along the last dimension.
+    ldmax : int, optional
+        Retained modes along ``d``, clamped to ``nd``. Defaults to ``nd``.
+    lhmax : int, optional
+        Retained modes along ``h``, clamped to ``nh``. Defaults to ``nh``.
+    lwmax : int, optional
+        Retained modes along ``w``, clamped to ``nw // 2 + 1``. Defaults to
+        ``nw // 2 + 1``.
+
+    See Also
+    --------
+    InverseRealFFT3 : the corresponding inverse transform.
     """
 
     def __init__(self, nd, nh, nw, ldmax=None, lhmax=None, lwmax=None):
@@ -162,6 +345,19 @@ class RealFFT3(nn.Module):
         self.lhmax_low = math.floor(self.lhmax / 2)
 
     def forward(self, x):
+        r"""
+        Transform to spectral space and truncate all three spectral axes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Real-valued input of shape ``(..., nd, nh, nw)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Complex coefficients of shape ``(..., ldmax, lhmax, lwmax)``.
+        """
         x = torch.fft.rfftn(x, s=(self.nd, self.nh, self.nw), dim=(-3, -2, -1), norm="ortho")
 
         # truncate in w
@@ -177,8 +373,34 @@ class RealFFT3(nn.Module):
 
 
 class InverseRealFFT3(nn.Module):
-    """
-    Helper routine to wrap FFT similarly to the SHT
+    r"""
+    Inverse real-valued 3D FFT, counterpart to :class:`RealFFT3`.
+
+    Zero-pads the ``d`` and ``h`` spectral axes back to full length (inserting
+    the padding between the retained positive and negative frequency blocks)
+    and lets :func:`torch.fft.irfftn` pad the halved ``w`` axis implicitly.
+    Padding is skipped on any axis that was not truncated. Normalization is
+    fixed to ``"ortho"``.
+
+    Parameters
+    ----------
+    nd : int
+        Number of grid points along the third-to-last dimension.
+    nh : int
+        Number of grid points along the second-to-last dimension.
+    nw : int
+        Number of grid points along the last dimension.
+    ldmax : int, optional
+        Modes expected along ``d``, clamped to ``nd``. Defaults to ``nd``.
+    lhmax : int, optional
+        Modes expected along ``h``, clamped to ``nh``. Defaults to ``nh``.
+    lwmax : int, optional
+        Modes expected along ``w``, clamped to ``nw // 2 + 1``. Defaults to
+        ``nw // 2 + 1``.
+
+    See Also
+    --------
+    RealFFT3 : the corresponding forward transform.
     """
 
     def __init__(self, nd, nh, nw, ldmax=None, lhmax=None, lwmax=None):
@@ -199,6 +421,19 @@ class InverseRealFFT3(nn.Module):
         self.lhmax_low = math.floor(self.lhmax / 2)
 
     def forward(self, x):
+        r"""
+        Zero-pad the truncated spectrum and transform back to grid space.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Complex coefficients of shape ``(..., ldmax, lhmax, lwmax)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Real-valued field of shape ``(..., nd, nh, nw)``.
+        """
 
         # pad in d
         if self.ldmax < self.nd:

--- a/makani/models/common/imputation.py
+++ b/makani/models/common/imputation.py
@@ -21,8 +21,39 @@ from makani.utils import comm
 from .layers import EncoderDecoder
 
 
-# helper module to handle imputation of SST
 class MLPImputation(nn.Module):
+    r"""
+    Learned imputation of missing values from the other input channels.
+
+    Fields such as sea surface temperature are undefined over parts of the
+    globe and arrive as ``NaN``. Feeding those straight into a network poisons
+    every downstream activation, so they must be filled first. This module
+    predicts the fill values with a small MLP that sees all ``inp_chans``
+    channels, letting it infer a plausible value from correlated fields rather
+    than substituting a constant.
+
+    Only masked positions are replaced; valid data passes through untouched.
+    Positions that are ``NaN`` in the input are always treated as missing, in
+    addition to anything flagged by an explicit ``mask``.
+
+    Parameters
+    ----------
+    inp_chans : int, optional
+        Total number of input channels the MLP conditions on, by default ``2``.
+    inpute_chans : torch.Tensor, optional
+        1D integer tensor of channel indices to impute, by default
+        ``tensor([0])``. Its length sets the number of predicted channels.
+    mlp_ratio : float, optional
+        Hidden width of the MLP as a multiple of the number of imputed
+        channels, by default ``2.0``.
+    activation_function : torch.nn.Module, optional
+        Activation used inside the MLP, by default :class:`torch.nn.GELU`.
+
+    See Also
+    --------
+    ConstantImputation : cheaper alternative that fills with a learned constant.
+    """
+
     def __init__(
         self,
         inp_chans: int = 2,
@@ -56,6 +87,26 @@ class MLPImputation(nn.Module):
         return x.scatter(c_dim, idx_expanded, values)
 
     def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None):
+        r"""
+        Fill masked entries of the imputed channels with MLP predictions.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(..., inp_chans, nlat, nlon)``. Leading batch
+            dimensions are flattened internally, so any number of them is fine.
+        mask : torch.Tensor, optional
+            Boolean mask of shape ``(..., len(inpute_chans), nlat, nlon)``, with
+            ``True`` marking positions to impute. Combined by logical OR with
+            the ``NaN`` positions of ``x``. If omitted, only ``NaN`` positions
+            are imputed.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``, with masked entries of the
+            imputed channels replaced and everything else unchanged.
+        """
         x_sub = x[..., self.inpute_chans, :, :]
 
         if mask is None:
@@ -79,6 +130,29 @@ class MLPImputation(nn.Module):
 
 
 class ConstantImputation(nn.Module):
+    r"""
+    Imputation of missing values with a learned per-channel constant.
+
+    The cheap counterpart to :class:`MLPImputation`: instead of predicting fill
+    values from the other channels, each channel gets a single scalar that is
+    learned jointly with the rest of the model. Masked positions are replaced by
+    that scalar and valid data passes through untouched.
+
+    Under spatial model parallelism the fill values are replicated rather than
+    sharded (the parameter is marked shared across the ``"spatial"`` group), so
+    every rank imputes with identical constants.
+
+    Parameters
+    ----------
+    inp_chans : int, optional
+        Number of input channels, by default ``2``. One fill value is learned
+        per channel, initialized from a standard normal.
+
+    See Also
+    --------
+    MLPImputation : learned imputation conditioned on the other channels.
+    """
+
     def __init__(
         self,
         inp_chans: int = 2,
@@ -92,6 +166,23 @@ class ConstantImputation(nn.Module):
             self.weight.sharded_dims_mp = [None, None, None]
 
     def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None):
+        r"""
+        Replace masked entries with the learned per-channel constants.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(..., inp_chans, nlat, nlon)``.
+        mask : torch.Tensor, optional
+            Boolean mask broadcastable to ``x``, with ``True`` marking positions
+            to impute. Combined by logical OR with the ``NaN`` positions of
+            ``x``. If omitted, only ``NaN`` positions are imputed.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x`` with masked entries filled.
+        """
         if mask is None:
             mask = torch.isnan(x)
         else:

--- a/makani/models/common/layer_norm.py
+++ b/makani/models/common/layer_norm.py
@@ -27,10 +27,58 @@ from makani.utils.grids import grid_to_quadrature_rule, GridQuadrature
 from makani.mpu.layer_norm import _normalize_kernel, _normalize_transform_kernel
 
 
-# instance norm with S2 weights
 class GeometricInstanceNormS2(nn.Module):
-    """
-    Computes a distributed S2 weighted instance norm using Welford's online algorithm
+    r"""
+    Instance normalization with quadrature weights on the sphere :math:`S^2`.
+
+    Ordinary instance norm averages every grid point equally, which on a
+    lat-lon grid over-weights the poles: cells there cover far less area than
+    cells at the equator, so a uniform mean is not the mean of the underlying
+    field. This module instead uses the quadrature weights :math:`q_{ij}` of the
+    grid, so that the statistics approximate true spherical integrals,
+
+    .. math::
+
+        \mu_{bc} = \sum_{ij} q_{ij}\, x_{bcij},
+        \qquad
+        \sigma^2_{bc} = \sum_{ij} q_{ij}\, (x_{bcij} - \mu_{bc})^2
+
+    with :math:`\sum_{ij} q_{ij} = 1`. Mean and variance are taken per sample
+    and per channel, then applied as
+    :math:`(x - \mu)/\sqrt{\sigma^2 + \varepsilon}`, optionally followed by a
+    learned per-channel affine map.
+
+    Statistics are accumulated in fp32 regardless of the surrounding autocast
+    context and the result is cast back to the input dtype, matching how
+    PyTorch's native norm layers behave under mixed precision.
+
+    Parameters
+    ----------
+    img_shape : (int, int)
+        Latitude and longitude extent of the full grid the quadrature rule is
+        built for.
+    crop_shape : (int, int)
+        Extent of the sub-region actually normalized over.
+    crop_offset : (int, int)
+        Offset of that sub-region within the full grid.
+    grid_type : str
+        Grid the input lives on (e.g. ``"equiangular"``, ``"legendre-gauss"``);
+        determines the quadrature rule via
+        :func:`~makani.utils.grids.grid_to_quadrature_rule`.
+    num_features : int
+        Number of channels. Only used to size the affine parameters.
+    eps : float, optional
+        Constant added to the variance for numerical stability, by default ``1e-05``.
+    affine : bool, optional
+        If ``True``, apply a learned per-channel scale and shift after
+        normalizing, by default ``False``.
+
+    Notes
+    -----
+    The quadrature is constructed with ``distributed=False``, so the statistics
+    are computed over each rank's local shard. This layer is intended for the
+    non-spatially-decomposed case; under spatial model parallelism the reduction
+    would need to span the ``"spatial"`` group.
     """
 
     def __init__(
@@ -66,6 +114,21 @@ class GeometricInstanceNormS2(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""
+        Normalize each sample and channel by its quadrature-weighted statistics.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, C, H, W)``, where ``(H, W)`` matches the
+            ``crop_shape`` the quadrature was constructed for.
+
+        Returns
+        -------
+        torch.Tensor
+            Normalized tensor of shape ``(B, C, H, W)``, cast back to the dtype
+            of ``x``.
+        """
 
         # extract shapes
         B, C, H, W = x.shape

--- a/makani/models/common/layers.py
+++ b/makani/models/common/layers.py
@@ -47,17 +47,71 @@ def drop_path(x: torch.Tensor, drop_prob: float = 0.0, training: bool = False) -
 
 
 class DropPath(nn.Module):
-    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+    r"""
+    Stochastic depth: randomly zero the residual branch for whole samples.
+
+    Module wrapper around :func:`drop_path`. Placed on the residual branch of a
+    block, it drops that branch entirely for a random subset of the batch during
+    training, so the network is implicitly trained as an ensemble of varying
+    depth. Surviving samples are rescaled by :math:`1/(1-p)` to keep the
+    expected activation unchanged, and the layer is a no-op in ``eval`` mode.
+
+    Parameters
+    ----------
+    drop_prob : float, optional
+        Probability :math:`p` of dropping the branch for a given sample.
+        ``None`` or ``0.0`` disables the layer.
+    """
 
     def __init__(self, drop_prob=None):
         super(DropPath, self).__init__()
         self.drop_prob = drop_prob
 
     def forward(self, x):
+        r"""
+        Drop the branch for a random subset of samples.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, ...)``. The drop mask is drawn per sample and
+            broadcast over all remaining dimensions.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``. Returned unchanged in ``eval``
+            mode or when ``drop_prob`` is ``0.0``.
+        """
         return drop_path(x, self.drop_prob, self.training)
 
 
 class SeededDropout2d(nn.Module):
+    r"""
+    Channel dropout drawing from a private, explicitly seeded RNG.
+
+    Behaves like :class:`torch.nn.Dropout2d` (whole channels are zeroed, not
+    individual elements), except that the mask is drawn from generators owned by
+    this module instead of the global RNG. That makes the dropout pattern
+    reproducible and independent of however much other randomness the
+    surrounding model consumed, which is what ensemble members need when their
+    perturbations must be controlled rather than incidental.
+
+    Parameters
+    ----------
+    drop_prob : float, optional
+        Probability of zeroing a channel, by default ``0.0``.
+    seed : int, optional
+        Seed for the private CPU and CUDA generators, by default ``333``. Pass
+        distinct seeds across ensemble members to decorrelate them.
+
+    Notes
+    -----
+    ``forward`` is marked :func:`torch.compiler.disable`, so it runs eagerly.
+    Swapping global RNG state is not traceable by Dynamo; excluding this one
+    method lets the surrounding graph still compile.
+    """
+
     def __init__(self, drop_prob=0.0, seed=333):
         super(SeededDropout2d, self).__init__()
         self.drop_prob = drop_prob
@@ -78,12 +132,47 @@ class SeededDropout2d(nn.Module):
     # mid-trace; the surrounding graph still compiles around it.
     @torch.compiler.disable
     def forward(self, x):
+        r"""
+        Apply channel dropout using this module's private RNG.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, C, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``, with whole channels zeroed and
+            the rest rescaled by :math:`1/(1-p)`. A no-op in ``eval`` mode.
+        """
         with rng_context(self.rng_cpu, self.rng_gpu):
             xdrop = self.drop(x)
         return xdrop
 
 
 class LayerScale(nn.Module):
+    r"""
+    Learned per-channel rescaling of a residual branch.
+
+    Multiplies each channel by its own learned scalar, initialized to a small
+    value so the branch starts out contributing almost nothing and the block
+    behaves like an identity at initialization. The network then learns how much
+    of each branch to admit, which is what makes very deep residual stacks train
+    stably.
+
+    Implemented as a grouped 1x1 convolution with one group per channel, which
+    is equivalent to a broadcast multiply but keeps the parameter in the layout
+    the surrounding conv-based blocks expect.
+
+    Parameters
+    ----------
+    num_chans : int, optional
+        Number of channels, by default ``3``. One scale is learned per channel.
+    init_value : float, optional
+        Value all scales are initialized to, by default ``0.1``.
+    """
+
     def __init__(self, num_chans=3, init_value=0.1):
         super().__init__()
         self.num_chans = num_chans
@@ -91,10 +180,60 @@ class LayerScale(nn.Module):
         torch.nn.init.constant_(self.weight, val=init_value)
 
     def forward(self, x):
+        r"""
+        Scale each channel by its learned coefficient.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, num_chans, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``.
+        """
         return nn.functional.conv2d(x, self.weight, groups=self.num_chans)
 
 
 class PatchEmbed2D(nn.Module):
+    r"""
+    Split a 2D field into non-overlapping patches and embed each one.
+
+    The standard vision-transformer stem: a strided convolution whose kernel and
+    stride both equal ``patch_size`` computes one ``embed_dim``-dimensional
+    token per patch in a single op. This reduces an ``(H, W)`` field to
+    ``(H/p_h, W/p_w)`` tokens, which is what makes attention over a
+    high-resolution field affordable.
+
+    Parameters
+    ----------
+    img_size : (int, int), optional
+        Expected input height and width, by default ``(224, 224)``. Checked at
+        runtime in ``forward``.
+    patch_size : (int, int), optional
+        Patch height and width, by default ``(16, 16)``.
+    in_chans : int, optional
+        Number of input channels, by default ``3``.
+    embed_dim : int, optional
+        Dimension of each output token, by default ``768``.
+    padding : bool, optional
+        If ``True``, symmetrically zero-pad the input so both dimensions become
+        divisible by ``patch_size``, by default ``False``.
+    flatten : bool, optional
+        If ``True`` (the default), flatten the two spatial dimensions into a
+        single token axis. If ``False``, the patch grid is kept 2D.
+    norm_layer : callable, optional
+        Normalization applied to the embedded tokens over the channel dimension,
+        called as ``norm_layer(embed_dim)``. By default no normalization.
+
+    Notes
+    -----
+    The projection weight and bias are tagged ``is_shared_mp = ["spatial"]``, so
+    they are replicated rather than sharded across the spatial model-parallel
+    group and their gradients are reduced over it.
+    """
+
     def __init__(
         self,
         img_size=(224, 224),
@@ -136,6 +275,21 @@ class PatchEmbed2D(nn.Module):
             self.pad = nn.ZeroPad2d((padding_left, padding_right, padding_top, padding_bottom))
 
     def forward(self, x):
+        r"""
+        Embed the input field into patch tokens.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_chans, H, W)``, where ``(H, W)`` must equal
+            ``img_size``.
+
+        Returns
+        -------
+        torch.Tensor
+            Token tensor of shape ``(B, embed_dim, num_patches)`` if
+            ``flatten`` is ``True``, otherwise ``(B, embed_dim, H/p_h, W/p_w)``.
+        """
         # gather input
         B, C, H, W = x.shape
         if self.padding:
@@ -153,16 +307,34 @@ class PatchEmbed2D(nn.Module):
 
 
 class PatchEmbed3D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    3D Image to Patch Embedding.
+    r"""
+    Split a 3D volume into non-overlapping patches and embed each one.
 
-    Args:
-        img_size (tuple[int]): Image size.
-        patch_size (tuple[int]): Patch token size.
-        in_chans (int): Number of input image channels.
-        embed_dim(int): Number of projection output channels.
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
+    Volumetric counterpart of :class:`PatchEmbed2D`, used by models that treat
+    pressure levels as a third spatial axis rather than as channels: patches
+    then span a block of levels as well as a lat-lon tile, so vertical structure
+    is captured in the token itself. The patch grid is kept 3D (no flattening).
+
+    Parameters
+    ----------
+    img_size : tuple of int
+        Expected input size as ``(level, height, width)``.
+    patch_size : tuple of int
+        Patch size as ``(level, height, width)``.
+    in_chans : int
+        Number of input channels.
+    embed_dim : int
+        Dimension of each output token.
+    padding : bool, optional
+        If ``True``, symmetrically zero-pad each axis so it becomes divisible by
+        the corresponding patch size, by default ``False``.
+    norm_layer : callable, optional
+        Normalization applied to the embedded tokens over the channel
+        dimension, called as ``norm_layer(embed_dim)``. By default none.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn
     """
 
     def __init__(self, img_size, patch_size, in_chans, embed_dim, padding=False, norm_layer=None):
@@ -210,6 +382,20 @@ class PatchEmbed3D(nn.Module):
             self.norm = None
 
     def forward(self, x: torch.Tensor):
+        r"""
+        Embed the input volume into patch tokens.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_chans, L, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Token tensor of shape ``(B, embed_dim, L/p_l, H/p_h, W/p_w)``,
+            computed on the padded input when ``padding`` is enabled.
+        """
         B, C, L, H, W = x.shape
         if self.padding:
             x = self.pad(x)
@@ -220,15 +406,29 @@ class PatchEmbed3D(nn.Module):
 
 
 class PatchRecovery2D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    Patch Embedding Recovery to 2D Image.
+    r"""
+    Decode patch tokens back into a full-resolution 2D field.
 
-    Args:
-        img_size (tuple[int]): Lat, Lon
-        patch_size (tuple[int]): Lat, Lon
-        in_chans (int): Number of input channels.
-        out_chans (int): Number of output channels.
+    Inverse of :class:`PatchEmbed2D`: a transposed convolution with kernel and
+    stride equal to ``patch_size`` expands each token back into its patch. Since
+    the token grid may cover more area than the original field (the encoder can
+    pad up to a whole number of patches), the result is center-cropped back to
+    ``img_size``.
+
+    Parameters
+    ----------
+    img_size : tuple of int
+        Target output size as ``(lat, lon)``.
+    patch_size : tuple of int
+        Patch size as ``(lat, lon)``; must match the encoder's.
+    in_chans : int
+        Number of input channels, i.e. the token embedding dimension.
+    out_chans : int
+        Number of output channels.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn
     """
 
     def __init__(self, img_size, patch_size, in_chans, out_chans):
@@ -237,6 +437,19 @@ class PatchRecovery2D(nn.Module):
         self.conv = nn.ConvTranspose2d(in_chans, out_chans, patch_size, patch_size)
 
     def forward(self, x):
+        r"""
+        Expand tokens to grid space and center-crop to ``img_size``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Token tensor of shape ``(B, in_chans, H_p, W_p)`` on the patch grid.
+
+        Returns
+        -------
+        torch.Tensor
+            Field of shape ``(B, out_chans, lat, lon)``.
+        """
         output = self.conv(x)
 
         _, _, H, W = output.shape
@@ -253,15 +466,28 @@ class PatchRecovery2D(nn.Module):
 
 
 class PatchRecovery3D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    Patch Embedding Recovery to 3D Image.
+    r"""
+    Decode patch tokens back into a full-resolution 3D volume.
 
-    Args:
-        img_size (tuple[int]): Pl, Lat, Lon
-        patch_size (tuple[int]): Pl, Lat, Lon
-        in_chans (int): Number of input channels.
-        out_chans (int): Number of output channels.
+    Volumetric counterpart of :class:`PatchRecovery2D` and the inverse of
+    :class:`PatchEmbed3D`: a transposed convolution expands each token into its
+    ``(level, lat, lon)`` patch, and the result is center-cropped back to
+    ``img_size`` to undo any padding the encoder applied.
+
+    Parameters
+    ----------
+    img_size : tuple of int
+        Target output size as ``(pl, lat, lon)``.
+    patch_size : tuple of int
+        Patch size as ``(pl, lat, lon)``; must match the encoder's.
+    in_chans : int
+        Number of input channels, i.e. the token embedding dimension.
+    out_chans : int
+        Number of output channels.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn
     """
 
     def __init__(self, img_size, patch_size, in_chans, out_chans):
@@ -270,6 +496,19 @@ class PatchRecovery3D(nn.Module):
         self.conv = nn.ConvTranspose3d(in_chans, out_chans, patch_size, patch_size)
 
     def forward(self, x: torch.Tensor):
+        r"""
+        Expand tokens to grid space and center-crop to ``img_size``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Token tensor of shape ``(B, in_chans, L_p, H_p, W_p)`` on the patch grid.
+
+        Returns
+        -------
+        torch.Tensor
+            Volume of shape ``(B, out_chans, pl, lat, lon)``.
+        """
         output = self.conv(x)
         _, _, Pl, Lat, Lon = output.shape
 
@@ -296,6 +535,56 @@ class PatchRecovery3D(nn.Module):
 
 
 class EncoderDecoder(nn.Module):
+    r"""
+    Stack of pointwise layers used as an encoder or decoder head.
+
+    A configurable number of hidden layers, each a 1x1 convolution (or a
+    :class:`~torch.nn.Linear`, depending on ``input_format``) followed by an
+    activation, ending in a bias-free output projection. Acting only across
+    channels, it changes the feature dimension without touching spatial
+    structure -- which is what makes it the right tool for lifting input
+    variables into the model's latent width and projecting back out again.
+
+    Hidden layers are initialized with :math:`\mathcal{N}(0, 2/\mathrm{fan\_in})`
+    (He initialization, appropriate for the ReLU-family activations these are
+    used with), while the output layer uses ``gain / fan_in``, so callers can
+    scale down the final projection where a near-zero-variance initial output is
+    wanted.
+
+    Parameters
+    ----------
+    num_layers : int
+        Number of hidden layer/activation pairs before the output projection.
+        ``0`` gives a bare linear projection.
+    input_dim : int
+        Number of input channels/features.
+    output_dim : int
+        Number of output channels/features.
+    hidden_dim : int
+        Width of the hidden layers.
+    act_layer : callable
+        Activation module constructor, called with no arguments.
+    gain : float, optional
+        Scales the variance of the output layer's initialization, by default ``1.0``.
+    input_format : str, optional
+        ``"nchw"`` (default) uses 1x1 convolutions on ``(B, C, H, W)`` inputs;
+        ``"traditional"`` uses linear layers acting on the last dimension.
+    groups : int, optional
+        Number of groups for the convolutions, by default ``1``. Only meaningful
+        for ``"nchw"``; splits the channel mixing into independent blocks.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``input_format`` is not ``"nchw"`` or ``"traditional"``.
+
+    Notes
+    -----
+    All weights and biases are tagged ``is_shared_mp = ["spatial"]``: the layer
+    is pointwise, so every spatial rank holds the same parameters and their
+    gradients are reduced across the spatial group.
+    """
+
     def __init__(
         self,
         num_layers,
@@ -354,10 +643,87 @@ class EncoderDecoder(nn.Module):
         self.fwd = nn.Sequential(*encoder_modules)
 
     def forward(self, x):
+        r"""
+        Apply the stack of pointwise layers.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, input_dim, H, W)`` for ``input_format="nchw"``,
+            or ``(..., input_dim)`` for ``"traditional"``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output with the channel/feature dimension mapped to ``output_dim``
+            and all other dimensions unchanged.
+        """
         return self.fwd(x)
 
 
 class MLP(nn.Module):
+    r"""
+    Two-layer pointwise feed-forward block.
+
+    The channel-mixing half of a transformer or neural-operator block: expand to
+    ``hidden_features``, apply a nonlinearity, project back to
+    ``out_features``, with dropout after each stage. All operations are
+    pointwise in space, so spatial mixing is left entirely to the attention or
+    spectral layer this block is paired with.
+
+    Weights use :math:`\mathcal{N}(0, 2/\mathrm{fan\_in})` on the first layer and
+    ``gain / hidden_features`` on the second, so ``gain`` controls how strongly
+    the block contributes at initialization.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input channels/features.
+    hidden_features : int, optional
+        Width of the hidden layer, defaults to ``in_features``.
+    out_features : int, optional
+        Number of output channels/features, defaults to ``in_features``.
+    act_layer : callable, optional
+        Activation module constructor, by default :class:`torch.nn.GELU`.
+    output_bias : bool, optional
+        Whether the output projection carries a bias, by default ``True``.
+    input_format : str, optional
+        ``"nchw"`` (default) for ``(B, C, H, W)`` inputs, or ``"traditional"``
+        for channels-last inputs.
+    drop_rate : float, optional
+        Dropout probability, by default ``0.0`` (dropout replaced by identity).
+    drop_type : str, optional
+        ``"iid"`` (default) drops individual elements; ``"features"`` drops
+        whole channels via :class:`torch.nn.Dropout2d`. ``"features"`` requires
+        ``input_format="nchw"``.
+    checkpointing : bool, optional
+        If ``True``, recompute the block during the backward pass instead of
+        storing its activations, trading compute for memory. By default ``False``.
+    gain : float, optional
+        Scales the variance of the output layer's initialization, by default ``1.0``.
+    use_te : bool, optional
+        If ``True``, use TransformerEngine linear layers for the two GEMMs
+        (enabling FP8/FP4 paths). Silently falls back to the standard path with
+        a warning if TransformerEngine is not installed. Initialization is
+        identical either way, so toggling this does not change results at step 0.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``input_format`` is unsupported, if ``drop_type`` is unsupported, or
+        if ``"traditional"`` is combined with ``drop_type="features"``.
+
+    Notes
+    -----
+    TransformerEngine linears operate on the last dimension, so for ``"nchw"``
+    inputs the block transposes to channels-last around the GEMMs. When dropout
+    is elementwise the whole block stays channels-last and pays only one permute
+    in and one out; feature dropout needs ``nchw`` to drop at ``dim=1`` and
+    forces additional transposes.
+    """
+
     def __init__(
         self,
         in_features,
@@ -482,10 +848,44 @@ class MLP(nn.Module):
 
     @torch.compiler.disable(recursive=False)
     def checkpoint_forward(self, x):
+        r"""
+        Run the block under gradient checkpointing.
+
+        Activations are discarded and recomputed during the backward pass.
+        Normally reached via ``forward`` with ``checkpointing=True`` rather than
+        called directly.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input in the layout implied by ``input_format``.
+
+        Returns
+        -------
+        torch.Tensor
+            Same result as ``forward``, with the intermediate activations not
+            retained.
+        """
         fwd = self._te_forward if self.use_te else self.fwd
         return checkpoint(fwd, x, use_reentrant=False)
 
     def forward(self, x):
+        r"""
+        Apply the feed-forward block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_features, H, W)`` for
+            ``input_format="nchw"``, or ``(..., in_features)`` for
+            ``"traditional"``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output with the channel/feature dimension mapped to
+            ``out_features``, all other dimensions unchanged.
+        """
         if self.checkpointing:
             return self.checkpoint_forward(x)
         elif self.use_te:
@@ -495,15 +895,31 @@ class MLP(nn.Module):
 
 
 class UpSample2D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    2D Up-sampling operation.
+    r"""
+    Learned 2x upsampling of a token grid via channel-to-space rearrangement.
 
-    Args:
-        in_dim (int): Number of input channels.
-        out_dim (int): Number of output channels.
-        input_resolution (tuple[int]): [latitude, longitude]
-        output_resolution (tuple[int]): [latitude, longitude]
+    Rather than interpolating, each token is projected to four times the output
+    width and that channel block is reshaped into a 2x2 spatial neighborhood --
+    so the finer detail is *learned* from the coarse token, not smoothed in.
+    The doubled grid is then center-cropped to ``output_resolution``, which lets
+    the layer target resolutions that are not exactly twice the input, and a
+    LayerNorm plus a second projection mixes the result.
+
+    Parameters
+    ----------
+    in_dim : int
+        Number of input channels.
+    out_dim : int
+        Number of output channels.
+    input_resolution : tuple of int
+        Input grid as ``(latitude, longitude)``.
+    output_resolution : tuple of int
+        Output grid as ``(latitude, longitude)``. Must be no larger than twice
+        the input resolution along each axis.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn
     """
 
     def __init__(self, in_dim, out_dim, input_resolution, output_resolution):
@@ -515,9 +931,19 @@ class UpSample2D(nn.Module):
         self.output_resolution = output_resolution
 
     def forward(self, x: torch.Tensor):
-        """
-        Args:
-            x (torch.Tensor): (B, N, C)
+        r"""
+        Upsample the token grid and crop to the output resolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens as either ``(B, N, in_dim)`` with ``N = in_lat * in_lon``, or
+            ``(B, in_lat, in_lon, in_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, out_lat, out_lon, out_dim)``.
         """
         if len(x.shape) == 3:
             B, N, C = x.shape
@@ -556,14 +982,29 @@ class UpSample2D(nn.Module):
 
 
 class DownSample2D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    2D Down-sampling operation
+    r"""
+    Learned 2x downsampling of a token grid via space-to-channel rearrangement.
 
-    Args:
-        in_dim (int): Number of input channels.
-        input_resolution (tuple[int]): [latitude, longitude]
-        output_resolution (tuple[int]): [latitude, longitude]
+    The mirror image of :class:`UpSample2D`: the input is zero-padded to exactly
+    twice the output resolution, each 2x2 spatial neighborhood is folded into
+    the channel dimension (giving ``4 * in_dim`` channels), and a linear layer
+    then mixes those down to ``2 * in_dim``. Nothing is discarded before the
+    projection, so the layer learns which detail to keep instead of committing
+    to a fixed pooling rule.
+
+    Parameters
+    ----------
+    in_dim : int
+        Number of input channels. The output has ``2 * in_dim`` channels.
+    input_resolution : tuple of int
+        Input grid as ``(latitude, longitude)``.
+    output_resolution : tuple of int
+        Output grid as ``(latitude, longitude)``. Twice this resolution must be
+        at least the input resolution along each axis; the difference is padded.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn
     """
 
     def __init__(self, in_dim, input_resolution, output_resolution):
@@ -588,6 +1029,20 @@ class DownSample2D(nn.Module):
         self.pad = nn.ZeroPad2d((pad_left, pad_right, pad_top, pad_bottom))
 
     def forward(self, x: torch.Tensor):
+        r"""
+        Pad, fold 2x2 neighborhoods into channels, and project down.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens as either ``(B, N, in_dim)`` with ``N = in_lat * in_lon``, or
+            ``(B, in_lat, in_lon, in_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, out_lat, out_lon, 2 * in_dim)``.
+        """
         in_lat, in_lon = self.input_resolution
         out_lat, out_lon = self.output_resolution
         # unfold input resolution
@@ -617,16 +1072,32 @@ class DownSample2D(nn.Module):
 
 
 class UpSample3D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    3D Up-sampling operation.
-    Implementation from: https://github.com/198808xc/Pangu-Weather/blob/main/pseudocode.py
+    r"""
+    Learned 2x horizontal upsampling of a 3D token grid.
 
-    Args:
-        in_dim (int): Number of input channels.
-        out_dim (int): Number of output channels.
-        input_resolution (tuple[int]): [pressure levels, latitude, longitude]
-        output_resolution (tuple[int]): [pressure levels, latitude, longitude]
+    Volumetric counterpart of :class:`UpSample2D`. Upsampling is applied to the
+    latitude and longitude axes only -- the pressure-level axis is truncated to
+    ``out_pl`` rather than refined, since vertical levels are physically
+    distinct surfaces and interpolating between them is not meaningful the way
+    horizontal refinement is.
+
+    Parameters
+    ----------
+    in_dim : int
+        Number of input channels.
+    out_dim : int
+        Number of output channels.
+    input_resolution : tuple of int
+        Input grid as ``(pressure levels, latitude, longitude)``.
+    output_resolution : tuple of int
+        Output grid as ``(pressure levels, latitude, longitude)``. The
+        horizontal extents must be no larger than twice the input; ``out_pl``
+        must be no larger than ``in_pl``.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn,
+    implementation from https://github.com/198808xc/Pangu-Weather/blob/main/pseudocode.py
     """
 
     def __init__(self, in_dim, out_dim, input_resolution, output_resolution):
@@ -638,9 +1109,19 @@ class UpSample3D(nn.Module):
         self.output_resolution = output_resolution
 
     def forward(self, x: torch.Tensor):
-        """
-        Args:
-            x (torch.Tensor): (B, N, C)
+        r"""
+        Upsample horizontally, then crop levels and the horizontal extent.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens of shape ``(B, N, in_dim)`` with
+            ``N = in_pl * in_lat * in_lon``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, out_pl * out_lat * out_lon, out_dim)``.
         """
         B, N, C = x.shape
         in_pl, in_lat, in_lon = self.input_resolution
@@ -673,15 +1154,28 @@ class UpSample3D(nn.Module):
 
 
 class DownSample3D(nn.Module):
-    """
-    Revise from WeatherLearn https://github.com/lizhuoq/WeatherLearn
-    3D Down-sampling operation
-    Implementation from: https://github.com/198808xc/Pangu-Weather/blob/main/pseudocode.py
+    r"""
+    Learned 2x horizontal downsampling of a 3D token grid.
 
-    Args:
-        in_dim (int): Number of input channels.
-        input_resolution (tuple[int]): [pressure levels, latitude, longitude]
-        output_resolution (tuple[int]): [pressure levels, latitude, longitude]
+    Volumetric counterpart of :class:`DownSample2D`. Only the latitude and
+    longitude axes are folded into channels; the pressure-level axis is left
+    intact, so vertical resolution is preserved while the horizontal grid is
+    coarsened.
+
+    Parameters
+    ----------
+    in_dim : int
+        Number of input channels. The output has ``2 * in_dim`` channels.
+    input_resolution : tuple of int
+        Input grid as ``(pressure levels, latitude, longitude)``.
+    output_resolution : tuple of int
+        Output grid as ``(pressure levels, latitude, longitude)``. Twice the
+        horizontal extents must be at least the input's; the difference is padded.
+
+    References
+    ----------
+    Revised from WeatherLearn https://github.com/lizhuoq/WeatherLearn,
+    implementation from https://github.com/198808xc/Pangu-Weather/blob/main/pseudocode.py
     """
 
     def __init__(self, in_dim, input_resolution, output_resolution):
@@ -708,6 +1202,20 @@ class DownSample3D(nn.Module):
         self.pad = nn.ZeroPad3d((pad_left, pad_right, pad_top, pad_bottom, pad_front, pad_back))
 
     def forward(self, x):
+        r"""
+        Pad horizontally, fold 2x2 neighborhoods into channels, and project down.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens of shape ``(B, N, in_dim)`` with
+            ``N = in_pl * in_lat * in_lon``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, out_pl * out_lat * out_lon, 2 * in_dim)``.
+        """
         B, N, C = x.shape
         in_pl, in_lat, in_lon = self.input_resolution
         out_pl, out_lat, out_lon = self.output_resolution

--- a/makani/models/common/pos_embedding.py
+++ b/makani/models/common/pos_embedding.py
@@ -46,12 +46,26 @@ class PositionEmbedding(nn.Module, metaclass=abc.ABCMeta):
         self.num_chans = num_chans
 
     def forward(self):
+        r"""
+        Return the position embedding tensor.
+
+        Takes no input: the embedding depends only on grid position, so callers
+        add the returned tensor to their features themselves. Subclasses are
+        expected to override this if the embedding needs to be materialized or
+        broadcast before use.
+
+        Returns
+        -------
+        torch.Tensor
+            Embedding of shape ``(1, num_chans, H, W)``, broadcastable against a
+            feature tensor on the same grid.
+        """
 
         return self.position_embeddings
 
 
 class LearnablePositionEmbedding(PositionEmbedding):
-    """
+    r"""
     Learnable position embeddings for spherical transformers.
 
     This module provides learnable position embeddings that can be either
@@ -67,6 +81,27 @@ class LearnablePositionEmbedding(PositionEmbedding):
         Number of channels, by default 1
     embed_type : str, optional
         Embedding type ("lat" or "latlon"), by default "lat"
+
+    Raises
+    ------
+    ValueError
+        If ``embed_type`` is neither ``"lat"`` nor ``"latlon"``.
+
+    Notes
+    -----
+    ``"lat"`` learns one vector per latitude ring and broadcasts it along
+    longitude. This is the natural choice on a sphere: the physics is
+    zonally symmetric, so tying parameters along longitude cuts the parameter
+    count by a factor of ``nlon`` without giving up the pole-to-equator
+    structure the model actually needs. ``"latlon"`` learns an independent
+    vector per grid point and is only worth it when longitude-dependent
+    features (land-sea contrast, orography) must be memorized.
+
+    Under model parallelism the embedding is allocated at each rank's *local*
+    shape and tagged with its sharding, so it is sharded over ``h`` (and over
+    ``w`` for ``"latlon"``) rather than replicated. For ``"lat"`` the parameter
+    is marked shared across the ``w`` group, which keeps gradients consistent
+    across the ranks that hold the same latitudes.
     """
 
     def __init__(self, img_shape=(480, 960), grid="equiangular", num_chans=1, embed_type="lat"):
@@ -100,4 +135,17 @@ class LearnablePositionEmbedding(PositionEmbedding):
             raise ValueError(f"Unknown learnable position embedding type {embed_type}")
 
     def forward(self):
+        r"""
+        Return the learned embedding, expanded to the local grid shape.
+
+        For ``embed_type="lat"`` the stored parameter has a singleton longitude
+        dimension; expanding it here gives callers a tensor matching the local
+        feature map without materializing ``nlon`` copies of the parameter.
+
+        Returns
+        -------
+        torch.Tensor
+            Embedding of shape ``(1, num_chans, local_shape_h, local_shape_w)``.
+            This is a view of the parameter, not a copy.
+        """
         return self.position_embeddings.expand(-1, -1, self.local_shape_h, self.local_shape_w)

--- a/makani/models/common/spectral_convolution.py
+++ b/makani/models/common/spectral_convolution.py
@@ -35,10 +35,82 @@ import torch_harmonics.distributed as thd
 
 
 class SpectralConv(nn.Module):
-    """
-    Spectral Convolution implemented via SHT or FFT. Designed for convolutions on the two-sphere S2
-    using the Spherical Harmonic Transforms in torch-harmonics, but supports convolutions on the periodic
-    domain via the RealFFT2 and InverseRealFFT2 wrappers.
+    r"""
+    Spectral convolution implemented via SHT or FFT.
+
+    Convolution in grid space is multiplication in spectral space, so this layer
+    transforms the input, multiplies by learned coefficients, and transforms
+    back:
+
+    .. math::
+
+        y = \mathcal{F}^{-1}\bigl( W \cdot \mathcal{F}(x) \bigr)
+
+    The learned weights therefore act globally on the field at a cost set by the
+    transform rather than by a kernel radius. Designed for convolutions on the
+    two-sphere :math:`S^2` using the spherical harmonic transforms in
+    torch-harmonics, but it works on the periodic plane too if the
+    :class:`~makani.models.common.fft.RealFFT2` /
+    :class:`~makani.models.common.fft.InverseRealFFT2` wrappers are passed
+    instead -- the layer only requires the transform interface, not sphericity.
+
+    Two weight layouts are available via ``operator_type``:
+
+    * ``"dhconv"`` -- one weight per spherical degree :math:`l`, shared across
+      orders :math:`m`. This is exactly the condition for the operator to be a
+      genuine convolution on :math:`S^2` (rotationally equivariant), and it
+      keeps the parameter count linear in ``lmax``.
+    * ``"diagonal"`` -- an independent weight per :math:`(l, m)` pair. More
+      expressive, but no longer rotation-equivariant.
+
+    Transforms run in fp32 with autocast disabled: the SHT is a long
+    accumulation over quadrature points, and doing it in reduced precision
+    loses accuracy in the high-degree coefficients. Only the contraction runs
+    in the surrounding precision.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform (e.g. ``RealSHT`` or ``RealFFT2``).
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform. May target a different resolution or grid
+        than ``forward_transform``, in which case the residual is resampled
+        accordingly.
+    in_channels : int
+        Number of input channels. Must be divisible by ``num_groups``.
+    out_channels : int
+        Number of output channels. Must be divisible by ``num_groups``.
+    num_groups : int, optional
+        Number of channel groups mixed independently, by default ``1``.
+    operator_type : str, optional
+        ``"dhconv"`` (default) or ``"diagonal"``; see above.
+    separable : bool, optional
+        If ``True``, apply one weight per input channel instead of mixing
+        channels, making the layer depthwise. Requires
+        ``out_channels == in_channels``. By default ``False``.
+    bias : bool, optional
+        If ``True``, add a learned per-channel bias in grid space, by default
+        ``False``.
+    gain : float, optional
+        Scales the variance of the weight initialization, by default ``1.0``.
+
+    Returns
+    -------
+    See ``forward``, which returns both the transformed output and a residual.
+
+    Raises
+    ------
+    ValueError
+        If the channel counts are not divisible by ``num_groups``, if the
+        inverse transform's mode counts disagree with the forward transform's,
+        or if ``operator_type`` is unsupported.
+
+    Notes
+    -----
+    Under model parallelism the weight is sharded along its spectral dimensions
+    (``h`` for degrees, ``w`` for orders) and marked shared over the groups it
+    is replicated across, so gradients are reduced correctly. For ``"dhconv"``
+    there is no order dimension, hence the weight is shared over ``w``.
     """
 
     def __init__(
@@ -139,6 +211,26 @@ class SpectralConv(nn.Module):
             self.bias.sharded_dims_mp = [None, None, None, None]
 
     def forward(self, x):
+        r"""
+        Transform, apply the learned spectral weights, and transform back.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, in_channels, nlat, nlon)`` on the grid
+            the forward transform was constructed for.
+
+        Returns
+        -------
+        x : torch.Tensor
+            Output field of shape ``(B, out_channels, nlat_out, nlon_out)``.
+        residual : torch.Tensor
+            The input, resampled onto the output grid if the forward and
+            inverse transforms differ in resolution or grid type, and returned
+            unchanged otherwise. Returned so the caller can form its own skip
+            connection at the correct resolution, which it could not do itself
+            without repeating the transform.
+        """
         dtype = x.dtype
         residual = x
 
@@ -173,8 +265,65 @@ class SpectralConv(nn.Module):
 
 
 class SpectralAttention(nn.Module):
-    """
-    Spherical non-linear FNO layer
+    r"""
+    Nonlinear spectral layer: an MLP applied in spherical harmonic space.
+
+    Where :class:`SpectralConv` multiplies the spectrum by a fixed learned
+    factor, this layer runs a small complex-valued MLP over the coefficients,
+
+    .. math::
+
+        y = \mathcal{F}^{-1}\bigl( \mathrm{MLP}(\mathcal{F}(x)) \bigr)
+
+    with complex activations between the layers. Interleaving nonlinearities
+    with the channel mixing lets modes interact rather than each being scaled
+    independently, which is what the "attention" in the name refers to -- it is
+    not dot-product attention.
+
+    Two weight layouts are available via ``operator_type``:
+
+    * ``"diagonal"`` -- one weight matrix shared across all modes.
+    * ``"l-dependant"`` -- an independent weight matrix per spherical degree
+      :math:`l`, so the channel mixing can vary with spatial scale. Costs a
+      factor of ``lmax`` more parameters.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform. May target a different resolution or grid.
+    in_channels : int
+        Number of input channels.
+    out_channels : int
+        Number of output channels.
+    operator_type : str, optional
+        ``"diagonal"`` (default) or ``"l-dependant"``; see above.
+    hidden_size_factor : int, optional
+        Hidden width of the spectral MLP as a multiple of ``in_channels``, by
+        default ``2``.
+    complex_activation : str, optional
+        Mode passed to :class:`~makani.models.common.activations.ComplexReLU`,
+        by default ``"real"``.
+    bias : bool, optional
+        If ``True``, add a learned complex bias in each spectral layer, by
+        default ``False``.
+    spectral_layers : int, optional
+        Number of hidden layers in the spectral MLP, by default ``1``.
+    drop_rate : float, optional
+        Dropout probability applied after each activation, by default ``0.0``.
+    gain : float, optional
+        Scales the variance of the output weight's initialization, by default ``1.0``.
+
+    Raises
+    ------
+    ValueError
+        If the inverse transform's mode counts disagree with the forward
+        transform's, or if ``operator_type`` is unknown.
+
+    See Also
+    --------
+    SpectralConv : the linear, cheaper spectral layer.
     """
 
     def __init__(
@@ -282,6 +431,23 @@ class SpectralAttention(nn.Module):
         self.drop = nn.Dropout(drop_rate) if drop_rate > 0.0 else nn.Identity()
 
     def forward_mlp(self, x):
+        r"""
+        Run the complex-valued MLP on spectral coefficients.
+
+        Exposed separately from ``forward`` so the spectral MLP can be applied
+        to coefficients that are already in spectral space, without paying for a
+        transform round trip.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Complex coefficients of shape ``(B, in_channels, lmax, mmax)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Complex coefficients of shape ``(B, out_channels, lmax, mmax)``.
+        """
         B, C, H, W = x.shape
 
         xr = torch.view_as_real(x)
@@ -304,6 +470,23 @@ class SpectralAttention(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Transform, apply the spectral MLP, and transform back.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, in_channels, nlat, nlon)``.
+
+        Returns
+        -------
+        x : torch.Tensor
+            Output field of shape ``(B, out_channels, nlat_out, nlon_out)``.
+        residual : torch.Tensor
+            The input, resampled onto the output grid if the forward and
+            inverse transforms differ, and unchanged otherwise. Returned so the
+            caller can form a skip connection at the correct resolution.
+        """
         dtype = x.dtype
         residual = x
 

--- a/makani/models/model_package.py
+++ b/makani/models/model_package.py
@@ -35,8 +35,19 @@ logger = logging.getLogger(__name__)
 
 
 class LocalPackage:
-    """
-    Implements the modulus Package interface.
+    r"""
+    Filesystem-backed model package, implementing the PhysicsNeMo Package interface.
+
+    A model package bundles everything needed to run a trained model outside the
+    training environment: the checkpoint, the config, the normalization
+    statistics, and the static fields. This class resolves the well-known
+    filenames within a package directory, so consumers refer to package members
+    by name rather than hard-coding the layout.
+
+    Parameters
+    ----------
+    root : str
+        Path to the package directory.
     """
 
     # These define the model package in terms of where makani expects the files to be located
@@ -54,6 +65,20 @@ class LocalPackage:
         self.root = root
 
     def get(self, path):
+        r"""
+        Resolve a package-relative path to an absolute one.
+
+        Parameters
+        ----------
+        path : str
+            Path relative to the package root, typically one of the class-level
+            filename constants.
+
+        Returns
+        -------
+        str
+            The absolute path. Existence is not checked.
+        """
         return os.path.join(self.root, path)
 
     @staticmethod
@@ -77,8 +102,25 @@ class LocalPackage:
 
 
 class ModelWrapper(torch.nn.Module):
-    """
+    r"""
     Model wrapper to make inference simple outside of makani.
+
+    Presents a trained model as a plain callable that takes physical fields and
+    a valid time, so downstream consumers do not need makani's training
+    machinery. The wrapper owns the pieces that would otherwise be the caller's
+    problem: input and output normalization, the lat-lon grid definition, and
+    the solar zenith angle channel, which has to be computed from the valid time
+    rather than read from the data.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        ML model that is wrapped.
+    params : ParamsBase
+        Parameter object containing information on how the model was
+        initialized in makani. Params assembled outside
+        :func:`load_model_package` (e.g. by earth2studio) are tolerated and do
+        not need to carry the resampled shapes.
 
     Attributes
     ----------
@@ -86,6 +128,12 @@ class ModelWrapper(torch.nn.Module):
         ML model that is wrapped.
     params : ParamsBase
         parameter object containing information on how the model was initialized in makani
+    lats : numpy.ndarray
+        Latitudes of the model grid, taken from ``params`` if present and
+        otherwise assumed equiangular from 90 to -90.
+    lons : numpy.ndarray
+        Longitudes of the model grid, taken from ``params`` if present and
+        otherwise assumed equiangular from 0 to 360.
 
     Methods
     -------
@@ -136,14 +184,39 @@ class ModelWrapper(torch.nn.Module):
 
     @property
     def in_channels(self):
+        r"""
+        Names of the input channels.
+
+        Returns
+        -------
+        list of str or None
+            Channel names, or ``None`` if the config does not record them.
+        """
         return self.params.get("channel_names", None)
 
     @property
     def out_channels(self):
+        r"""
+        Names of the output channels.
+
+        Returns
+        -------
+        list of str or None
+            Channel names, or ``None`` if the config does not record them.
+        """
         return self.params.get("channel_names", None)
 
     @property
     def timestep(self):
+        r"""
+        Model time step in hours.
+
+        Returns
+        -------
+        int or float
+            ``dt * dhours``: the number of data steps per model step times the
+            spacing of the data in hours.
+        """
         return self.params.dt * self.params.dhours
 
     def update_state(self, replace_state=True, batch_size=None):
@@ -159,6 +232,19 @@ class ModelWrapper(torch.nn.Module):
         return
 
     def set_rng(self, reset=True, seed=333):
+        r"""
+        Re-seed the model's stochastic noise, optionally clearing its state.
+
+        Use this to make an ensemble member reproducible, or to decorrelate
+        members by giving each a distinct seed.
+
+        Parameters
+        ----------
+        reset : bool, optional
+            Also zero the noise state, by default ``True``.
+        seed : int, optional
+            New seed, by default ``333``.
+        """
         self.model.preprocessor.set_rng(reset=reset, seed=seed)
         return
 

--- a/makani/models/networks/afnonet.py
+++ b/makani/models/networks/afnonet.py
@@ -22,19 +22,65 @@ from makani.models.common import DropPath, PatchEmbed2D
 
 
 class PeriodicPad2d(nn.Module):
-    """Pad longitudinal (left-right) circular, pad latitude (top-bottom) with zeros."""
+    r"""
+    Pad longitudinal (left-right) circular, pad latitude (top-bottom) with zeros.
+
+    Matches the topology of a global lat-lon grid: longitude wraps around, so
+    the left and right edges are genuinely adjacent and are padded circularly,
+    while latitude terminates at the poles and is padded with zeros.
+
+    Parameters
+    ----------
+    pad_width : int
+        Number of cells added on each of the four sides.
+    """
 
     def __init__(self, pad_width):
         super(PeriodicPad2d, self).__init__()
         self.pad_width = pad_width
 
     def forward(self, x):
+        r"""
+        Pad the input according to the grid topology.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, C, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Padded tensor of shape
+            ``(B, C, H + 2 * pad_width, W + 2 * pad_width)``.
+        """
         out = F.pad(x, (self.pad_width, self.pad_width, 0, 0), mode="circular")
         out = F.pad(out, (0, 0, self.pad_width, self.pad_width), mode="constant", value=0)
         return out
 
 
 class Mlp(nn.Module):
+    r"""
+    Two-layer channels-last feed-forward block.
+
+    The MLP used inside :class:`Block`. Simpler than
+    :class:`~makani.models.common.layers.MLP`: linear layers only, no
+    model-parallel or TransformerEngine paths.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    hidden_features : int, optional
+        Hidden width, defaults to ``in_features``.
+    out_features : int, optional
+        Number of output features, defaults to ``in_features``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    drop : float, optional
+        Dropout probability applied after each layer, by default ``0.0``.
+    """
+
     def __init__(self, in_features, hidden_features=None, out_features=None, act_layer=nn.GELU, drop=0.0):
         super().__init__()
         out_features = out_features or in_features
@@ -45,6 +91,19 @@ class Mlp(nn.Module):
         self.drop = nn.Dropout(drop)
 
     def forward(self, x):
+        r"""
+        Apply the feed-forward block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(..., in_features)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``(..., out_features)``.
+        """
         x = self.fc1(x)
         x = self.act(x)
         x = self.drop(x)
@@ -54,6 +113,53 @@ class Mlp(nn.Module):
 
 
 class AFNO2D(nn.Module):
+    r"""
+    Adaptive Fourier Neural Operator token mixer.
+
+    Mixes tokens by transforming to Fourier space, applying a two-layer
+    block-diagonal MLP to the complex coefficients, and transforming back:
+
+    .. math::
+
+        y = \mathcal{F}^{-1}\bigl(S_\lambda(\mathrm{MLP}(\mathcal{F}(x)))\bigr) + x
+
+    Three choices make this cheaper than dense spectral mixing. The channel
+    dimension is split into ``num_blocks`` groups mixed independently, so the
+    weights are block-diagonal rather than full. Only a fraction of the modes is
+    retained (``hard_thresholding_fraction``), discarding the high frequencies.
+    And a soft-shrink :math:`S_\lambda` sparsifies the coefficients, which acts
+    as a learned frequency-domain filter.
+
+    The transform is always taken in fp32 regardless of autocast, since the FFT
+    accumulates over the whole grid.
+
+    Parameters
+    ----------
+    hidden_size : int
+        Channel dimension. Must be divisible by ``num_blocks``.
+    num_blocks : int, optional
+        Number of independently mixed channel blocks, by default ``8``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold :math:`\lambda` applied to the output
+        coefficients, by default ``0.01``.
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1`` (keep all).
+    hidden_size_factor : int, optional
+        Width of the spectral MLP's hidden layer as a multiple of the block
+        size, by default ``1``.
+
+    Raises
+    ------
+    ValueError
+        If ``hidden_size`` is not divisible by ``num_blocks``.
+
+    References
+    ----------
+    Guibas, J.; Mardani, M.; Pathak, J.; Vahdat, A.; Kashinath, K.; Catanzaro,
+    B.; Anandkumar, A.; Adaptive Fourier Neural Operators: Efficient Token
+    Mixers for Transformers; ICLR 2022.
+    """
+
     def __init__(
         self, hidden_size, num_blocks=8, sparsity_threshold=0.01, hard_thresholding_fraction=1, hidden_size_factor=1
     ):
@@ -79,6 +185,19 @@ class AFNO2D(nn.Module):
         self.b2 = nn.Parameter(self.scale * torch.randn(2, self.num_blocks, self.block_size))
 
     def forward(self, x):
+        r"""
+        Mix tokens in Fourier space and add the input back as a residual.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, H, W, hidden_size)``, channels last.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``, with the input added back.
+        """
         bias = x
 
         dtype = x.dtype
@@ -167,6 +286,39 @@ class AFNO2D(nn.Module):
 
 
 class Block(nn.Module):
+    r"""
+    AFNO block: spectral token mixing followed by a channel MLP.
+
+    Structurally a transformer block with :class:`AFNO2D` in place of
+    attention. ``double_skip`` selects between two residual arrangements: with
+    it enabled each sublayer gets its own skip, and with it disabled a single
+    skip spans both.
+
+    Parameters
+    ----------
+    dim : int
+        Channel dimension.
+    mlp_ratio : float, optional
+        Hidden width of the MLP as a multiple of ``dim``, by default ``4.0``.
+    drop : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    drop_path : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    norm_layer : callable, optional
+        Normalization constructor, by default :class:`torch.nn.LayerNorm`.
+    double_skip : bool, optional
+        Use a separate residual connection around each sublayer, by default
+        ``True``.
+    num_blocks : int, optional
+        Number of channel blocks in the AFNO mixer, by default ``8``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold in the AFNO mixer, by default ``0.01``.
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1.0``.
+    """
+
     def __init__(
         self,
         dim,
@@ -191,6 +343,19 @@ class Block(nn.Module):
         self.double_skip = double_skip
 
     def forward(self, x):
+        r"""
+        Apply spectral mixing and the channel MLP with residual connections.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, H, W, dim)``, channels last.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``.
+        """
         residual = x
         x = self.norm1(x)
         x = self.filter(x)
@@ -207,6 +372,29 @@ class Block(nn.Module):
 
 
 class PrecipNet(nn.Module):
+    r"""
+    Precipitation head on top of a forecasting backbone.
+
+    Runs a backbone and post-processes its output with a periodically padded
+    3x3 convolution and a ReLU. The ReLU matters physically: precipitation
+    cannot be negative, and clamping it in the architecture is more reliable
+    than hoping the loss enforces it. The local convolution smooths the
+    backbone's output, which suits a field that is spatially patchy.
+
+    Parameters
+    ----------
+    backbone : torch.nn.Module
+        Model producing the field this head refines.
+    patch_size : (int, int), optional
+        Recorded for reference, by default ``(16, 16)``.
+    inp_chans : int, optional
+        Number of backbone input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+    """
+
     def __init__(self, backbone, patch_size=(16, 16), inp_chans=2, out_chans=2, **kwargs):
         super().__init__()
         self.patch_size = patch_size
@@ -218,6 +406,19 @@ class PrecipNet(nn.Module):
         self.act = nn.ReLU()
 
     def forward(self, x):
+        r"""
+        Run the backbone and refine its output into a non-negative field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Non-negative prediction of shape ``(B, out_chans, nlat, nlon)``.
+        """
         x = self.backbone(x)
         x = self.ppad(x)
         x = self.conv(x)
@@ -226,6 +427,54 @@ class PrecipNet(nn.Module):
 
 
 class AdaptiveFourierNeuralOperatorNet(nn.Module):
+    r"""
+    Adaptive Fourier Neural Operator network (AFNO).
+
+    A transformer-shaped architecture in which attention is replaced by the
+    :class:`AFNO2D` spectral mixer. The input is tokenized by patch embedding, a
+    stack of :class:`Block` layers mixes the tokens, and a linear head decodes
+    each token back into its patch. Replacing attention with an FFT-based mixer
+    reduces the token-mixing cost from quadratic to ``O(N log N)``, which is
+    what makes high-resolution inputs affordable.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(720, 1440)``.
+    patch_size : (int, int), optional
+        Patch size, by default ``(6, 6)``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    embed_dim : int, optional
+        Token dimension, by default ``768``.
+    num_layers : int, optional
+        Number of AFNO blocks, by default ``12``.
+    mlp_ratio : float, optional
+        Hidden width of the block MLPs as a multiple of ``embed_dim``, by
+        default ``4.0``.
+    drop_rate : float, optional
+        Dropout probability, by default ``0.0``.
+    drop_path_rate : float, optional
+        Maximum stochastic depth probability, ramped linearly across the depth,
+        by default ``0.0``.
+    num_blocks : int, optional
+        Number of independently mixed channel blocks in each AFNO mixer, by
+        default ``16``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold in the AFNO mixers, by default ``0.01``.
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1.0``.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+
+    References
+    ----------
+    Guibas, J. et al.; Adaptive Fourier Neural Operators: Efficient Token
+    Mixers for Transformers; ICLR 2022.
+    """
+
     def __init__(
         self,
         inp_shape=(720, 1440),
@@ -297,9 +546,38 @@ class AdaptiveFourierNeuralOperatorNet(nn.Module):
 
     @torch.compiler.disable(recursive=True)
     def no_weight_decay(self):
+        r"""
+        Parameters that should be excluded from weight decay.
+
+        Position embeddings and class tokens encode location and identity
+        rather than a learned transformation, so decaying them toward zero
+        degrades the model instead of regularizing it.
+
+        Returns
+        -------
+        set of str
+            Names of the parameters to exclude.
+        """
         return {"pos_embed", "cls_token"}
 
     def forward_features(self, x):
+        r"""
+        Tokenize the input and run it through the AFNO blocks.
+
+        Exposed separately from ``forward`` so callers can obtain the latent
+        token grid without decoding it back to a field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Token grid of shape ``(B, h, w, embed_dim)``, where ``h`` and ``w``
+            are the patched grid dimensions.
+        """
         B = x.shape[0]
         x = self.patch_embed(x).transpose(1, 2)
         x = x + self.pos_embed
@@ -312,6 +590,19 @@ class AdaptiveFourierNeuralOperatorNet(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)``.
+        """
         x = self.forward_features(x)
         x = self.head(x)
 

--- a/makani/models/networks/afnonet_v2.py
+++ b/makani/models/networks/afnonet_v2.py
@@ -25,6 +25,28 @@ from makani.models.common import ComplexReLU, PatchEmbed2D, DropPath, MLP
 
 @torch.compile
 def compl_mul_add_fwd(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    r"""
+    Block-diagonal complex matmul over real-viewed tensors.
+
+    Computes :math:`y_{b,k,o,x,y} = \sum_i a_{b,k,i,x,y} w_{k,i,o}` with complex
+    arithmetic expressed on the real and imaginary components explicitly rather
+    than on complex dtypes. Complex kernels are not always supported by the
+    compiler backends, so this variant keeps the whole block compilable;
+    :func:`compl_mul_add_fwd_c` is the complex-dtype equivalent.
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        Input of shape ``(B, num_blocks, in_block, H, W, 2)``, where the
+        trailing axis holds the real and imaginary parts.
+    b : torch.Tensor
+        Weight of shape ``(num_blocks, in_block, out_block, 2)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(B, num_blocks, out_block, H, W, 2)``.
+    """
     tmp = torch.einsum("bkixys,kior->srbkoxy", a, b)
     res = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
     return res
@@ -32,6 +54,26 @@ def compl_mul_add_fwd(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
 @torch.compile
 def compl_mul_add_fwd_c(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    r"""
+    Block-diagonal complex matmul using native complex dtypes.
+
+    Same contraction as :func:`compl_mul_add_fwd`, but performed with
+    ``complex64`` tensors instead of explicit real/imaginary bookkeeping. Faster
+    where the backend supports complex arithmetic; selected via the
+    ``use_complex_kernels`` flag on :class:`AFNO2D`.
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        Input of shape ``(B, num_blocks, in_block, H, W, 2)``, real-viewed.
+    b : torch.Tensor
+        Weight of shape ``(num_blocks, in_block, out_block, 2)``, real-viewed.
+
+    Returns
+    -------
+    torch.Tensor
+        Output of shape ``(B, num_blocks, out_block, H, W, 2)``, real-viewed.
+    """
     ac = torch.view_as_complex(a)
     bc = torch.view_as_complex(b)
     resc = torch.einsum("bkixy,kio->bkoxy", ac, bc)
@@ -40,6 +82,41 @@ def compl_mul_add_fwd_c(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
 
 class AFNO2D(nn.Module):
+    r"""
+    Adaptive Fourier Neural Operator token mixer, channels-first variant.
+
+    Same idea as :class:`makani.models.networks.afnonet.AFNO2D` -- FFT, a
+    block-diagonal complex MLP over the coefficients, soft-shrink, inverse FFT
+    -- with three practical differences: it operates on ``(B, C, H, W)`` inputs
+    instead of channels-last, it uses a complex activation
+    (:class:`~makani.models.common.activations.ComplexReLU`) rather than a
+    real one applied componentwise, and truncation is two-sided along the
+    unhalved axis so both positive and negative frequencies are retained.
+
+    Parameters
+    ----------
+    hidden_size : int
+        Channel dimension. Must be divisible by ``num_blocks``.
+    num_blocks : int, optional
+        Number of independently mixed channel blocks, by default ``8``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold on the output coefficients, by default ``0.0``
+        (no sparsification).
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1`` (keep all).
+    hidden_size_factor : int, optional
+        Width of the spectral MLP's hidden layer as a multiple of the block
+        size, by default ``1``.
+    use_complex_kernels : bool, optional
+        Use native complex arithmetic for the contraction rather than explicit
+        real/imaginary bookkeeping, by default ``False``.
+
+    Raises
+    ------
+    ValueError
+        If ``hidden_size`` is not divisible by ``num_blocks``.
+    """
+
     def __init__(
         self,
         hidden_size,
@@ -76,6 +153,20 @@ class AFNO2D(nn.Module):
         self.act = ComplexReLU(negative_slope=0.0, mode="cartesian")
 
     def forward(self, x):
+        r"""
+        Mix channels in Fourier space and add the input back as a residual.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, hidden_size, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``, with a learned bias and the
+            input added back.
+        """
         bias = x
 
         dtype = x.dtype
@@ -118,6 +209,58 @@ class AFNO2D(nn.Module):
 
 
 class Block(nn.Module):
+    r"""
+    AFNO block with configurable skip connections, channels-first variant.
+
+    Spectral mixing via :class:`AFNO2D` followed by a channel MLP, each behind a
+    normalization. Compared with
+    :class:`makani.models.networks.afnonet.Block`, the skip around the filter is
+    configurable -- it can be a learned 1x1 convolution, an identity, or absent
+    entirely -- and ``nested_skip_fno`` controls whether the MLP's residual
+    starts from the block input or from the filter output.
+
+    Parameters
+    ----------
+    h : int
+        Height of the token grid. Recorded for the normalization layers.
+    w : int
+        Width of the token grid.
+    dim : int
+        Channel dimension.
+    mlp_ratio : float, optional
+        Hidden width of the MLP as a multiple of ``dim``, by default ``4.0``.
+    drop : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    drop_path : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    norm_layer : callable, optional
+        Normalization constructor, called with no arguments. By default
+        :class:`torch.nn.LayerNorm`.
+    num_blocks : int, optional
+        Number of channel blocks in the AFNO mixer, by default ``8``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold in the AFNO mixer, by default ``0.01``.
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1.0``.
+    use_complex_kernels : bool, optional
+        Use native complex arithmetic in the mixer, by default ``True``.
+    skip_fno : str, optional
+        Skip connection around the filter: ``"linear"`` (default),
+        ``"identity"``, or ``None`` for none. Unrecognized values are treated
+        as ``None``.
+    nested_skip_fno : bool, optional
+        If ``True`` (the default), the MLP's residual is the block input, so
+        the two skips nest. If ``False``, it is the filter output, so they are
+        sequential.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness; the MLP is checkpointed at level
+        2 and above. By default ``0``.
+    verbose : bool, optional
+        Print which skip configuration was selected, by default ``True``.
+    """
+
     def __init__(
         self,
         h,
@@ -185,6 +328,19 @@ class Block(nn.Module):
         )
 
     def forward(self, x):
+        r"""
+        Apply spectral mixing and the channel MLP with the configured skips.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, dim, h, w)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``.
+        """
         residual = x
 
         x = self.norm1(x)
@@ -203,6 +359,69 @@ class Block(nn.Module):
 
 
 class AdaptiveFourierNeuralOperatorNet(nn.Module):
+    r"""
+    Adaptive Fourier Neural Operator network, revised implementation.
+
+    Same architecture as
+    :class:`makani.models.networks.afnonet.AdaptiveFourierNeuralOperatorNet` --
+    patch embedding, a stack of AFNO blocks, a linear decode head -- but working
+    in channels-first layout with a configurable normalization layer,
+    configurable skip connections around each filter, and gradient
+    checkpointing.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(720, 1440)``. Must be
+        divisible by ``patch_size``.
+    patch_size : (int, int), optional
+        Patch size, by default ``(6, 6)``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    embed_dim : int, optional
+        Token dimension, by default ``768``.
+    num_layers : int, optional
+        Number of AFNO blocks, by default ``12``.
+    mlp_ratio : float, optional
+        Hidden width of the block MLPs as a multiple of ``embed_dim``, by
+        default ``4.0``.
+    drop_rate : float, optional
+        Dropout probability, by default ``0.0``.
+    drop_path_rate : float, optional
+        Maximum stochastic depth probability, ramped linearly across the depth,
+        by default ``0.0``.
+    num_blocks : int, optional
+        Number of channel blocks in each AFNO mixer, by default ``16``.
+    sparsity_threshold : float, optional
+        Soft-shrink threshold in the AFNO mixers, by default ``0.01``.
+    normalization_layer : str, optional
+        ``"instance_norm"`` (default) or ``"layer_norm"``.
+    skip_fno : str, optional
+        Skip connection around each filter: ``"linear"`` (default),
+        ``"identity"``, or ``None``.
+    nested_skip_fno : bool, optional
+        Whether the block's two skips nest rather than run sequentially, by
+        default ``True``.
+    hard_thresholding_fraction : float, optional
+        Fraction of Fourier modes retained, by default ``1.0``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness, by default ``0``.
+    use_complex_kernels : bool, optional
+        Use native complex arithmetic in the mixers, by default ``True``.
+    verbose : bool, optional
+        Print the skip configuration of each block, by default ``False``.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+
+    Raises
+    ------
+    ValueError
+        If ``patch_size`` does not have two entries, if it does not divide the
+        image dimensions evenly, or if ``normalization_layer`` is unsupported.
+    """
+
     def __init__(
         self,
         inp_shape=(720, 1440),
@@ -306,9 +525,35 @@ class AdaptiveFourierNeuralOperatorNet(nn.Module):
 
     @torch.compiler.disable(recursive=False)
     def no_weight_decay(self):
+        r"""
+        Parameters that should be excluded from weight decay.
+
+        Position embeddings and class tokens encode location and identity
+        rather than a learned transformation, so decaying them degrades the
+        model instead of regularizing it.
+
+        Returns
+        -------
+        set of str
+            Names of the parameters to exclude.
+        """
         return {"pos_embed", "cls_token"}
 
     def forward_features(self, x):
+        r"""
+        Tokenize the input and run it through the AFNO blocks.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Latent grid of shape ``(B, embed_dim, h, w)``, where ``h`` and ``w``
+            are the patched grid dimensions.
+        """
         B = x.shape[0]
         x = self.patch_embed(x)
         x = x + self.pos_embed
@@ -323,6 +568,19 @@ class AdaptiveFourierNeuralOperatorNet(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)``.
+        """
         x = self.forward_features(x)
         x = self.head(x)
 

--- a/makani/models/networks/debug.py
+++ b/makani/models/networks/debug.py
@@ -18,6 +18,22 @@ from torch import nn
 
 
 class DebugNet(nn.Module):
+    r"""
+    Trivial pass-through network for testing the training pipeline.
+
+    Multiplies its input by a single learned scalar, initialized to one. That
+    scalar exists only so optimizer construction and the gradient reduction
+    hooks have something to work with -- a network with no parameters would
+    crash them. Use this to exercise the dataloader, loss, checkpointing and
+    distributed plumbing without the cost or the confounding behavior of a real
+    model.
+
+    Parameters
+    ----------
+    **kwargs
+        Ignored; accepted so the model registry can pass a full model config.
+    """
+
     def __init__(self, **kwargs):
         super().__init__()
 
@@ -25,4 +41,19 @@ class DebugNet(nn.Module):
         self.factor = nn.Parameter(torch.ones((1), dtype=torch.float32))
 
     def forward(self, x):
+        r"""
+        Scale the input by the learned scalar.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of any shape.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``. Note the channel count is
+            unchanged, so this only stands in for a model whose input and
+            output channels match.
+        """
         return self.factor * x

--- a/makani/models/networks/fourcastnet3.py
+++ b/makani/models/networks/fourcastnet3.py
@@ -38,8 +38,9 @@ from makani.utils import comm
 
 # for annotation of models
 from dataclasses import dataclass
-import physicsnemo
 from physicsnemo import ModelMetaData
+
+from makani.models.physicsnemo_compat import module_from_torch
 
 
 # heuristic for finding theta_cutoff
@@ -114,6 +115,54 @@ def _get_norm_layer_handle(
 
 
 class DiscreteContinuousEncoder(nn.Module):
+    r"""
+    Encoder built on a discrete-continuous convolution on the sphere.
+
+    Lifts input variables into the model's latent width while resampling from
+    the data grid onto the (typically coarser) model grid. A
+    discrete-continuous convolution is defined by a *continuous* kernel
+    evaluated at the actual angular positions of the grid points, so input and
+    output grids need not agree and the operator remains a genuine spherical
+    convolution rather than an approximation on a lat-lon array.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    use_mlp : bool, optional
+        Follow the convolution with an activation and a pointwise MLP, by
+        default ``False``. When enabled the convolution weights are scaled by
+        :math:`\sqrt{2}` to compensate for the variance the activation removes.
+    mlp_ratio : float, optional
+        Hidden width of that MLP as a multiple of ``out_chans``, by default ``2.0``.
+    activation_function : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+
+    See Also
+    --------
+    DiscreteContinuousDecoder : the corresponding decoder.
+    """
+
     def __init__(
         self,
         inp_shape=(721, 1440),
@@ -177,6 +226,19 @@ class DiscreteContinuousEncoder(nn.Module):
             )
 
     def forward(self, x):
+        r"""
+        Encode the input field onto the model grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Encoded field of shape ``(B, out_chans, *out_shape)``.
+        """
 
         # convolution
         x = self.conv(x)
@@ -191,6 +253,56 @@ class DiscreteContinuousEncoder(nn.Module):
 
 
 class DiscreteContinuousDecoder(nn.Module):
+    r"""
+    Decoder built on a discrete-continuous convolution on the sphere.
+
+    Mirror of :class:`DiscreteContinuousEncoder`: projects latent features back
+    to output variables while resampling from the model grid onto the (typically
+    finer) data grid. Upsampling happens before the convolution and runs in fp32
+    with autocast disabled, since it is a long accumulation whose accuracy the
+    output depends on directly.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    use_mlp : bool, optional
+        Precede the convolution with a pointwise MLP and activation, by
+        default ``False``.
+    mlp_ratio : float, optional
+        Hidden width of that MLP as a multiple of ``inp_chans``, by default ``2.0``.
+    activation_function : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    upsample_sht : bool, optional
+        Upsample spectrally via an SHT rather than by interpolation, by default
+        ``False``. Spectral upsampling is exact for band-limited fields but
+        costs more.
+
+    See Also
+    --------
+    DiscreteContinuousEncoder : the corresponding encoder.
+    """
+
     def __init__(
         self,
         inp_shape=(480, 960),
@@ -275,6 +387,20 @@ class DiscreteContinuousDecoder(nn.Module):
                 self.conv.bias.sharded_dims_mp = [None]
 
     def forward(self, x):
+        r"""
+        Decode latent features onto the output grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Latent field of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output field of shape ``(B, out_chans, *out_shape)``, cast back to
+            the dtype of ``x``.
+        """
         dtype = x.dtype
 
         if hasattr(self, "act"):
@@ -293,6 +419,62 @@ class DiscreteContinuousDecoder(nn.Module):
 
 
 class NeuralOperatorBlock(nn.Module):
+    r"""
+    Processor block mixing spatially via either a local or a global operator.
+
+    The building block of the FourCastNet 3 processor. ``conv_type`` selects
+    between a discrete-continuous convolution with a bounded angular footprint
+    (``"local"``) and a spectral convolution acting on all modes at once
+    (``"global"``). Interleaving the two lets the model capture fine local
+    structure and long-range teleconnections without paying global cost in every
+    layer.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform; also defines the input grid.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform; also defines the output grid, which may
+        differ in resolution.
+    inp_chans : int
+        Number of input channels.
+    out_chans : int
+        Number of output channels.
+    conv_type : str, optional
+        ``"local"`` (default) for a discrete-continuous convolution,
+        ``"global"`` for a spectral convolution.
+    mlp_ratio : float, optional
+        Hidden width of the channel MLP as a multiple of the channel count, by
+        default ``2.0``.
+    mlp_drop_rate : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    normalization_layer : str, optional
+        Name of the normalization to use, by default ``"none"``.
+    num_groups : int, optional
+        Number of channel groups in the convolution, by default ``1``.
+    skip : str, optional
+        Skip connection type, by default ``"identity"``.
+    layer_scale : bool, optional
+        Apply a learned per-channel scale to the branch output, by default
+        ``True``. Initialized small so the block starts near the identity.
+    use_mlp : bool, optional
+        Include the channel MLP, by default ``False``.
+    kernel_shape : (int, int), optional
+        Kernel shape for the local convolution, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis for the local convolution kernel, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness, by default ``0``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    """
+
     def __init__(
         self,
         forward_transform,
@@ -916,6 +1098,20 @@ class AtmoSphericNeuralOperatorNet(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, n_inp_chans, nlat, nlon)`` on the input grid.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, n_out_chans, nlat, nlon)`` on the output
+            grid.
+        """
 
         # save big skip
         if self.big_skip:
@@ -942,7 +1138,34 @@ class AtmoSphericNeuralOperatorNet(nn.Module):
 # this part exposes the model to modulus by constructing modulus Modules
 @dataclass
 class AtmoSphericNeuralOperatorNetMetaData(ModelMetaData):
-    name: str = "FCN3"
+    r"""
+    PhysicsNeMo metadata for :class:`AtmoSphericNeuralOperatorNet`.
+
+    Declares which execution features the model supports, so PhysicsNeMo knows
+    what it may enable when wrapping it. Consumed by
+    :func:`~makani.models.physicsnemo_compat.module_from_torch` to produce the
+    ``FCN3`` module exported from this file.
+
+    Attributes
+    ----------
+    jit : bool
+        TorchScript tracing is not supported.
+    cuda_graphs : bool
+        CUDA graph capture is not supported.
+    amp_cpu : bool
+        Mixed precision on CPU is not supported.
+    amp_gpu : bool
+        Mixed precision on GPU is supported.
+
+    Notes
+    -----
+    ``jit`` refers to TorchScript only. ``torch.compile`` is supported for this
+    model and is unaffected by these flags.
+
+    The model name is deliberately not set here. ``ModelMetaData.name`` is
+    deprecated in PhysicsNeMo 2.x, so it is passed to ``module_from_torch``
+    instead and applied only where it still has an effect.
+    """
 
     jit: bool = False
     cuda_graphs: bool = False
@@ -950,4 +1173,8 @@ class AtmoSphericNeuralOperatorNetMetaData(ModelMetaData):
     amp_gpu: bool = True
 
 
-FCN3 = physicsnemo.Module.from_torch(AtmoSphericNeuralOperatorNet, AtmoSphericNeuralOperatorNetMetaData())
+FCN3 = module_from_torch(
+    AtmoSphericNeuralOperatorNet,
+    AtmoSphericNeuralOperatorNetMetaData(),
+    name="FCN3",
+)

--- a/makani/models/networks/fourcastnet3_1.py
+++ b/makani/models/networks/fourcastnet3_1.py
@@ -46,8 +46,9 @@ from makani.utils import comm
 
 # for annotation of models
 from dataclasses import dataclass
-import physicsnemo
 from physicsnemo import ModelMetaData
+
+from makani.models.physicsnemo_compat import module_from_torch
 
 
 # heuristic for finding theta_cutoff
@@ -64,9 +65,33 @@ def _soft_clamp(x: torch.Tensor, offset: float = 0.0):
     return y
 
 
-# heper function to be able to pass Sin as an activation function
 class Sin(nn.Module):
+    r"""
+    Sine activation, as a module.
+
+    :func:`torch.sin` is a function, not an ``nn.Module``, so it cannot be
+    passed where the model config expects an activation constructor. This
+    trivial wrapper makes it usable there.
+
+    Sinusoidal activations are worth having available for physical fields:
+    unlike ReLU-family activations they are smooth and periodic, which suits
+    networks that need to represent oscillatory structure.
+    """
+
     def forward(self, x):
+        r"""
+        Apply the sine elementwise.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of any shape.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape as ``x``.
+        """
         return torch.sin(x)
 
 
@@ -125,6 +150,55 @@ def _get_norm_layer_handle(
 
 
 class DiscreteContinuousEncoder(nn.Module):
+    r"""
+    Encoder built on a discrete-continuous convolution on the sphere.
+
+    Lifts input variables into the model's latent width while resampling from
+    the data grid onto the (typically coarser) model grid. A
+    discrete-continuous convolution is defined by a *continuous* kernel
+    evaluated at the actual angular positions of the grid points, so input and
+    output grids need not agree and the operator remains a genuine spherical
+    convolution.
+
+    Differs from the FourCastNet 3 encoder in that the kernel cutoff radius is
+    derived from the spectral truncation ``lmax`` rather than the input
+    resolution, and a fused convolution kernel can be requested.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"nodal"``.
+    lmax : int, optional
+        Spectral truncation used to derive the kernel cutoff radius, by default
+        ``240``.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    fused : bool, optional
+        Use the fused convolution implementation, by default ``False``.
+
+    See Also
+    --------
+    DiscreteContinuousDecoder : the corresponding decoder.
+    """
+
     def __init__(
         self,
         inp_shape=(721, 1440),
@@ -173,6 +247,19 @@ class DiscreteContinuousEncoder(nn.Module):
                 self.conv.bias.sharded_dims_mp = [None]
 
     def forward(self, x):
+        r"""
+        Encode the input field onto the model grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Encoded field of shape ``(B, out_chans, *out_shape)``.
+        """
 
         # convolution
         x = self.conv(x)
@@ -181,6 +268,53 @@ class DiscreteContinuousEncoder(nn.Module):
 
 
 class DiscreteContinuousDecoder(nn.Module):
+    r"""
+    Decoder built on a discrete-continuous convolution on the sphere.
+
+    Mirror of :class:`DiscreteContinuousEncoder`: projects latent features back
+    to output variables while resampling from the model grid onto the data
+    grid. Resampling runs in fp32 with autocast disabled, since it is a long
+    accumulation whose accuracy the output depends on directly.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"nodal"``.
+    lmax : int, optional
+        Spectral truncation used to derive the kernel cutoff radius, by default
+        ``240``.
+    resample_sht : bool, optional
+        Resample spectrally via an SHT rather than by bilinear interpolation,
+        by default ``False``. Spectral resampling is exact for band-limited
+        fields but costs more.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    fused : bool, optional
+        Use the fused convolution implementation, by default ``False``.
+
+    See Also
+    --------
+    DiscreteContinuousEncoder : the corresponding encoder.
+    """
+
     def __init__(
         self,
         inp_shape=(480, 960),
@@ -252,6 +386,19 @@ class DiscreteContinuousDecoder(nn.Module):
                 self.conv.bias.sharded_dims_mp = [None]
 
     def forward(self, x):
+        r"""
+        Decode latent features onto the output grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Latent field of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output field of shape ``(B, out_chans, *out_shape)``.
+        """
         dtype = x.dtype
 
         with amp.autocast(device_type="cuda", enabled=False):
@@ -264,6 +411,63 @@ class DiscreteContinuousDecoder(nn.Module):
 
 
 class NeuralOperatorBlock(nn.Module):
+    r"""
+    Processor block mixing spatially via either a local or a global operator.
+
+    The building block of :class:`AtmoSphericNeuralOperatorNet31`.
+    ``conv_type`` selects between a discrete-continuous convolution with a
+    bounded angular footprint (``"local"``) and a spectral convolution acting
+    on all modes at once (``"global"``). Interleaving the two lets the model
+    capture fine local structure and long-range teleconnections without paying
+    global cost in every layer.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform; also defines the input grid.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform; also defines the output grid, which may
+        differ in resolution.
+    inp_chans : int
+        Number of input channels.
+    out_chans : int
+        Number of output channels.
+    conv_type : str, optional
+        ``"local"`` (default) for a discrete-continuous convolution,
+        ``"global"`` for a spectral convolution.
+    mlp_ratio : float, optional
+        Hidden width of the channel MLP as a multiple of the channel count, by
+        default ``2.0``.
+    mlp_drop_rate : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    normalization_layer : str, optional
+        Name of the normalization to use, by default ``"none"``.
+    num_groups : int, optional
+        Number of channel groups in the convolution, by default ``1``.
+    skip : str, optional
+        Skip connection type, by default ``"identity"``.
+    layer_scale : bool, optional
+        Apply a learned per-channel scale to the branch output, by default
+        ``True``. Initialized small so the block starts near the identity.
+    use_mlp : bool, optional
+        Include the channel MLP, by default ``False``.
+    kernel_shape : (int, int), optional
+        Kernel shape for the local convolution, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis for the local convolution kernel, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"nodal"``.
+    lmax : int, optional
+        Spectral truncation used to derive the kernel cutoff radius, by default
+        ``240``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness, by default ``0``.
+    """
+
     def __init__(
         self,
         forward_transform,
@@ -818,6 +1022,26 @@ class AtmoSphericNeuralOperatorNet31(nn.Module):
         return x
 
     def processor_blocks(self, x, x_aux):
+        r"""
+        Run the latent state through the stack of processor blocks.
+
+        Auxiliary embeddings are re-concatenated before *every* block rather
+        than only at the encoder, so conditioning information stays available at
+        every depth instead of having to survive the whole stack.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Latent field of shape ``(B, embed_dim, h, w)``.
+        x_aux : torch.Tensor or None
+            Auxiliary embedding channels to append to each block's input, or
+            ``None`` to append nothing.
+
+        Returns
+        -------
+        torch.Tensor
+            Processed latent field of shape ``(B, embed_dim, h, w)``.
+        """
         # maybe clean the padding just in case
         x = self.pos_drop(x)
 
@@ -856,6 +1080,24 @@ class AtmoSphericNeuralOperatorNet31(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Runs SST imputation, encodes the auxiliary channels, encodes the
+        prognostic channels, applies the processor blocks, and decodes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)`` on the input grid.
+            May contain ``NaN`` in the imputed channels.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)`` on the output
+            grid.
+        """
 
         # sst imputation
         x = self.impute_sst_channels(x)
@@ -894,7 +1136,33 @@ class AtmoSphericNeuralOperatorNet31(nn.Module):
 # this part exposes the model to modulus by constructing modulus Modules
 @dataclass
 class AtmoSphericNeuralOperatorNetMetaData(ModelMetaData):
-    name: str = "FCN3.1"
+    r"""
+    PhysicsNeMo metadata for :class:`AtmoSphericNeuralOperatorNet31`.
+
+    Declares which execution features the model supports, so PhysicsNeMo knows
+    what it may enable when wrapping it. Consumed by
+    :func:`~makani.models.physicsnemo_compat.module_from_torch`.
+
+    Attributes
+    ----------
+    jit : bool
+        TorchScript tracing is not supported.
+    cuda_graphs : bool
+        CUDA graph capture is not supported.
+    amp_cpu : bool
+        Mixed precision on CPU is not supported.
+    amp_gpu : bool
+        Mixed precision on GPU is supported.
+
+    Notes
+    -----
+    ``jit`` refers to TorchScript only. ``torch.compile`` is supported for this
+    model and is unaffected by these flags.
+
+    The model name is deliberately not set here. ``ModelMetaData.name`` is
+    deprecated in PhysicsNeMo 2.x, so it is passed to ``module_from_torch``
+    instead and applied only where it still has an effect.
+    """
 
     jit: bool = False
     cuda_graphs: bool = False
@@ -902,4 +1170,8 @@ class AtmoSphericNeuralOperatorNetMetaData(ModelMetaData):
     amp_gpu: bool = True
 
 
-FCN3 = physicsnemo.Module.from_torch(AtmoSphericNeuralOperatorNet31, AtmoSphericNeuralOperatorNetMetaData())
+FCN3 = module_from_torch(
+    AtmoSphericNeuralOperatorNet31,
+    AtmoSphericNeuralOperatorNetMetaData(),
+    name="FCN3.1",
+)

--- a/makani/models/networks/pangu.py
+++ b/makani/models/networks/pangu.py
@@ -397,18 +397,93 @@ class EarthAttention3D(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
 
     def calculate_attn(self, q, k):
+        r"""
+        Compute raw attention logits from queries and keys.
+
+        Split out as its own method so subclasses and export wrappers can
+        substitute a different attention implementation without reimplementing
+        the surrounding bias and masking logic.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            Queries of shape ``(B_, num_heads, nW_, N, head_dim)``.
+        k : torch.Tensor
+            Keys of the same shape.
+
+        Returns
+        -------
+        torch.Tensor
+            Logits of shape ``(B_, num_heads, nW_, N, N)``. Not yet scaled,
+            biased or softmaxed.
+        """
         attn = q @ k.transpose(-2, -1)
         return attn
 
     def add_earth_pos_bias(self, attn, earth_position_bias):
+        r"""
+        Add the Earth-specific position bias to the attention logits.
+
+        Parameters
+        ----------
+        attn : torch.Tensor
+            Attention logits of shape ``(B_, num_heads, nW_, N, N)``.
+        earth_position_bias : torch.Tensor
+            Bias of shape ``(num_heads, nW_, N, N)``, broadcast over the batch.
+
+        Returns
+        -------
+        torch.Tensor
+            Biased logits, same shape as ``attn``.
+        """
         attn = attn + earth_position_bias.unsqueeze(0)
         return attn
 
     def apply_attention(self, attn, v, B_, nW_, N, C):
+        r"""
+        Apply normalized attention weights to the values.
+
+        Parameters
+        ----------
+        attn : torch.Tensor
+            Normalized attention weights of shape ``(B_, num_heads, nW_, N, N)``.
+        v : torch.Tensor
+            Values of shape ``(B_, num_heads, nW_, N, head_dim)``.
+        B_ : int
+            Batch dimension, including the longitude windows folded into it.
+        nW_ : int
+            Number of window groups.
+        N : int
+            Number of tokens per window.
+        C : int
+            Feature dimension.
+
+        Returns
+        -------
+        torch.Tensor
+            Attended features of shape ``(B_, nW_, N, C)``, with the heads
+            merged back together.
+        """
         x = (attn @ v).permute(0, 2, 3, 1, 4).reshape(B_, nW_, N, C)
         return x
 
     def extract_earth_pos_bias(self):
+        r"""
+        Gather the position bias for the current window layout.
+
+        Indexes the learned bias table by the precomputed relative-position
+        index and reshapes it to broadcast against the attention logits. The
+        bias is Earth-specific: on a lat-lon grid the relationship between two
+        cells depends on their absolute latitude and pressure level, not only on
+        their offset, so the table is indexed by more than a relative
+        displacement.
+
+        Returns
+        -------
+        torch.Tensor
+            Bias of shape ``(num_heads, num_pl * num_lat, N, N)`` where
+            ``N = Wpl * Wlat * Wlon``.
+        """
         earth_position_bias = self.earth_position_bias_table[self.earth_position_index.view(-1)].view(
             self.window_size[0] * self.window_size[1] * self.window_size[2],
             self.window_size[0] * self.window_size[1] * self.window_size[2],
@@ -422,6 +497,32 @@ class EarthAttention3D(nn.Module):
         return earth_position_bias
 
     def apply_mask(self, attn, mask, B_, nW_, N):
+        r"""
+        Apply the shifted-window attention mask and normalize.
+
+        Under a shifted window partitioning, some windows contain tokens that
+        are not actually adjacent on the globe. The mask assigns those pairs
+        ``-inf`` so the softmax gives them zero weight.
+
+        Parameters
+        ----------
+        attn : torch.Tensor
+            Attention logits of shape ``(B_, num_heads, nW_, N, N)``.
+        mask : torch.Tensor
+            Additive mask of shape ``(num_lon, nW_, N, N)``, containing ``0``
+            for valid pairs and ``-inf`` for invalid ones.
+        B_ : int
+            Batch dimension, including the longitude windows folded into it.
+        nW_ : int
+            Number of window groups.
+        N : int
+            Number of tokens per window.
+
+        Returns
+        -------
+        torch.Tensor
+            Softmax-normalized attention weights, same shape as ``attn``.
+        """
         nLon = mask.shape[0]
         attn = attn.view(B_ // nLon, nLon, self.num_heads, nW_, N, N) + mask.unsqueeze(1).unsqueeze(0)
         attn = attn.view(-1, self.num_heads, nW_, N, N)
@@ -575,6 +676,24 @@ class Transformer3DBlock(nn.Module):
         self.register_buffer("attn_mask", attn_mask, persistent=False)
 
     def forward(self, x: torch.Tensor):
+        r"""
+        Apply windowed 3D attention and the channel MLP with residuals.
+
+        Pads the volume to a whole number of windows, optionally rolls it to
+        realize the shifted-window partitioning, attends within each window,
+        then reverses the roll and crops back to the original resolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens of shape ``(B, Pl * Lat * Lon, C)`` on the block's
+            ``input_resolution``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of the same shape as ``x``.
+        """
         Pl, Lat, Lon = self.input_resolution
         B, L, C = x.shape
 
@@ -696,6 +815,19 @@ class FuserLayer(nn.Module):
         )
 
     def forward(self, x):
+        r"""
+        Run the tokens through this layer's stack of transformer blocks.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens of shape ``(B, Pl * Lat * Lon, C)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of the same shape as ``x``.
+        """
         for blk in self.blocks:
             x = blk(x)
         return x
@@ -939,6 +1071,28 @@ class Pangu(nn.Module):
         return output
 
     def forward(self, input):
+        r"""
+        Map an input field to the predicted output field.
+
+        Splits the flat channel stack into surface and atmospheric (pressure
+        level) variables, embeds each with its own patch embedding, runs the
+        encoder-decoder transformer stack with a skip connection between the two
+        levels of resolution, and recombines the two variable groups into a
+        single output stack.
+
+        Parameters
+        ----------
+        input : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``, with the surface and
+            atmospheric variables concatenated along the channel dimension in
+            the order the model was configured with.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)``, in the same
+            channel layout as the input.
+        """
 
         # Prep the input by splitting into surface and atmospheric variables
         surface_aux, atmospheric = self.prepare_input(input)

--- a/makani/models/networks/pangu_onnx.py
+++ b/makani/models/networks/pangu_onnx.py
@@ -68,6 +68,33 @@ class PanguOnnx(OnnxWrapper):
         return
 
     def prepare_input(self, input):
+        r"""
+        Split the flat channel stack into the two inputs the ONNX graph expects.
+
+        The exported Pangu graph takes surface and atmospheric variables as
+        separate inputs, with the atmospheric ones laid out by pressure level
+        rather than flattened into channels. This reshapes makani's single
+        channel stack accordingly.
+
+        Parameters
+        ----------
+        input : torch.Tensor
+            Input of shape ``(1, V, Lat, Long)``.
+
+        Returns
+        -------
+        surface_aux_inp : torch.Tensor
+            Surface variables of shape ``(n_surf_chans, Lat, Long)``.
+        atmospheric_inp : torch.Tensor
+            Atmospheric variables of shape
+            ``(n_atmo_chans, n_atmo_groups, Lat, Long)``.
+
+        Raises
+        ------
+        NotImplementedError
+            If the batch size is greater than one. The exported graph has a
+            fixed batch dimension.
+        """
 
         B, V, Lat, Long = input.shape
 
@@ -96,6 +123,20 @@ class PanguOnnx(OnnxWrapper):
         return output.unsqueeze(0)
 
     def forward(self, input):
+        r"""
+        Run the exported Pangu ONNX graph on a makani-layout input.
+
+        Parameters
+        ----------
+        input : torch.Tensor
+            Input of shape ``(1, V, Lat, Long)`` in makani's channel layout.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(1, V, Lat, Long)``, restructured back into
+            makani's channel layout.
+        """
 
         surface, atmospheric = self.prepare_input(input)
 

--- a/makani/models/networks/sfnonet.py
+++ b/makani/models/networks/sfnonet.py
@@ -44,11 +44,60 @@ from makani.mpu.layer_norm import DistributedInstanceNorm2d, DistributedLayerNor
 
 # for annotation of models
 from dataclasses import dataclass
-import physicsnemo
 from physicsnemo import ModelMetaData
+
+from makani.models.physicsnemo_compat import module_from_torch
 
 
 class SpectralFilterLayer(nn.Module):
+    r"""
+    Thin dispatcher selecting the spectral filter used inside a block.
+
+    Exists so that :class:`NeuralOperatorBlock` can be written against one
+    interface while the choice between a linear spectral convolution and a
+    nonlinear spectral MLP stays a config option. Constructor arguments that do
+    not apply to the selected filter are ignored.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform.
+    embed_dim : int
+        Channel width; used for both input and output.
+    filter_type : str, optional
+        ``"linear"`` (default) selects
+        :class:`~makani.models.common.spectral_convolution.SpectralConv`;
+        ``"non-linear"`` selects
+        :class:`~makani.models.common.spectral_convolution.SpectralAttention`.
+    operator_type : str, optional
+        Weight layout passed to the selected filter, by default ``"diagonal"``.
+    hidden_size_factor : int, optional
+        Hidden width multiplier for the nonlinear filter, by default ``1``.
+        Ignored by the linear filter.
+    rank : float, optional
+        Accepted for config compatibility; currently unused.
+    separable : bool, optional
+        Depthwise (per-channel) filtering for the linear filter, by default
+        ``False``. Ignored by the nonlinear filter.
+    complex_activation : str, optional
+        Complex activation mode for the nonlinear filter, by default ``"real"``.
+    spectral_layers : int, optional
+        Number of layers in the nonlinear filter's spectral MLP, by default ``1``.
+    bias : bool, optional
+        Whether the filter carries a bias, by default ``False``.
+    drop_rate : float, optional
+        Dropout probability inside the nonlinear filter, by default ``0.0``.
+    gain : float, optional
+        Scales the variance of the filter's output initialization, by default ``1.0``.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``filter_type`` is neither ``"linear"`` nor ``"non-linear"``.
+    """
+
     def __init__(
         self,
         forward_transform,
@@ -98,10 +147,104 @@ class SpectralFilterLayer(nn.Module):
             raise (NotImplementedError)
 
     def forward(self, x):
+        r"""
+        Apply the selected spectral filter.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, embed_dim, nlat, nlon)``.
+
+        Returns
+        -------
+        x : torch.Tensor
+            Filtered field, on the inverse transform's grid.
+        residual : torch.Tensor
+            The input resampled onto the output grid; see
+            :meth:`~makani.models.common.spectral_convolution.SpectralConv.forward`.
+        """
         return self.filter(x)
 
 
 class NeuralOperatorBlock(nn.Module):
+    r"""
+    One block of the SFNO processor: spectral filter, norms, skips, and MLP.
+
+    The structural analogue of a transformer block, with the spectral filter
+    playing the role of attention (global mixing across space) and the MLP
+    mixing channels pointwise. Both stages sit behind their own normalization
+    and skip connection:
+
+    .. code-block:: text
+
+        x -> filter -> norm0 -> [+ inner_skip(residual)] -> act
+          -> mlp -> norm1 -> [+ outer_skip(residual)] -> [act]
+
+    Skip weights are initialized with a gain that is halved for each active skip
+    path, so the variance of the block's output stays roughly constant no matter
+    which skips are enabled -- deep stacks then do not need retuning when the
+    block configuration changes.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform for the filter.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform for the filter. May target a different
+        resolution, which is how the model changes resolution between blocks.
+    embed_dim : int
+        Channel width of the block.
+    filter_type : str, optional
+        ``"linear"`` (default) or ``"non-linear"``; see :class:`SpectralFilterLayer`.
+    operator_type : str, optional
+        Weight layout for the spectral filter, by default ``"diagonal"``.
+    mlp_ratio : float, optional
+        Hidden width of the MLP as a multiple of ``embed_dim``, by default ``2.0``.
+        Also used as the nonlinear filter's hidden size factor.
+    mlp_drop_rate : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability for the block, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`. Passing
+        :class:`torch.nn.Identity` halves the initialization gain, since no
+        activation-induced variance loss needs compensating.
+    norm_layer : tuple of callable, optional
+        Two normalization constructors, applied after the filter and after the
+        MLP respectively. By default both are :class:`torch.nn.Identity`.
+    rank : float, optional
+        Accepted for config compatibility; currently unused.
+    separable : bool, optional
+        Depthwise filtering for the linear filter, by default ``False``.
+    inner_skip : str, optional
+        Skip around the filter: ``"linear"`` (default), ``"identity"``, or
+        ``"none"``.
+    outer_skip : str, optional
+        Skip around the MLP: ``"linear"``, ``"identity"``, or ``"none"``. By
+        default ``None``, which raises -- pass ``"none"`` to disable it.
+    use_mlp : bool, optional
+        Whether to include the channel MLP, by default ``False``. Automatically
+        uses the distributed MLP when the ``matmul`` group is larger than one.
+    comm_feature_name : str, optional
+        Communicator group the distributed MLP shards over, by default ``"matmul"``.
+    complex_activation : str, optional
+        Complex activation mode for the nonlinear filter, by default ``"real"``.
+    spectral_layers : int, optional
+        Number of layers in the nonlinear filter's spectral MLP, by default ``1``.
+    bias : bool, optional
+        Whether the spectral filter carries a bias, by default ``False``.
+    final_activation : bool, optional
+        Apply an activation after the outer skip, by default ``False``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness; the MLP is checkpointed at level
+        2 and above. By default ``0``.
+
+    Raises
+    ------
+    ValueError
+        If ``inner_skip`` or ``outer_skip`` is not one of the supported values.
+    """
+
     def __init__(
         self,
         forward_transform,
@@ -222,8 +365,21 @@ class NeuralOperatorBlock(nn.Module):
             self.act_layer1 = act_layer()
 
     def forward(self, x):
-        """
-        Updated FNO block
+        r"""
+        Apply the spectral filter, skips, norms and MLP.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, embed_dim, nlat_in, nlon_in)`` matching the
+            forward transform's grid.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``(B, embed_dim, nlat_out, nlon_out)`` on the
+            inverse transform's grid, which differs from the input shape when
+            the block changes resolution.
         """
 
         x, residual = self.filter(x)
@@ -253,8 +409,110 @@ class NeuralOperatorBlock(nn.Module):
 
 
 class SphericalFourierNeuralOperatorNet(nn.Module):
-    """
-    SFNO implementation as in Bonev et al.; Spherical Fourier Neural Operators: Learning Stable Dynamics on the Sphere
+    r"""
+    Spherical Fourier Neural Operator (SFNO).
+
+    An encoder-processor-decoder network in which all spatial mixing happens in
+    spherical harmonic space. The encoder lifts input variables to ``embed_dim``
+    channels, a stack of :class:`NeuralOperatorBlock` layers evolves them, and
+    the decoder projects back to ``out_chans``. Because the transforms are
+    spherical rather than planar, the operator respects the geometry of the
+    globe -- no pole artifacts and no seam at the dateline -- which is what
+    makes the rollouts stable over long horizons.
+
+    The first block downsamples from the input grid to an internal grid reduced
+    by ``scale_factor``, the interior blocks operate at that resolution, and the
+    last block maps back to the output grid. Spectral truncation is controlled
+    by ``hard_thresholding_fraction`` or by ``max_modes`` directly.
+
+    Parameters
+    ----------
+    spectral_transform : str, optional
+        ``"sht"`` (default) for spherical harmonic transforms, or ``"fft"`` to
+        treat the domain as a periodic plane.
+    model_grid_type : str, optional
+        Grid the input data lives on, by default ``"equiangular"``.
+    sht_grid_type : str, optional
+        Grid used internally by the transforms, by default ``"legendre-gauss"``,
+        whose quadrature is exact for band-limited fields.
+    filter_type : str, optional
+        ``"linear"`` (default) or ``"non-linear"`` spectral filter.
+    operator_type : str, optional
+        Weight layout of the spectral filter, by default ``"dhconv"``
+        (rotationally equivariant).
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    scale_factor : int, optional
+        Factor by which the internal grid is coarsened relative to the input,
+        by default ``8``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    embed_dim : int, optional
+        Latent channel width, by default ``32``.
+    num_layers : int, optional
+        Number of neural operator blocks, by default ``4``.
+    use_mlp : bool, optional
+        Include the channel MLP in each block, by default ``True``.
+    mlp_ratio : float, optional
+        Hidden width of the block MLPs as a multiple of ``embed_dim``, by
+        default ``2.0``.
+    encoder_ratio : int, optional
+        Hidden width of the encoder as a multiple of ``embed_dim``, by default ``1``.
+    decoder_ratio : int, optional
+        Hidden width of the decoder as a multiple of ``embed_dim``, by default ``1``.
+    activation_function : str, optional
+        One of ``"relu"``, ``"gelu"`` (default) or ``"silu"``.
+    encoder_layers : int, optional
+        Number of hidden layers in the encoder and decoder, by default ``1``.
+    pos_embed : str, optional
+        Position embedding type, by default ``"none"``.
+    pos_drop_rate : float, optional
+        Dropout applied after the position embedding, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    mlp_drop_rate : float, optional
+        Dropout inside the block MLPs, by default ``0.0``.
+    normalization_layer : str, optional
+        Normalization used inside the blocks, by default ``"instance_norm"``.
+    max_modes : (int, int), optional
+        Explicit spectral truncation as ``(lmax, mmax)``. Overrides
+        ``hard_thresholding_fraction`` when given.
+    hard_thresholding_fraction : float, optional
+        Fraction of the available modes retained, by default ``1.0``.
+    big_skip : bool, optional
+        Add a skip connection from the network input to the decoder input, by
+        default ``True``. Lets the network predict a correction rather than the
+        full field.
+    rank : float, optional
+        Accepted for config compatibility; currently unused.
+    separable : bool, optional
+        Depthwise spectral filtering, by default ``False``.
+    complex_activation : str, optional
+        Complex activation mode for nonlinear filters, by default ``"real"``.
+    spectral_layers : int, optional
+        Number of layers in each nonlinear filter's spectral MLP, by default ``3``.
+    bias : bool, optional
+        Whether the spectral filters carry a bias, by default ``False``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness (higher recomputes more), by
+        default ``0``.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+
+    Raises
+    ------
+    ValueError
+        If ``activation_function`` is not one of the supported names.
+
+    References
+    ----------
+    [1] Bonev, B.; Kurth, T.; Hundt, C.; Pathak, J.; Baust, M.; Kashinath, K.;
+    Anandkumar, A.; Spherical Fourier Neural Operators: Learning Stable Dynamics
+    on the Sphere; ICML 2023.
     """
 
     def __init__(
@@ -581,6 +839,19 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
 
     @torch.compiler.disable(recursive=True)
     def no_weight_decay(self):
+        r"""
+        Parameters that should be excluded from weight decay.
+
+        Position embeddings and class tokens encode absolute location and
+        identity rather than a learned transformation, so decaying them toward
+        zero degrades the model instead of regularizing it. Optimizer setup
+        calls this to build its no-decay parameter group.
+
+        Returns
+        -------
+        set of str
+            Names of the parameters to exclude.
+        """
         return {"pos_embed", "cls_token"}
 
     def _forward_features(self, x):
@@ -593,6 +864,19 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)`` on ``inp_shape``.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)`` on ``out_shape``.
+        """
         # save big skip
         if self.big_skip:
             # if output shape differs, use the spectral transforms to change resolution
@@ -653,7 +937,32 @@ class SphericalFourierNeuralOperatorNet(nn.Module):
 # this part exposes the model to modulus by constructing modulus Modules
 @dataclass
 class SphericalFourierNeuralOperatorNetMetaData(ModelMetaData):
-    name: str = "SFNO"
+    r"""
+    PhysicsNeMo metadata for :class:`SphericalFourierNeuralOperatorNet`.
+
+    Declares which execution features the model supports, so PhysicsNeMo knows
+    what it may enable when wrapping it. Consumed by
+    :func:`~makani.models.physicsnemo_compat.module_from_torch`, which produces
+    the ``SFNO`` module exported from this file.
+
+    Attributes
+    ----------
+    jit : bool
+        TorchScript tracing is not supported. This says nothing about
+        ``torch.compile``, which these flags do not govern.
+    cuda_graphs : bool
+        CUDA graph capture is not supported.
+    amp_cpu : bool
+        Mixed precision on CPU is not supported.
+    amp_gpu : bool
+        Mixed precision on GPU is supported.
+
+    Notes
+    -----
+    The model name is deliberately not set here. ``ModelMetaData.name`` is
+    deprecated in PhysicsNeMo 2.x, so it is passed to ``module_from_torch``
+    instead and applied only where it still has an effect.
+    """
 
     jit: bool = False
     cuda_graphs: bool = False
@@ -661,17 +970,68 @@ class SphericalFourierNeuralOperatorNetMetaData(ModelMetaData):
     amp_gpu: bool = True
 
 
-SFNO = physicsnemo.Module.from_torch(SphericalFourierNeuralOperatorNet, SphericalFourierNeuralOperatorNetMetaData())
+SFNO = module_from_torch(
+    SphericalFourierNeuralOperatorNet,
+    SphericalFourierNeuralOperatorNetMetaData(),
+    name="SFNO",
+)
 
 
 class FourierNeuralOperatorNet(SphericalFourierNeuralOperatorNet):
+    r"""
+    Planar Fourier Neural Operator (FNO).
+
+    :class:`SphericalFourierNeuralOperatorNet` with ``spectral_transform="fft"``
+    forced, so mixing happens over Fourier modes on a doubly periodic plane
+    rather than over spherical harmonics. Useful as a baseline and for domains
+    that genuinely are periodic; on global data it treats the poles and the
+    dateline as ordinary interior points, which the spherical variant does not.
+
+    Parameters
+    ----------
+    *args
+        Forwarded to :class:`SphericalFourierNeuralOperatorNet`.
+    **kwargs
+        Forwarded to :class:`SphericalFourierNeuralOperatorNet`. Passing
+        ``spectral_transform`` raises, since it is set here.
+
+    See Also
+    --------
+    SphericalFourierNeuralOperatorNet : the base implementation and full
+        parameter documentation.
+    """
+
     def __init__(self, *args, **kwargs):
         return super().__init__(*args, spectral_transform="fft", **kwargs)
 
 
 @dataclass
 class FourierNeuralOperatorNetMetaData(ModelMetaData):
-    name: str = "FNO"
+    r"""
+    PhysicsNeMo metadata for :class:`FourierNeuralOperatorNet`.
+
+    Same supported-feature declaration as
+    :class:`SphericalFourierNeuralOperatorNetMetaData`, under the name ``"FNO"``.
+    Consumed by :func:`~makani.models.physicsnemo_compat.module_from_torch` to
+    produce the ``FNO`` module exported from this file.
+
+    Attributes
+    ----------
+    jit : bool
+        TorchScript tracing is not supported. This says nothing about
+        ``torch.compile``, which these flags do not govern.
+    cuda_graphs : bool
+        CUDA graph capture is not supported.
+    amp_cpu : bool
+        Mixed precision on CPU is not supported.
+    amp_gpu : bool
+        Mixed precision on GPU is supported.
+
+    Notes
+    -----
+    The model name is deliberately not set here; see
+    :class:`SphericalFourierNeuralOperatorNetMetaData`.
+    """
 
     jit: bool = False
     cuda_graphs: bool = False
@@ -679,4 +1039,8 @@ class FourierNeuralOperatorNetMetaData(ModelMetaData):
     amp_gpu: bool = True
 
 
-FNO = physicsnemo.Module.from_torch(FourierNeuralOperatorNet, FourierNeuralOperatorNetMetaData())
+FNO = module_from_torch(
+    FourierNeuralOperatorNet,
+    FourierNeuralOperatorNetMetaData(),
+    name="FNO",
+)

--- a/makani/models/networks/snonet.py
+++ b/makani/models/networks/snonet.py
@@ -48,6 +48,57 @@ def _compute_cutoff_radius(nlat, kernel_shape, basis_type):
 
 
 class DiscreteContinuousEncoder(nn.Module):
+    r"""
+    Encoder built on a discrete-continuous convolution on the sphere.
+
+    Lifts input variables into the model's latent width while resampling from
+    the data grid onto the (typically coarser) model grid. Unlike an ordinary
+    convolution, a discrete-continuous convolution is defined by a *continuous*
+    kernel evaluated at the actual angular positions of the grid points, so
+    input and output grids need not agree and the operator remains a genuine
+    spherical convolution rather than an approximation on a lat-lon array.
+
+    The kernel cutoff radius is derived from the input resolution and kernel
+    shape, so the receptive field stays consistent across resolutions.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    use_mlp : bool, optional
+        Follow the convolution with an activation and a pointwise MLP, by
+        default ``False``. When enabled the convolution weights are scaled by
+        :math:`\sqrt{2}` to compensate for the variance the activation removes.
+    mlp_ratio : float, optional
+        Hidden width of that MLP as a multiple of ``out_chans``, by default ``2.0``.
+    activation_function : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+
+    See Also
+    --------
+    DiscreteContinuousDecoder : the corresponding decoder.
+    """
+
     def __init__(
         self,
         inp_shape=(721, 1440),
@@ -111,6 +162,19 @@ class DiscreteContinuousEncoder(nn.Module):
             )
 
     def forward(self, x):
+        r"""
+        Encode the input field onto the model grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Encoded field of shape ``(B, out_chans, *out_shape)``.
+        """
 
         # perform conv
         x = self.conv(x)
@@ -125,6 +189,56 @@ class DiscreteContinuousEncoder(nn.Module):
 
 
 class DiscreteContinuousDecoder(nn.Module):
+    r"""
+    Decoder built on a discrete-continuous convolution on the sphere.
+
+    Mirror of :class:`DiscreteContinuousEncoder`: projects latent features back
+    to output variables while resampling from the model grid onto the (typically
+    finer) data grid. The upsampling step is applied before the convolution and
+    runs in fp32 with autocast disabled, since it is a long accumulation whose
+    accuracy the output depends on directly.
+
+    Parameters
+    ----------
+    inp_shape : (int, int), optional
+        Input grid as ``(nlat, nlon)``, by default ``(480, 960)``.
+    out_shape : (int, int), optional
+        Output grid as ``(nlat, nlon)``, by default ``(721, 1440)``.
+    grid_in : str, optional
+        Input grid type, by default ``"equiangular"``.
+    grid_out : str, optional
+        Output grid type, by default ``"equiangular"``.
+    inp_chans : int, optional
+        Number of input channels, by default ``2``.
+    out_chans : int, optional
+        Number of output channels, by default ``2``.
+    kernel_shape : (int, int), optional
+        Shape of the continuous kernel, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis the kernel is expanded in, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    use_mlp : bool, optional
+        Precede the convolution with a pointwise MLP and activation, by
+        default ``False``.
+    mlp_ratio : float, optional
+        Hidden width of that MLP as a multiple of ``inp_chans``, by default ``2.0``.
+    activation_function : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    groups : int, optional
+        Number of convolution groups, by default ``1``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    upsample_sht : bool, optional
+        Upsample spectrally via an SHT rather than by interpolation, by default
+        ``False``. Spectral upsampling is exact for band-limited fields but
+        costs more.
+
+    See Also
+    --------
+    DiscreteContinuousEncoder : the corresponding encoder.
+    """
+
     def __init__(
         self,
         inp_shape=(480, 960),
@@ -209,6 +323,20 @@ class DiscreteContinuousDecoder(nn.Module):
                 self.conv.bias.sharded_dims_mp = [None]
 
     def forward(self, x):
+        r"""
+        Decode latent features onto the output grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Latent field of shape ``(B, inp_chans, *inp_shape)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output field of shape ``(B, out_chans, *out_shape)``, cast back to
+            the dtype of ``x``.
+        """
         dtype = x.dtype
 
         if hasattr(self, "act"):
@@ -227,6 +355,63 @@ class DiscreteContinuousDecoder(nn.Module):
 
 
 class NeuralOperatorBlock(nn.Module):
+    r"""
+    Processor block mixing spatially via either a local or a global operator.
+
+    The building block of :class:`SphericalNeuralOperatorNet`. Unlike the SFNO
+    block, which always mixes globally in spectral space, this one lets
+    ``conv_type`` choose between a discrete-continuous convolution with a
+    bounded angular footprint (``"local"``) and a spectral convolution acting on
+    all modes at once (``"global"``). Stacking both kinds lets a model resolve
+    fine local structure and long-range teleconnections without paying global
+    cost at every layer.
+
+    Parameters
+    ----------
+    forward_transform : torch.nn.Module
+        Grid-to-spectral transform; also defines the input grid.
+    inverse_transform : torch.nn.Module
+        Spectral-to-grid transform; also defines the output grid, which may
+        differ in resolution.
+    inp_chans : int
+        Number of input channels.
+    out_chans : int
+        Number of output channels.
+    conv_type : str, optional
+        ``"local"`` (default) for a discrete-continuous convolution,
+        ``"global"`` for a spectral convolution.
+    mlp_ratio : float, optional
+        Hidden width of the channel MLP as a multiple of the channel count, by
+        default ``2.0``.
+    mlp_drop_rate : float, optional
+        Dropout probability inside the MLP, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    norm_layer : callable, optional
+        Normalization constructor, by default :class:`torch.nn.Identity`.
+    num_groups : int, optional
+        Number of channel groups in the convolution, by default ``1``.
+    skip : str, optional
+        Skip connection type, by default ``"identity"``.
+    layer_scale : bool, optional
+        Apply a learned per-channel scale to the branch output, by default
+        ``True``. Initialized small so the block starts near the identity.
+    use_mlp : bool, optional
+        Include the channel MLP, by default ``False``.
+    kernel_shape : (int, int), optional
+        Kernel shape for the local convolution, by default ``(3, 3)``.
+    basis_type : str, optional
+        Basis for the local convolution kernel, by default ``"harmonic"``.
+    basis_norm_mode : str, optional
+        Basis normalization mode, by default ``"mean"``.
+    checkpointing_level : int, optional
+        Gradient checkpointing aggressiveness, by default ``0``.
+    bias : bool, optional
+        Whether the convolution carries a bias, by default ``False``.
+    """
+
     def __init__(
         self,
         forward_transform,
@@ -654,12 +839,44 @@ class SphericalNeuralOperatorNet(nn.Module):
         return x
 
     def clamp_water_channels(self, x):
+        r"""
+        Clamp water-related output channels to non-negative values.
+
+        Quantities such as specific humidity and precipitation cannot be
+        negative, but nothing in the network guarantees that. Applying a ReLU to
+        exactly those channels enforces it in the architecture rather than
+        relying on the loss. A no-op if no water channel mask is configured.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Output field of shape ``(B, out_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of the same shape, with the masked channels clamped at zero
+            and all others untouched.
+        """
         if hasattr(self, "water_channel_mask"):
             w = nn.functional.relu(x)
             x = torch.where(self.water_channel_mask, w, x)
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)`` on ``inp_shape``.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)`` on ``out_shape``.
+        """
         dtype = x.dtype
 
         # save big skip

--- a/makani/models/networks/vit.py
+++ b/makani/models/networks/vit.py
@@ -25,6 +25,51 @@ from makani.mpu.layers import DistributedMLP, DistributedAttention
 
 
 class Attention(nn.Module):
+    r"""
+    Standard multi-head self-attention.
+
+    Projects the input to queries, keys and values, splits them into
+    ``num_heads`` independent subspaces, and applies scaled dot-product
+    attention:
+
+    .. math::
+
+        \mathrm{Attention}(Q, K, V) =
+        \mathrm{softmax}\!\left(\frac{Q K^\top}{\sqrt{d_h}}\right) V
+
+    Dispatches to :func:`torch.nn.functional.scaled_dot_product_attention`, so
+    it uses a fused kernel where one is available.
+
+    Parameters
+    ----------
+    dim : int
+        Feature dimension. Must be divisible by ``num_heads``.
+    input_format : str, optional
+        Input layout, by default ``"traditional"`` (channels last).
+    num_heads : int, optional
+        Number of attention heads, by default ``8``.
+    qkv_bias : bool, optional
+        Whether the QKV projection carries a bias, by default ``False``.
+    qk_norm : bool, optional
+        Normalize queries and keys before the attention product, by default
+        ``False``. Bounds the logits and stabilizes training at large widths.
+    attn_drop_rate : float, optional
+        Dropout probability on the attention weights, by default ``0.0``.
+    proj_drop_rate : float, optional
+        Dropout probability after the output projection, by default ``0.0``.
+    norm_layer : callable, optional
+        Normalization used for ``qk_norm``, by default :class:`torch.nn.LayerNorm`.
+
+    Raises
+    ------
+    ValueError
+        If ``dim`` is not divisible by ``num_heads``.
+
+    See Also
+    --------
+    makani.mpu.layers.DistributedAttention : head-parallel version.
+    """
+
     def __init__(
         self,
         dim,
@@ -56,6 +101,19 @@ class Attention(nn.Module):
             self.proj_drop = nn.Identity()
 
     def forward(self, x):
+        r"""
+        Apply multi-head self-attention.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Token tensor of shape ``(B, N, dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, N, dim)``.
+        """
         B, N, C = x.shape
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
         q, k, v = qkv.unbind(0)
@@ -70,6 +128,47 @@ class Attention(nn.Module):
 
 
 class Block(nn.Module):
+    r"""
+    Standard pre-norm transformer block.
+
+    Attention followed by a feed-forward MLP, each preceded by a normalization
+    and wrapped in a residual connection:
+
+    .. code-block:: text
+
+        x = x + drop_path(attn(norm1(x)))
+        x = norm2(x)
+        x = x + drop_path(mlp(x))
+
+    Both sublayers automatically switch to their tensor-parallel
+    implementations when the ``comm_name`` group has more than one rank, so the
+    same block definition serves single-GPU and model-parallel runs.
+
+    Parameters
+    ----------
+    dim : int
+        Feature dimension.
+    num_heads : int
+        Number of attention heads.
+    mlp_ratio : float, optional
+        Hidden width of the MLP as a multiple of ``dim``, by default ``4.0``.
+    qkv_bias : bool, optional
+        Whether the QKV projection carries a bias, by default ``False``.
+    mlp_drop_rate : float, optional
+        Dropout probability in the MLP and after the attention projection, by
+        default ``0.0``.
+    attn_drop_rate : float, optional
+        Dropout probability on the attention weights, by default ``0.0``.
+    path_drop_rate : float, optional
+        Stochastic depth probability for both residual branches, by default ``0.0``.
+    act_layer : callable, optional
+        Activation constructor for the MLP, by default :class:`torch.nn.GELU`.
+    norm_layer : callable, optional
+        Normalization constructor, by default :class:`torch.nn.LayerNorm`.
+    comm_name : str, optional
+        Communicator group used when model parallel, by default ``"matmul"``.
+    """
+
     def __init__(
         self,
         dim,
@@ -135,6 +234,19 @@ class Block(nn.Module):
             )
 
     def forward(self, x):
+        r"""
+        Apply attention and MLP with residual connections.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Token tensor of shape ``(B, N, dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, N, dim)``.
+        """
         y = self.attn(self.norm1(x))
         x = x + self.drop_path(y)
         x = self.norm2(x)
@@ -143,6 +255,62 @@ class Block(nn.Module):
 
 
 class VisionTransformer(nn.Module):
+    r"""
+    Vision transformer baseline for gridded forecasting.
+
+    Embeds the input field into patch tokens, adds a learned position
+    embedding, runs a stack of :class:`Block` layers, and decodes each token
+    back into its patch of the output field. Attention is global over patches,
+    so every location can influence every other in a single layer -- but at
+    ``O(N^2)`` cost in the number of patches, which is why the input is
+    tokenized rather than processed at full resolution.
+
+    Included as a baseline against the spectral operators; unlike them it has no
+    notion of the sphere's geometry.
+
+    Parameters
+    ----------
+    inp_shape : list of int, optional
+        Input grid as ``[nlat, nlon]``, by default ``[72, 144]``.
+    patch_size : (int, int), optional
+        Patch size, by default ``(6, 6)``.
+    inp_chans : int, optional
+        Number of input channels, by default ``3``.
+    out_chans : int, optional
+        Number of output channels, by default ``3``.
+    embed_dim : int, optional
+        Token dimension, by default ``768``.
+    depth : int, optional
+        Number of transformer blocks, by default ``12``.
+    num_heads : int, optional
+        Number of attention heads per block, by default ``12``.
+    mlp_ratio : float, optional
+        Hidden width of the block MLPs as a multiple of ``embed_dim``, by
+        default ``4.0``.
+    qkv_bias : bool, optional
+        Whether the QKV projections carry a bias, by default ``True``.
+    mlp_drop_rate : float, optional
+        Dropout probability in the MLPs, by default ``0.0``.
+    attn_drop_rate : float, optional
+        Dropout probability on the attention weights, by default ``0.0``.
+    path_drop_rate : float, optional
+        Maximum stochastic depth probability, by default ``0.0``. Ramped
+        linearly from zero at the first block to this value at the last, the
+        usual schedule: early layers are kept intact while deeper ones are
+        dropped more aggressively.
+    norm_layer : str, optional
+        Normalization type; only ``"layer_norm"`` is supported.
+    comm_name : str, optional
+        Communicator group used when model parallel, by default ``"matmul"``.
+    **kwargs
+        Ignored; present so model configs can pass extra keys.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``norm_layer`` is not ``"layer_norm"``.
+    """
+
     def __init__(
         self,
         inp_shape=[72, 144],
@@ -222,6 +390,24 @@ class VisionTransformer(nn.Module):
             nn.init.constant_(m.weight, 1.0)
 
     def prepare_tokens(self, x):
+        r"""
+        Embed the input field into position-encoded tokens.
+
+        Exposed separately from ``forward`` so callers can obtain the token
+        sequence -- for probing or feature extraction -- without running the
+        blocks.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input field of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, num_patches, embed_dim)``, with the position
+            embedding added and dropout applied.
+        """
         B, C, H, W = x.shape
         x = self.patch_embed(x).transpose(1, 2)  # patch linear embedding
 
@@ -230,6 +416,22 @@ class VisionTransformer(nn.Module):
         return self.pos_drop(x)
 
     def forward_head(self, x):
+        r"""
+        Decode tokens back into a full-resolution output field.
+
+        Each token is projected to ``out_chans * patch_h * patch_w`` values and
+        those are unfolded into its patch, reassembling the grid.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tokens of shape ``(B, num_patches, embed_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Field of shape ``(B, out_chans, nlat, nlon)``.
+        """
         B, _, _ = x.shape  # B x N x embed_dim
         x = x.reshape(B, self.patch_embed.red_img_size[0], self.patch_embed.red_img_size[1], self.embed_dim)
         B, h, w, _ = x.shape
@@ -243,6 +445,19 @@ class VisionTransformer(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Map an input field to the predicted output field.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, out_chans, nlat, nlon)``.
+        """
         x = self.prepare_tokens(x)
         for blk in self.blocks:
             x = blk(x)

--- a/makani/models/noise.py
+++ b/makani/models/noise.py
@@ -34,6 +34,58 @@ from torch_harmonics.distributed import split_tensor_along_dim
 
 
 class BaseNoiseS2(nn.Module):
+    r"""
+    Abstract base class for random fields on the sphere :math:`S^2`.
+
+    Noise for an ensemble weather model has to be spatially correlated: white
+    noise on a lat-lon grid is neither isotropic (grid cells shrink toward the
+    poles) nor physically plausible as a perturbation. All subclasses therefore
+    generate noise in *spectral* space and transform it to the grid with an
+    inverse SHT, which makes the correlation structure an explicit choice of
+    angular power spectrum and keeps the field isotropic by construction.
+
+    This base class owns the machinery every variant needs: the inverse SHT
+    (distributed when spatial model parallelism is active), private RNGs, and a
+    ``state`` buffer holding the current spectral coefficients. Subclasses
+    define the spectrum and decide whether they are stateful (the field evolves
+    from step to step, as in :class:`DiffusionNoiseS2`) or stateless (each draw
+    is independent, as in :class:`IsotropicGaussianRandomFieldS2`).
+
+    The state buffer is non-persistent: it is a per-run scratch tensor and is
+    deliberately kept out of checkpoints, so restoring one does not resurrect a
+    stale noise realization.
+
+    Parameters
+    ----------
+    img_shape : (int, int)
+        Output grid as ``(nlat, nlon)``.
+    batch_size : int
+        Initial batch size of the state buffer. Automatically resized when a
+        different batch size is passed to ``update`` or ``reset``.
+    num_channels : int
+        Number of noise channels.
+    num_time_steps : int
+        Number of time steps held in the state.
+    grid_type : str, optional
+        Grid the noise is generated on, by default ``"equiangular"``.
+    lmax : int, optional
+        Spectral truncation. Defaults to the maximum supported by the grid;
+        lowering it produces a smoother field.
+    seed : int, optional
+        Seed for the private CPU and CUDA generators, by default ``333``.
+    reflect : bool, optional
+        If ``True``, negate every draw. Used for antithetic ensemble pairing:
+        two members sharing a seed but differing in this flag produce exactly
+        opposite perturbations, which cancels first-order sampling error in the
+        ensemble mean. By default ``False``.
+    **kwargs
+        Ignored; present so noise configs can pass extra keys.
+
+    See Also
+    --------
+    build_noise : factory constructing the right subclass from a config dict.
+    """
+
     def __init__(
         self,
         img_shape,
@@ -46,10 +98,6 @@ class BaseNoiseS2(nn.Module):
         reflect=False,
         **kwargs,
     ):
-        r"""
-        Abstract base class for noise on the sphere. Initializes the inverse SHT needed by many of the
-        noise classes. Derived noise classes can be stateful or stateless.
-        """
         super().__init__()
 
         # Number of latitudinal modes.
@@ -118,9 +166,35 @@ class BaseNoiseS2(nn.Module):
             )
 
     def is_stateful(self):
+        r"""
+        Whether the noise carries state across calls.
+
+        Callers use this to decide whether the noise module must be
+        checkpointed, reset between rollouts, or kept in sync across ensemble
+        members. Must be overridden by subclasses.
+
+        Returns
+        -------
+        bool
+            ``True`` if successive draws depend on the previous state.
+
+        Raises
+        ------
+        NotImplementedError
+            Always, unless overridden.
+        """
         raise NotImplementedError("is_stateful method not implemented for this noise class")
 
     def extra_repr(self):
+        r"""
+        Extra fields shown in the module's ``repr``.
+
+        Returns
+        -------
+        str
+            Grid shape, channel and time step counts, spectral truncation and
+            reflection flag.
+        """
         return (
             f"img_shape=({self.nlat}, {self.nlon}), "
             f"num_channels={self.num_channels}, num_time_steps={self.num_time_steps}, "
@@ -128,21 +202,61 @@ class BaseNoiseS2(nn.Module):
         )
 
     def set_rng(self, seed=333):
+        r"""
+        Re-seed the module's private CPU and CUDA generators.
+
+        The noise stream is deliberately independent of the global RNG, so
+        seeding it explicitly is the only way to make a run reproducible or to
+        decorrelate ensemble members from one another.
+
+        Parameters
+        ----------
+        seed : int, optional
+            Seed applied to both generators, by default ``333``. The CUDA
+            generator is only created when CUDA is available.
+        """
         self.rng_cpu = torch.Generator(device=torch.device("cpu"))
         self.rng_cpu.manual_seed(seed)
         if torch.cuda.is_available():
             self.rng_gpu = torch.Generator(device=torch.device(f"cuda:{comm.get_local_rank()}"))
             self.rng_gpu.manual_seed(seed)
 
-    # Resets the internal state. Can be used to change the batch size if required.
     def reset(self, batch_size=None):
+        r"""
+        Zero the internal state, optionally resizing it.
+
+        Call this between rollouts so a new forecast does not inherit the noise
+        trajectory of the previous one.
+
+        Parameters
+        ----------
+        batch_size : int, optional
+            New batch size. If given and different from the current one, the
+            state buffer is reallocated; otherwise the existing buffer is
+            zeroed in place.
+        """
         if batch_size is not None:
             self._ensure_state(batch_size)
         with torch.no_grad():
             self.state.zero_()
 
-    # this routine generates a noise sample for a single time step and updates the state accordingly, by appending the last time step
     def update(self, replace_state=False, batch_size=None):
+        r"""
+        Draw a fresh set of spectral coefficients into the state.
+
+        The base implementation is memoryless: it overwrites the state with new
+        standard normal coefficients. Stateful subclasses override this to
+        propagate the previous state forward in time instead.
+
+        Parameters
+        ----------
+        replace_state : bool, optional
+            Accepted for interface compatibility with stateful subclasses,
+            where it selects whether the new sample replaces the state or is
+            appended to it. Ignored here, since the base class always replaces.
+        batch_size : int, optional
+            If given, resize the state buffer to this batch size before drawing.
+        """
 
         if batch_size is not None:
             self._ensure_state(batch_size)
@@ -162,6 +276,22 @@ class BaseNoiseS2(nn.Module):
         return
 
     def set_rng_state(self, cpu_state, gpu_state):
+        r"""
+        Restore the generators from previously captured states.
+
+        Together with :meth:`get_rng_state` this makes a run resumable: without
+        it, restarting from a checkpoint would continue with a different noise
+        stream than an uninterrupted run would have produced.
+
+        Parameters
+        ----------
+        cpu_state : torch.ByteTensor or None
+            State for the CPU generator, as returned by :meth:`get_rng_state`.
+            ``None`` leaves the CPU generator untouched.
+        gpu_state : torch.ByteTensor or None
+            State for the CUDA generator. Ignored if CUDA is unavailable or if
+            ``None``.
+        """
         if cpu_state is not None:
             self.rng_cpu.set_state(cpu_state)
         if torch.cuda.is_available() and (gpu_state is not None):
@@ -170,6 +300,20 @@ class BaseNoiseS2(nn.Module):
         return
 
     def get_rng_state(self):
+        r"""
+        Capture the current generator states for checkpointing.
+
+        Returns
+        -------
+        cpu_state : torch.ByteTensor
+            State of the CPU generator.
+        gpu_state : torch.ByteTensor or None
+            State of the CUDA generator, or ``None`` if CUDA is unavailable.
+
+        See Also
+        --------
+        set_rng_state : restores what this returns.
+        """
         cpu_state = self.rng_cpu.get_state()
         gpu_state = None
         if torch.cuda.is_available():
@@ -178,9 +322,36 @@ class BaseNoiseS2(nn.Module):
         return cpu_state, gpu_state
 
     def get_tensor_state(self):
+        r"""
+        Return a detached copy of the current spectral state.
+
+        Returns
+        -------
+        torch.Tensor
+            Copy of the state buffer, shape
+            ``(batch, *self._state_shape_suffix)``. A copy rather than a view,
+            so the caller can hold on to it across further ``update`` calls.
+        """
         return self.state.detach().clone()
 
     def set_tensor_state(self, newstate):
+        r"""
+        Overwrite the spectral state, resizing the batch dimension if needed.
+
+        Parameters
+        ----------
+        newstate : torch.Tensor
+            Replacement state. Everything beyond the batch dimension must match
+            the module's expected layout; only the batch size may differ, and
+            the buffer is reallocated to accommodate it.
+
+        Raises
+        ------
+        ValueError
+            If the shape beyond the batch dimension does not match. Checked
+            up front so a mismatch reports the expected and actual layouts,
+            rather than failing later inside the copy.
+        """
         # Validate the state layout (everything beyond the batch dim) matches this
         # noise module's expected suffix BEFORE touching `self.state`. Only the batch
         # dim may differ — it is auto-resized via `_ensure_state`. Any other
@@ -203,6 +374,74 @@ class BaseNoiseS2(nn.Module):
 
 
 class IsotropicGaussianRandomFieldS2(BaseNoiseS2):
+    r"""
+    Isotropic Gaussian random field on the unit sphere. Stateless.
+
+    Draws standard normal spherical harmonic coefficients, scales them by a
+    per-degree standard deviation, and transforms to the grid. Because the
+    scaling depends only on the degree :math:`l` and not the order :math:`m`,
+    the resulting field is statistically isotropic -- no direction or location
+    on the sphere is special, which a field generated directly on a lat-lon
+    grid would not satisfy.
+
+    The angular power spectrum follows a power law,
+
+    .. math::
+
+        \sigma_l = \sigma \sqrt{\frac{(2l+1)^{-\alpha}}{Z}},
+        \qquad
+        Z = \sum_l \frac{(2l+1)\,(2l+1)^{-\alpha}}{4\pi}
+
+    where the normalization :math:`Z` fixes the pointwise variance of the field
+    at :math:`\sigma^2` regardless of :math:`\alpha` or the truncation, so
+    changing the correlation length does not silently change the amplitude.
+    :math:`\alpha = 0` gives white noise; larger :math:`\alpha` damps high
+    degrees and yields a smoother, longer-correlated field.
+
+    Each call to ``update`` draws an independent realization, so the noise is
+    stateless and :meth:`is_stateful` returns ``False``.
+
+    Parameters
+    ----------
+    img_shape : (int, int)
+        Output grid as ``(nlat, nlon)``.
+    batch_size : int
+        Initial batch size of the state buffer.
+    num_channels : int
+        Number of noise channels.
+    num_time_steps : int, optional
+        Number of time steps held in the state, by default ``1``.
+    sigma : float, default is 1.0
+        Scale parameter corresponding to the diagonal entry of the covariance
+        kernel, i.e. the pointwise standard deviation of the field.
+    alpha : float, default is 0.0
+        Decay factor in the angular power spectrum. White noise corresponds to
+        ``alpha = 0.0``.
+    grid_type : string, default is "equiangular"
+        Grid type. Currently supports ``"equiangular"`` and ``"legendre-gauss"``.
+    seed : int, optional
+        Seed for the private generators, by default ``333``.
+    reflect : bool, optional
+        Negate every draw, for antithetic ensemble pairing. By default ``False``.
+    learnable : bool, default is False
+        Parameter which enables learnable Gaussian noise: the per-degree
+        standard deviations become trainable instead of fixed, letting the
+        model adapt the correlation structure during training.
+    **kwargs
+        Ignored; present so noise configs can pass extra keys.
+
+    References
+    ----------
+    [1] Lang, A.; Schwab C.; Isotropic Gaussian random fields on the sphere:
+    regularity, fast simulation and stochastic partial differential equations;
+    The Annals of Applied Probability; 2015, Vol. 25, No. 6, 3047-3094;
+    DOI: 10.1214/14-AAP1067
+
+    See Also
+    --------
+    DiffusionNoiseS2 : stateful noise with temporal correlation.
+    """
+
     def __init__(
         self,
         img_shape,
@@ -217,31 +456,6 @@ class IsotropicGaussianRandomFieldS2(BaseNoiseS2):
         learnable=False,
         **kwargs,
     ):
-        r"""
-        GRF on the unit sphere. This implementation follows [1]. This noise is stateless.
-
-        References
-        ============
-        [1] Lang, A.; Schwab C.; ISOTROPIC GAUSSIAN RANDOM FIELDS ON THE SPHERE: REGULARITY, FAST SIMULATION AND STOCHASTIC PARTIAL DIFFERENTIAL EQUATIONS; The Annals of Applied Probability; 2015, Vol. 25, No. 6, 3047-3094; DOI: 10.1214/14-AAP1067
-
-        Parameters
-        ============
-        img_shape : (int, int)
-            Number of latitudinal and longitudinal modes
-        batch_size: int
-            Batch size for the noise
-        num_channels: int
-            Number of channels for the noise
-        sigma : float, default is 1.0
-            Scale parameter corresponding to the diagonal entry of the covariance kernel
-        alpha: float, default is 0.0
-            Decay factor in the angular power spectrum. White noise corresponds to alpha = 0.0
-        grid_type : string, default is "equiangular"
-            Grid type. Currently supports "equiangular" and
-            "legendre-gauss".
-        learnable : bool, default is False
-            Parameter which enables learnable Gaussian noise
-        """
         super().__init__(
             img_shape=img_shape,
             batch_size=batch_size,
@@ -288,9 +502,25 @@ class IsotropicGaussianRandomFieldS2(BaseNoiseS2):
 
     @override
     def is_stateful(self):
+        r"""
+        Whether the noise carries state across calls.
+
+        Returns
+        -------
+        bool
+            Always ``False``: every draw is an independent realization.
+        """
         return False
 
     def extra_repr(self):
+        r"""
+        Extra fields shown in the module's ``repr``.
+
+        Returns
+        -------
+        str
+            The base class fields plus ``sigma``, ``alpha`` and ``learnable``.
+        """
         return super().extra_repr() + f", sigma={self.sigma}, alpha={self.alpha}, learnable={self.learnable}"
 
     # run eager: the noise field is complex-valued (torch.complex + inverse SHT), and
@@ -300,6 +530,23 @@ class IsotropicGaussianRandomFieldS2(BaseNoiseS2):
     @torch.compiler.disable
     @override
     def forward(self, update_internal_state=False):
+        r"""
+        Scale the stored coefficients by the power spectrum and transform to the grid.
+
+        Parameters
+        ----------
+        update_internal_state : bool, optional
+            If ``True``, draw a fresh set of coefficients *after* producing the
+            output, so the next call returns an independent realization. By
+            default ``False``, which returns the same field until ``update`` is
+            called explicitly.
+
+        Returns
+        -------
+        torch.Tensor
+            Real-valued noise of shape
+            ``(batch, num_time_steps, num_channels, nlat_local, nlon_local)``.
+        """
 
         # combine channels and time:
         # torch.view_as_complex on a registered buffer hits a torch.compile/Inductor
@@ -326,8 +573,36 @@ class IsotropicGaussianRandomFieldS2(BaseNoiseS2):
         return eta
 
 
-# taken from scipy: https://github.com/scipy/scipy/blob/v1.13.0/scipy/linalg/_special_matrices.py#L17-L77
 def toep(c, r=None):
+    r"""
+    Construct a Toeplitz matrix from its first column and row.
+
+    Every diagonal of the result is constant: ``T[i, j]`` depends only on
+    ``i - j``. Used here to build the discount matrix of powers of :math:`\phi`
+    that correlates a freshly drawn noise history, so that resampling the whole
+    history reproduces the temporal correlation of the process instead of
+    giving independent steps.
+
+    Vendored from SciPy to avoid a runtime dependency on it.
+
+    Parameters
+    ----------
+    c : array_like
+        First column of the matrix. Flattened if not already 1D.
+    r : array_like, optional
+        First row of the matrix. ``r[0]`` is ignored -- ``c[0]`` sets the
+        diagonal. Defaults to ``conj(c)``, which gives a Hermitian matrix.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(len(c), len(r))``.
+
+    References
+    ----------
+    Taken from scipy:
+    https://github.com/scipy/scipy/blob/v1.13.0/scipy/linalg/_special_matrices.py#L17-L77
+    """
 
     c = np.asarray(c).ravel()
     if r is None:
@@ -344,6 +619,71 @@ def toep(c, r=None):
 
 
 class DiffusionNoiseS2(BaseNoiseS2):
+    r"""
+    Temporally correlated random field from a diffusion process on the sphere. Stateful.
+
+    Perturbations in an ensemble forecast should not be redrawn independently at
+    every step -- that produces noise the model damps out immediately rather
+    than a coherent perturbation that grows. This module instead evolves the
+    spectral coefficients as an Ornstein-Uhlenbeck process, so each step is
+    correlated with the last:
+
+    .. math::
+
+        \eta_{t+1} = \phi\, \eta_t + \sqrt{1 - \phi^2}\; \sigma_l\, \xi_t,
+        \qquad \phi = e^{-\lambda}
+
+    with :math:`\xi_t` standard normal. The prefactor
+    :math:`\sqrt{1-\phi^2}` keeps the process stationary: the marginal variance
+    stays at :math:`\sigma^2` for every :math:`t` instead of drifting as the
+    correlation length changes. :math:`\lambda = \Delta t / \tau` sets how fast
+    the field decorrelates in time, while ``kT`` sets the spatial correlation
+    length through the angular power spectrum.
+
+    Both ``kT`` and ``lambd`` may be given per channel, so different variables
+    can carry perturbations at different scales.
+
+    Parameters
+    ----------
+    img_shape : (int, int)
+        Output grid as ``(nlat, nlon)``.
+    batch_size : int
+        Initial batch size of the state buffer.
+    num_channels : int
+        Number of noise channels.
+    num_time_steps : int, optional
+        Number of time steps held in the state, by default ``1``.
+    sigma : float, default is 1
+        Stationary standard deviation.
+    kT : float or List, default is 0.5 * (500 km / 6370 km)^2 = 0.00308057
+        Spatial correlation length. If this is a list it has to match
+        ``num_channels``.
+    lambd : float or List, default is 1.0
+        Temporal correlation length, should be set to ``(t / tau)``. If this is
+        a list it has to match ``num_channels``.
+    grid_type : string, default is "equiangular"
+        Grid type. Currently supports ``"equiangular"`` and ``"legendre-gauss"``.
+    seed : int, optional
+        Seed for the private generators, by default ``333``.
+    reflect : bool, optional
+        Negate every draw, for antithetic ensemble pairing. By default ``False``.
+    learnable : bool, default is False
+        Parameter which enables learnable Diffusion noise: the per-degree
+        standard deviations become trainable.
+    **kwargs
+        Ignored; present so noise configs can pass extra keys.
+
+    References
+    ----------
+    Palmer, T. et al.; Stochastic parametrization and model uncertainty; ECMWF
+    Technical Memorandum 598, 2009, appendix 8.1.
+    https://www.ecmwf.int/sites/default/files/elibrary/2009/11577-stochastic-parametrization-and-model-uncertainty.pdf
+
+    See Also
+    --------
+    IsotropicGaussianRandomFieldS2 : stateless noise with no temporal correlation.
+    """
+
     def __init__(
         self,
         img_shape,
@@ -359,31 +699,6 @@ class DiffusionNoiseS2(BaseNoiseS2):
         learnable=False,
         **kwargs,
     ):
-        r"""
-        A Random Field derived from a gaussian Diffusion Process on the sphere:
-
-        For details see https://www.ecmwf.int/sites/default/files/elibrary/2009/11577-stochastic-parametrization-and-model-uncertainty.pdf,
-        appendix 8.1.
-        Supports noising multiple channels at once. This noise is stateful.
-
-        img_shape : (int, int)
-            Number of latitudinal and longitudinal modes
-        batch_size: int
-            Batch size for the noise
-        num_channels: int
-            Number of channels for the noise
-        sigma : float, default is 1
-            Stationary standard deviation
-        kT : float or List, default is 0.5 * (500 km / 6370 km)^2 = 0.00308057
-            Spatial correlation length. If this is a list it has to match num_channels.
-        lambd : float or List, default is 1.0
-            Temporal correlation length, should be set to (t / tau). If this is a list it has to match num_channels.
-        grid_type : string, default is "equiangular"
-            Grid type. Currently supports "equiangular" and
-            "legendre-gauss".
-        learnable : bool, default is False
-            Parameter which enables learnable Diffusion noise
-        """
         super().__init__(
             img_shape=img_shape,
             batch_size=batch_size,
@@ -485,16 +800,56 @@ class DiffusionNoiseS2(BaseNoiseS2):
 
     @override
     def is_stateful(self):
+        r"""
+        Whether the noise carries state across calls.
+
+        Returns
+        -------
+        bool
+            Always ``True``: each step is correlated with the previous one, so
+            the state must be checkpointed and reset between rollouts.
+        """
         return True
 
     def extra_repr(self):
+        r"""
+        Extra fields shown in the module's ``repr``.
+
+        Returns
+        -------
+        str
+            The base class fields plus ``sigma``, ``kT``, ``lambd`` and
+            ``learnable``.
+        """
         return (
             super().extra_repr() + f", sigma={self.sigma}, kT={self.kT}, lambd={self.lambd}, learnable={self.learnable}"
         )
 
-    # this routine generates a noise sample for a single time step and updates the state accordingly, by appending the last time step
     @override
     def update(self, replace_state=False, batch_size=None):
+        r"""
+        Advance the noise process by one step, or resample the whole history.
+
+        Parameters
+        ----------
+        replace_state : bool, optional
+            If ``False`` (the default), take one autoregressive step: the
+            existing state is damped by :math:`\phi` and a fresh innovation is
+            added, so the new field stays correlated with the old one. When
+            ``num_time_steps > 1`` the oldest step is dropped and the new one
+            appended.
+
+            If ``True``, discard the state and draw a fresh history from the
+            *stationary* distribution. The first time step is scaled by
+            :math:`1/\sqrt{1-\phi^2}` and, for ``num_time_steps > 1``, the
+            history is correlated by a Toeplitz discount matrix of powers of
+            :math:`\phi`. This matters when starting a rollout: drawing
+            independent steps instead would begin from a field with the wrong
+            variance and no temporal structure, and the process would need many
+            steps to spin up.
+        batch_size : int, optional
+            If given, resize the state buffer to this batch size before drawing.
+        """
         if batch_size is not None:
             self._ensure_state(batch_size)
 
@@ -549,6 +904,23 @@ class DiffusionNoiseS2(BaseNoiseS2):
     @torch.compiler.disable
     @override
     def forward(self, update_internal_state=False):
+        r"""
+        Transform the current spectral state to a noise field on the grid.
+
+        Parameters
+        ----------
+        update_internal_state : bool, optional
+            If ``True``, advance the process by one step *after* producing the
+            output, so the next call returns the following step of the
+            trajectory. By default ``False``, leaving the caller to drive the
+            process via :meth:`update`.
+
+        Returns
+        -------
+        torch.Tensor
+            Real-valued noise of shape
+            ``(batch, num_time_steps, num_channels, nlat_local, nlon_local)``.
+        """
 
         # combine channels and time:
         # see IsotropicGaussianRandomFieldS2.forward for why we avoid view_as_complex
@@ -573,6 +945,55 @@ class DiffusionNoiseS2(BaseNoiseS2):
 
 
 class DummyNoiseS2(BaseNoiseS2):
+    r"""
+    Dummy noise module for testing and debugging. This noise is stateless.
+
+    The module always emits a tensor with the correct output shape
+    ``(B, T, C, H, W)`` but carries no stochastic signal beyond what the chosen
+    mode specifies. Unlike the real noise classes it stores its state in
+    *spatial* rather than spectral layout and never runs an SHT, so it is cheap
+    enough to use in tests that only care about shapes and control flow.
+
+    Supported modes:
+
+    ``constant_zero`` (default)
+        Always emits an all-zero tensor. Useful for verifying shape consistency
+        of the noise pipeline without introducing any stochastic signal. In
+        particular, when the preprocessor is configured in ``"perturb"`` mode
+        the noise is *added* to the model input channels. Returning zeros
+        guarantees that the input is not modified, so integration tests can
+        check shapes and control-flow correctness without having to account for
+        random perturbations.
+
+    ``constant_random``
+        Draws a Gaussian tensor once per :meth:`update` call and holds it fixed
+        until the next one. Useful for verifying that the model handles a
+        non-zero, reproducible noise pattern correctly without the overhead of
+        the spherical harmonic transform used by the real noise classes.
+
+    Parameters
+    ----------
+    img_shape : (int, int)
+        Number of latitudinal and longitudinal modes.
+    batch_size : int
+        Batch size for the noise.
+    num_channels : int
+        Number of channels for the noise.
+    num_time_steps : int, optional
+        Number of time steps, by default ``1``.
+    mode : str, default 'constant_zero'
+        Output mode. One of ``'constant_zero'`` or ``'constant_random'``.
+    seed : int, default 333
+        Random seed used in ``'constant_random'`` mode; ignored otherwise.
+    **kwargs
+        Ignored; present so noise configs can pass extra keys.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not one of the two supported values.
+    """
+
     def __init__(
         self,
         img_shape,
@@ -583,43 +1004,6 @@ class DummyNoiseS2(BaseNoiseS2):
         seed=333,
         **kwargs,
     ):
-        r"""
-        Dummy noise module for testing and debugging. This noise is stateless.
-
-        The module always emits a tensor with the correct output shape (B, T, C, H, W)
-        but carries no stochastic signal beyond what the chosen mode specifies.
-
-        Supported modes
-        ---------------
-        constant_zero (default)
-            Always emits an all-zero tensor. Useful for verifying shape consistency
-            of the noise pipeline without introducing any stochastic signal. In particular,
-            when the preprocessor is configured in 'perturb' mode the noise is *added* to
-            the model input channels. Returning zeros guarantees that the input is not
-            modified, so integration tests can check shapes and control-flow correctness
-            without having to account for random perturbations.
-
-        constant_random
-            Draws a spatially-uniform Gaussian tensor once per update() call and holds it
-            fixed until the next update(). Useful for verifying that the model handles a
-            non-zero, reproducible noise pattern correctly without the overhead of the
-            spherical-harmonic transform used by the real noise classes.
-
-        Parameters
-        ============
-        img_shape : (int, int)
-            Number of latitudinal and longitudinal modes
-        batch_size: int
-            Batch size for the noise
-        num_channels: int
-            Number of channels for the noise
-        num_time_steps: int
-            Number of time steps
-        mode : str, default 'constant_zero'
-            Output mode. One of 'constant_zero' or 'constant_random'.
-        seed : int, default 333
-            Random seed used in 'constant_random' mode; ignored otherwise.
-        """
 
         if mode not in ("constant_zero", "constant_random"):
             raise ValueError(f"DummyNoiseS2: unknown mode '{mode}'. " f"Expected 'constant_zero' or 'constant_random'.")
@@ -645,13 +1029,41 @@ class DummyNoiseS2(BaseNoiseS2):
 
     @override
     def is_stateful(self):
+        r"""
+        Whether the noise carries state across calls.
+
+        Returns
+        -------
+        bool
+            Always ``False``: the stored tensor is held fixed between updates
+            rather than evolved.
+        """
         return False
 
     def extra_repr(self):
+        r"""
+        Extra fields shown in the module's ``repr``.
+
+        Returns
+        -------
+        str
+            The base class fields plus ``mode``.
+        """
         return super().extra_repr() + f", mode={self.mode}"
 
     @override
     def update(self, replace_state=False, batch_size=None):
+        r"""
+        Refresh the stored tensor according to the selected mode.
+
+        Parameters
+        ----------
+        replace_state : bool, optional
+            Accepted for interface compatibility with the stateful noise
+            classes; ignored here, since the state is always overwritten.
+        batch_size : int, optional
+            If given, resize the state buffer to this batch size first.
+        """
         if batch_size is not None:
             self._ensure_state(batch_size)
 
@@ -672,6 +1084,23 @@ class DummyNoiseS2(BaseNoiseS2):
 
     @override
     def forward(self, update_internal_state=False):
+        r"""
+        Return the stored tensor, no transform involved.
+
+        Parameters
+        ----------
+        update_internal_state : bool, optional
+            If ``True``, refresh the stored tensor *after* returning the current
+            one, by default ``False``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape
+            ``(batch, num_time_steps, num_channels, nlat_local, nlon_local)``:
+            all zeros, or a fixed Gaussian draw, depending on ``mode``. This is
+            the live state buffer, not a copy.
+        """
 
         state = self.state
 

--- a/makani/models/onnx_wrapper.py
+++ b/makani/models/onnx_wrapper.py
@@ -52,6 +52,19 @@ class OnnxWrapper(nn.Module):
         self.load_onnx_session(onnx_file)
 
     def load_onnx_session(self, onnx_file):
+        r"""
+        Create the ONNX Runtime inference sessions for a weight file.
+
+        Builds a CUDA session when a GPU is available and always builds a CPU
+        session, so :meth:`onnx_session_run` can pick whichever matches the
+        device the inputs arrive on. Called from the constructor; call it again
+        to swap in different weights without rebuilding the wrapper.
+
+        Parameters
+        ----------
+        onnx_file : str
+            Path to the ``.onnx`` weight file.
+        """
         self.onnx_file = onnx_file
 
         # Check if cuda is available to initialize a CUDA onnxruntime
@@ -69,6 +82,26 @@ class OnnxWrapper(nn.Module):
         )
 
     def onnx_session_run(self, inputs):
+        r"""
+        Run the ONNX graph on a dict of input tensors.
+
+        Selects the CUDA session when the inputs are on a GPU and one is
+        available, otherwise the CPU session. Tensors are converted to fp32
+        numpy arrays for the runtime and the outputs are converted back to
+        torch tensors on the input's device.
+
+        Parameters
+        ----------
+        inputs : dict of str to torch.Tensor
+            Graph inputs keyed by ONNX input name. Modified in place: the
+            values are replaced by their numpy equivalents.
+
+        Returns
+        -------
+        list of torch.Tensor
+            Graph outputs, in the order the ONNX graph declares them, on the
+            same device as the inputs.
+        """
         input_device = next(iter(inputs.values())).device
         if (self.gpu_session is not None) and input_device != torch.device("cpu"):
             onnx_session = self.gpu_session

--- a/makani/models/parametrizations.py
+++ b/makani/models/parametrizations.py
@@ -231,10 +231,53 @@ class _HydrostaticBalanceWrapper(nn.Module):
         return out
 
 
-# constraints is a list of dicts with variables, e.g.:
-# constraints = [{type: hydrostatic_balance,
-#                 options: {specific options}]
 class ConstraintsWrapper(nn.Module):
+    r"""
+    Enforce physical constraints on a model's output.
+
+    A purely data-driven prediction need not satisfy the balance relations the
+    atmosphere obeys. This wrapper projects the output onto the constrained
+    manifold after the forward pass, so the prediction is physically consistent
+    by construction rather than only approximately so through the loss.
+
+    Can either wrap a model (constraints applied to its output) or act
+    standalone on a tensor, which is useful for post-processing predictions
+    produced elsewhere.
+
+    ``constraints`` is a list of dicts, e.g.::
+
+        constraints = [{"type": "hydrostatic_balance",
+                        "options": {...}}]
+
+    Parameters
+    ----------
+    constraints : list of dict
+        Constraint specifications. Each entry needs a ``"type"`` key and an
+        ``"options"`` dict forwarded to that constraint. Currently only
+        ``"hydrostatic_balance"`` is supported.
+    channel_names : list of str
+        Names of the output channels, used to locate the variables each
+        constraint acts on.
+    bias : torch.Tensor
+        Normalization bias of the output channels. Needed because constraints
+        are physical relations and must be applied in physical units, not
+        normalized ones.
+    scale : torch.Tensor
+        Normalization scale of the output channels.
+    model_handle : callable, optional
+        Zero-argument factory returning a model to wrap. If omitted, the
+        wrapper applies the constraints directly to its input.
+
+    Raises
+    ------
+    NotImplementedError
+        If a constraint type other than ``"hydrostatic_balance"`` is requested.
+
+    Notes
+    -----
+    Only a single constraint is applied at present; if several are configured,
+    the first one is used.
+    """
 
     def __init__(self, constraints, channel_names, bias, scale, model_handle=None):
         super().__init__()
@@ -260,6 +303,21 @@ class ConstraintsWrapper(nn.Module):
                 )
 
     def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        r"""
+        Run the wrapped model, if any, and apply the constraint to the result.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Model input if a model is wrapped, otherwise the field to constrain
+            directly.
+
+        Returns
+        -------
+        torch.Tensor
+            Constrained output. Channels the constraint does not act on pass
+            through unchanged.
+        """
         if self.model is not None:
             # get model output
             inp = self.model(inp)

--- a/makani/models/physicsnemo_compat.py
+++ b/makani/models/physicsnemo_compat.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Compatibility helpers for building PhysicsNeMo modules across 1.x and 2.x.
+
+PhysicsNeMo 2.0 changed how :meth:`physicsnemo.Module.from_torch` behaves in two
+ways that matter to makani, and both are silent -- the old call still runs, it
+just does less than it used to:
+
+* **Registration became opt-in.** In 1.x every converted class was registered in
+  the ``ModelRegistry`` automatically. In 2.x ``register`` defaults to ``False``,
+  and an unregistered class cannot be reloaded via
+  :meth:`physicsnemo.Module.from_checkpoint`.
+* **The generated class is named differently.** 1.x appended a
+  ``PhysicsNeMoModel`` suffix; 2.x uses the wrapped class name verbatim unless a
+  ``name`` is supplied. That name is stored in the checkpoint metadata and is
+  what ``from_checkpoint`` resolves against, so letting it change would strand
+  checkpoints written under the other version.
+
+Separately, ``ModelMetaData.name`` is deprecated in 2.x: setting it raises a
+``DeprecationWarning`` and has no effect, since the model name now comes from the
+class. In 1.x it is still read, for the logger label and for the default
+``.mdlus`` filename. makani therefore keeps ``name`` off the metadata dataclasses
+and lets :func:`module_from_torch` apply it where it is still meaningful.
+
+The version is probed by inspecting the ``from_torch`` signature rather than by
+comparing ``physicsnemo.__version__``. Feature detection keeps this correct
+across release candidates and backports, where a version comparison would have to
+guess.
+"""
+
+import inspect
+
+import physicsnemo
+
+__all__ = [
+    "PHYSICSNEMO_REGISTER_IS_OPT_IN",
+    "get_model_registry",
+    "legacy_registered_name",
+    "module_from_torch",
+]
+
+
+# True on PhysicsNeMo >= 2.0, where from_torch gained `name`/`register` and no
+# longer registers by default.
+PHYSICSNEMO_REGISTER_IS_OPT_IN = "register" in inspect.signature(physicsnemo.Module.from_torch).parameters
+
+
+def get_model_registry():
+    r"""
+    Return the PhysicsNeMo ``ModelRegistry`` class from wherever it lives.
+
+    The registry moved from ``physicsnemo.registry`` (1.x) to
+    ``physicsnemo.core`` (2.x), and the old package was removed rather than
+    aliased, so importing it directly pins a caller to one major version.
+
+    Returns
+    -------
+    type
+        The ``ModelRegistry`` class.
+    """
+    try:
+        # PhysicsNeMo >= 2.0
+        from physicsnemo.core import ModelRegistry
+    except ImportError:
+        # PhysicsNeMo 1.x
+        from physicsnemo.registry import ModelRegistry
+
+    return ModelRegistry
+
+
+def legacy_registered_name(torch_model_class):
+    r"""
+    Return the class name PhysicsNeMo 1.x would have generated.
+
+    Reproducing the 1.x name on 2.x is what keeps checkpoints portable in both
+    directions: the name is recorded in the checkpoint metadata and resolved
+    again on load, so it has to agree across versions.
+
+    Parameters
+    ----------
+    torch_model_class : type
+        The PyTorch model class being wrapped.
+
+    Returns
+    -------
+    str
+        The wrapped class name with a ``PhysicsNeMoModel`` suffix, e.g.
+        ``"SphericalFourierNeuralOperatorNetPhysicsNeMoModel"``.
+    """
+    return f"{torch_model_class.__name__}PhysicsNeMoModel"
+
+
+def module_from_torch(torch_model_class, meta, name=None, registered_name=None):
+    r"""
+    Wrap a PyTorch model as a PhysicsNeMo module, identically on 1.x and 2.x.
+
+    Produces a class with the same ``__name__`` and the same ``ModelRegistry``
+    entry under either major version, so callers -- and any checkpoint that
+    records the class name -- cannot tell which one is installed.
+
+    Parameters
+    ----------
+    torch_model_class : type
+        The PyTorch model class to wrap.
+    meta : physicsnemo.ModelMetaData
+        Metadata instance for the model. Must not set ``name``; pass it via the
+        ``name`` argument instead, so 2.x does not warn about a deprecated field.
+    name : str, optional
+        Friendly model name, e.g. ``"SFNO"``. Applied to ``meta.name`` on 1.x,
+        where it drives the logger label and the default ``.mdlus`` filename. On
+        2.x it is also assigned, for makani-side introspection, but PhysicsNeMo
+        itself ignores it. Assigning after construction rather than passing it to
+        the dataclass is deliberate: the deprecation warning fires in
+        ``__post_init__`` only.
+    registered_name : str, optional
+        Name to register the class under. Defaults to
+        :func:`legacy_registered_name`, which matches 1.x.
+
+    Returns
+    -------
+    type
+        A ``physicsnemo.Module`` subclass wrapping ``torch_model_class``.
+    """
+    if registered_name is None:
+        registered_name = legacy_registered_name(torch_model_class)
+
+    if name is not None:
+        meta.name = name
+
+    if PHYSICSNEMO_REGISTER_IS_OPT_IN:
+        return physicsnemo.Module.from_torch(
+            torch_model_class,
+            meta,
+            name=registered_name,
+            register=True,
+        )
+
+    # PhysicsNeMo 1.x: from_torch registers unconditionally, under exactly the
+    # name legacy_registered_name() reproduces, so there is nothing to pass.
+    return physicsnemo.Module.from_torch(torch_model_class, meta)

--- a/makani/models/preprocessor.py
+++ b/makani/models/preprocessor.py
@@ -40,6 +40,47 @@ def _run_eager(fn, *args, **kwargs):
 
 
 class Preprocessor2D(nn.Module):
+    r"""
+    Input/output plumbing that surrounds the model in a rollout.
+
+    Sits between the dataloader and the network and owns everything that is not
+    the model itself: history handling, static and unpredicted features, noise
+    injection, bias correction, and the normalization of the history window.
+    Keeping this in one module is what lets the network see a single flat
+    channel stack while the training loop still reasons in terms of time steps
+    and variable groups.
+
+    The main responsibilities are:
+
+    * **History.** Inputs may carry ``n_history + 1`` time steps. These are
+      flattened into the channel dimension for the model
+      (:meth:`flatten_history`) and expanded back when needed
+      (:meth:`expand_history`); :meth:`append_history` slides the window forward
+      by one step during autoregressive rollout.
+    * **Unpredicted features.** Quantities the model consumes but does not
+      predict, such as the solar zenith angle, are cached per step and appended
+      to the input. They must be carried over from the target to the input at
+      each rollout step, since the model cannot generate them itself.
+    * **Static features.** Time-invariant fields such as orography and the
+      land-sea mask, appended to every input.
+    * **Noise.** Optional stochastic perturbation of the input, either
+      concatenated as extra channels or added to selected channels, for
+      ensemble forecasting.
+    * **Bias correction.** An optional additive correction applied to the
+      model input.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration object. Relevant keys include the image shape and
+        resampled shape, ``n_history``, ``history_normalization_mode``,
+        ``input_noise``, and the static-feature and bias-correction settings.
+
+    See Also
+    --------
+    get_preprocessor : factory that constructs this from a config.
+    """
+
     def __init__(self, params):
         super().__init__()
 
@@ -191,6 +232,23 @@ class Preprocessor2D(nn.Module):
                 raise NotImplementedError(f'Error, input noise type {noise_params["type"]} not supported.')
 
     def flatten_history(self, x):
+        r"""
+        Fold the time dimension into the channel dimension.
+
+        The network takes a single channel stack, so a history window has to be
+        flattened before it is passed in.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor of shape ``(B, T, C, H, W)``. Tensors that are already 4D
+            are returned unchanged, so this is safe to call unconditionally.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, T * C, H, W)``.
+        """
         # flatten input
         if x.dim() == 5:
             b_, t_, c_, h_, w_ = x.shape
@@ -199,6 +257,27 @@ class Preprocessor2D(nn.Module):
         return x
 
     def expand_history(self, x, nhist):
+        r"""
+        Split a flattened channel stack back into time and channel dimensions.
+
+        Inverse of :meth:`flatten_history`.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor of shape ``(B, T * C, H, W)``. Tensors that are already 5D
+            are returned unchanged.
+        nhist : int
+            Number of time steps ``T`` to split off. The channel dimension must
+            be divisible by this; the check is a ``torch._check`` so it survives
+            as a runtime assertion under ``torch.compile`` rather than becoming
+            a graph-breaking data-dependent branch.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, nhist, C, H, W)``.
+        """
         if x.dim() == 4:
             b_, ct_, h_, w_ = x.shape
             # torch._check (rather than `if ...: raise`) so this stays a runtime
@@ -216,6 +295,20 @@ class Preprocessor2D(nn.Module):
         return x
 
     def add_static_features(self, x):
+        r"""
+        Append the time-invariant feature channels to the input.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor of shape ``(B, C, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, C + n_static, H, W)``, or ``x`` unchanged if
+            no static features are configured.
+        """
         if self.do_add_static_features:
             # we need to replicate the grid for each batch:
             static = torch.tile(self.static_features, dims=(x.shape[0], 1, 1, 1))
@@ -224,6 +317,21 @@ class Preprocessor2D(nn.Module):
         return x
 
     def remove_static_features(self, x):
+        r"""
+        Strip the static feature channels appended by :meth:`add_static_features`.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor of shape ``(B, C + n_static, H, W)``, with the static
+            features occupying the trailing channels.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(B, C, H, W)``, or ``x`` unchanged if no static
+            features are configured.
+        """
         # only remove if something was added in the first place
         if self.do_add_static_features:
             nfeat = self.static_features.shape[1]
@@ -232,9 +340,37 @@ class Preprocessor2D(nn.Module):
 
     def append_history(self, x1, x2, step, update_state=True):
         r"""
-        Take care of unpredicted features first. This is necessary in order to copy the targets unpredicted features
-        (such as zenith angle) into the inputs unpredicted features, such that they can be forward in the next
-        autoregressive step. extract utar
+        Slide the history window forward by one autoregressive step.
+
+        Drops the oldest time step from ``x1`` and appends the new prediction
+        ``x2``, producing the input for the next step of the rollout.
+
+        This also advances the cached unpredicted features: quantities such as
+        the solar zenith angle are known in advance but not predicted by the
+        model, so the target's copy for this step has to be moved into the input
+        buffer or the next step would be conditioned on stale values. Whether
+        the train or eval buffers are updated follows the module's training
+        mode.
+
+        Parameters
+        ----------
+        x1 : torch.Tensor
+            Current input history, shape ``(B, (n_history + 1) * C, H, W)``.
+        x2 : torch.Tensor
+            Newly predicted step, shape ``(B, C, H, W)``.
+        step : int
+            Index of the current rollout step, used to select the corresponding
+            unpredicted features. Steps beyond the cached range leave the
+            unpredicted features untouched.
+        update_state : bool, optional
+            If ``False``, skip advancing the unpredicted feature buffers and
+            only shift the history. By default ``True``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated history of the same shape as ``x1``. With
+            ``n_history == 0`` this is just ``x2``.
         """
 
         # update the unpredicted input
@@ -328,6 +464,40 @@ class Preprocessor2D(nn.Module):
         return xo
 
     def history_compute_stats(self, x):
+        r"""
+        Compute and cache the normalization statistics for a history window.
+
+        Must be called before :meth:`history_normalize` or
+        :meth:`history_denormalize`, and re-called whenever the batch size
+        changes. Statistics are area-weighted using the grid quadrature, so
+        they are true spherical means rather than uniform grid averages, and
+        are broadcast across the spatial model-parallel group so every rank
+        normalizes identically.
+
+        The behavior depends on ``history_normalization_mode``:
+
+        * ``"none"`` -- statistics are set to zero mean and unit standard
+          deviation, making normalization a no-op.
+        * ``"timediff"`` -- statistics of the *differences* between consecutive
+          time steps are cached instead, characterizing the tendency rather than
+          the state.
+        * anything else (e.g. ``"exponential"``) -- a weighted mean and standard
+          deviation over the history window, using
+          ``history_normalization_weights``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            History window of shape ``(B, (n_history + 1) * C, H, W)`` or
+            ``(B, T, C, H, W)``.
+
+        Returns
+        -------
+        None
+            Results are stored on the module as ``history_mean`` /
+            ``history_std`` (or ``history_diff_mean`` / ``history_diff_var``
+            in ``"timediff"`` mode).
+        """
         if self.history_normalization_mode == "none":
             self.history_mean = torch.zeros((1, 1, 1, 1), dtype=torch.float32, device=x.device)
             self.history_std = torch.ones((1, 1, 1, 1), dtype=torch.float32, device=x.device)
@@ -414,6 +584,33 @@ class Preprocessor2D(nn.Module):
         )
 
     def history_normalize(self, x, target=False):
+        r"""
+        Normalize a tensor with the cached history statistics.
+
+        A no-op in the ``"none"`` and ``"timediff"`` modes, which do not define
+        a state-space normalization.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor of shape ``(B, C, H, W)`` or ``(B, T, C, H, W)``. The
+            original layout is restored on return.
+        target : bool, optional
+            If ``True``, treat ``x`` as a single-step target and use only the
+            leading channels of the statistics. If ``False`` (the default),
+            treat it as a full history window and tile the statistics over the
+            ``n_history + 1`` steps.
+
+        Returns
+        -------
+        torch.Tensor
+            Normalized tensor with the same shape as ``x``.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`history_compute_stats` has not been called yet.
+        """
         if self.history_normalization_mode in ["none", "timediff"]:
             return x
 
@@ -440,6 +637,30 @@ class Preprocessor2D(nn.Module):
         return xn
 
     def history_denormalize(self, xn, target=False):
+        r"""
+        Undo :meth:`history_normalize` using the cached statistics.
+
+        A no-op in the ``"none"`` and ``"timediff"`` modes.
+
+        Parameters
+        ----------
+        xn : torch.Tensor
+            Normalized tensor of shape ``(B, C, H, W)`` or ``(B, T, C, H, W)``.
+        target : bool, optional
+            If ``True``, treat ``xn`` as a single-step target and use only the
+            leading channels of the statistics; otherwise tile them over the
+            history window. By default ``False``.
+
+        Returns
+        -------
+        torch.Tensor
+            Denormalized tensor with the same shape as ``xn``.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`history_compute_stats` has not been called yet.
+        """
         if self.history_normalization_mode in ["none", "timediff"]:
             return xn
 
@@ -486,6 +707,35 @@ class Preprocessor2D(nn.Module):
             setattr(self, name, tensor.clone())
 
     def cache_unpredicted_features(self, x, y, xz=None, yz=None):
+        r"""
+        Cache the unpredicted input and target features for this sample.
+
+        Stores the auxiliary channels the model consumes but does not predict,
+        so that :meth:`append_history` and :meth:`append_unpredicted_features`
+        can draw on them during rollout. Separate train and eval caches are
+        kept, selected by the module's training mode, so that evaluation does
+        not clobber the state of an in-flight training step.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Model input. Passed through unchanged.
+        y : torch.Tensor
+            Model target. Passed through unchanged.
+        xz : torch.Tensor, optional
+            Unpredicted input features, shape ``(B, T, C_z, H, W)``. ``None``
+            clears the cache.
+        yz : torch.Tensor, optional
+            Unpredicted target features, shape ``(B, steps, C_z, H, W)``.
+            ``None`` clears the cache.
+
+        Returns
+        -------
+        x : torch.Tensor
+            The input, unchanged.
+        y : torch.Tensor
+            The target, unchanged.
+        """
         if self.training:
             self._ensure_cached("unpredicted_inp_train", xz)
             self._ensure_cached("unpredicted_tar_train", yz)
@@ -496,12 +746,44 @@ class Preprocessor2D(nn.Module):
         return x, y
 
     def get_base_seed(self, default=333):
+        r"""
+        Return the per-rank base seed of the noise module.
+
+        Parameters
+        ----------
+        default : int, optional
+            Value returned when no input noise is configured, by default ``333``.
+
+        Returns
+        -------
+        int
+            The noise base seed, which encodes the rank's position in the
+            ensemble and model-parallel grid.
+        """
         if hasattr(self, "input_noise"):
             return self.noise_base_seed
         else:
             return default
 
     def get_internal_rng(self, gpu=True):
+        r"""
+        Return the noise module's private generator.
+
+        Exposed so callers can draw additional randomness from the same stream
+        as the input noise, keeping everything reproducible under one seed
+        instead of mixing in the global RNG.
+
+        Parameters
+        ----------
+        gpu : bool, optional
+            Return the CUDA generator if ``True`` (the default), otherwise the
+            CPU generator.
+
+        Returns
+        -------
+        torch.Generator or None
+            ``None`` if no input noise is configured.
+        """
         if hasattr(self, "input_noise"):
             if gpu:
                 return self.input_noise.rng_gpu
@@ -511,6 +793,20 @@ class Preprocessor2D(nn.Module):
             return None
 
     def set_rng(self, reset=True, seed=333):
+        r"""
+        Re-seed the noise module, optionally clearing its state.
+
+        A no-op if no input noise is configured.
+
+        Parameters
+        ----------
+        reset : bool, optional
+            Also zero the noise state, by default ``True``. Leave the state in
+            place only if you intend to continue an existing trajectory under a
+            new seed.
+        seed : int, optional
+            New seed, by default ``333``.
+        """
         if hasattr(self, "input_noise"):
             self.input_noise.set_rng(seed)
             if reset:
@@ -518,6 +814,26 @@ class Preprocessor2D(nn.Module):
         return
 
     def get_internal_state(self, tensor=False):
+        r"""
+        Capture the noise module's state for checkpointing.
+
+        Parameters
+        ----------
+        tensor : bool, optional
+            If ``True``, return the spectral state tensor. If ``False`` (the
+            default), return the RNG state instead. A full resume generally
+            needs both.
+
+        Returns
+        -------
+        torch.Tensor or tuple or None
+            The state tensor, or a ``(cpu_state, gpu_state)`` RNG tuple. Yields
+            ``None`` / ``(None, None)`` when no input noise is configured.
+
+        See Also
+        --------
+        set_internal_state : restores what this returns.
+        """
         if hasattr(self, "input_noise"):
             if tensor:
                 state = self.input_noise.get_tensor_state()
@@ -532,6 +848,19 @@ class Preprocessor2D(nn.Module):
         return state
 
     def set_internal_state(self, state: Union[Tuple, torch.Tensor]):
+        r"""
+        Restore the noise module's state.
+
+        A no-op if no input noise is configured or if ``state`` is ``None``.
+
+        Parameters
+        ----------
+        state : tuple or torch.Tensor
+            A tensor is treated as the spectral state; a tuple is treated as an
+            ``(cpu_state, gpu_state)`` RNG pair. Which one it is is inferred
+            from the type, so the two forms returned by
+            :meth:`get_internal_state` can both be passed back here.
+        """
         if hasattr(self, "input_noise") and (state is not None):
             if isinstance(state, torch.Tensor):
                 self.input_noise.set_tensor_state(state)
@@ -541,8 +870,28 @@ class Preprocessor2D(nn.Module):
         return
 
     def update_internal_state(self, replace_state=False, batch_size=None):
-        """Advance the stochastic noise state by one step.
+        r"""Advance the stochastic noise state by one step.
 
+        A no-op if no input noise is configured.
+
+        Parameters
+        ----------
+        replace_state : bool, optional
+            If ``True``, draw a fresh state from the stationary distribution
+            rather than taking one autoregressive step. Required when changing
+            the batch size of stateful noise. By default ``False``.
+        batch_size : int, optional
+            Resize the noise state to this batch size. ``None`` (the default)
+            leaves it unchanged.
+
+        Raises
+        ------
+        RuntimeError
+            If a resize of stateful noise is requested while continuing an
+            autoregressive sequence; see below.
+
+        Notes
+        -----
         ``batch_size`` resizes the state to the given batch; None leaves it at its
         current size. Resizing is guarded: the state carries an ``n_history + 1``
         time axis holding the autoregressive noise history, and reallocating it
@@ -579,6 +928,28 @@ class Preprocessor2D(nn.Module):
         return
 
     def append_unpredicted_features(self, inp, target=False):
+        r"""
+        Append the cached unpredicted features to a tensor.
+
+        Also injects the input noise when configured, since noise is applied at
+        the same point in the pipeline. The train or eval cache is selected by
+        the module's training mode; if the relevant cache is empty the input is
+        returned unchanged.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Tensor of shape ``(B, C, H, W)`` or ``(B, T, C, H, W)``. The
+            original layout is restored on return.
+        target : bool, optional
+            Append the target-side unpredicted features rather than the
+            input-side ones, by default ``False``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor with the unpredicted feature channels appended.
+        """
         if self.training:
             if not target:
                 if self.unpredicted_inp_train is not None:
@@ -595,14 +966,34 @@ class Preprocessor2D(nn.Module):
                     inp = self._append_channels(inp, self.unpredicted_tar_eval)
         return inp
 
-    # accessors: clone returned tensors just to be safe
     def get_static_features(self):
+        r"""
+        Return a copy of the static feature tensor.
+
+        Returns
+        -------
+        torch.Tensor or None
+            Static features of shape ``(1, n_static, H, W)``, or ``None`` if
+            none are configured. Cloned so callers cannot mutate the buffer.
+        """
         if self.do_add_static_features:
             return self.static_features.clone()
         else:
             return None
 
     def get_unpredicted_features(self):
+        r"""
+        Return copies of the cached unpredicted input and target features.
+
+        Which cache is read follows the module's training mode.
+
+        Returns
+        -------
+        inpu : torch.Tensor or None
+            Cached unpredicted input features, or ``None`` if unset.
+        taru : torch.Tensor or None
+            Cached unpredicted target features, or ``None`` if unset.
+        """
         if self.training:
             if self.unpredicted_inp_train is not None:
                 inpu = self.unpredicted_inp_train.clone()
@@ -625,10 +1016,42 @@ class Preprocessor2D(nn.Module):
         return inpu, taru
 
     def correct_bias(self, inp: torch.Tensor):
+        r"""
+        Subtract the configured bias correction from the input.
+
+        A no-op if no bias correction is configured.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Input tensor; the correction must broadcast against it.
+
+        Returns
+        -------
+        torch.Tensor
+            The corrected tensor, same shape as ``inp``.
+        """
         if hasattr(self, "bias_correction"):
             inp = inp - self.bias_correction
         return inp
 
 
 def get_preprocessor(params):
+    r"""
+    Construct the preprocessor for a given configuration.
+
+    Indirection point for callers, so that selecting a different preprocessor
+    implementation stays a change in one place rather than at every call site.
+    Currently always returns :class:`Preprocessor2D`.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration object, forwarded to the preprocessor.
+
+    Returns
+    -------
+    Preprocessor2D
+        The configured preprocessor.
+    """
     return Preprocessor2D(params)

--- a/makani/models/preprocessor_helpers.py
+++ b/makani/models/preprocessor_helpers.py
@@ -19,6 +19,31 @@ import torch
 
 
 def get_bias_correction(params):
+    r"""
+    Load and shard the bias correction field, if one is configured.
+
+    The returned tensor is already restricted to this rank's local domain and
+    subsampled to match the model grid, so the caller can subtract it directly
+    without further slicing.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration. ``bias_correction`` gives the path to the correction
+        file; the ``img_local_*`` keys and ``subsampling_factor`` determine the
+        local shard.
+
+    Returns
+    -------
+    torch.Tensor or None
+        Bias correction of shape ``(1, C, H_local, W_local)``, or ``None`` if
+        no ``bias_correction`` path is configured.
+
+    Raises
+    ------
+    IOError
+        If ``bias_correction`` is set but does not point at an existing file.
+    """
     if params.get("bias_correction", None) is not None:
         from makani.utils.auxiliary_fields import get_bias_correction
 
@@ -45,6 +70,30 @@ def get_bias_correction(params):
 
 
 def get_static_features(params):
+    r"""
+    Assemble the time-invariant feature channels for the model input.
+
+    Collects whichever static fields the configuration asks for -- grid
+    coordinates, orography, land-sea mask, soil type, Copernicus embeddings --
+    into a single tensor, sharded to this rank's local domain and subsampled to
+    the model grid. These give the network the geographic context that the
+    prognostic variables alone do not carry.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration. ``add_grid``, ``add_orography``, ``add_landmask``,
+        ``add_soiltype`` and ``add_copernicus_emb`` select which features are
+        included; ``normalize_static_features`` enables area-weighted
+        normalization; the ``img_local_*`` / ``img_crop_*`` keys and
+        ``subsampling_factor`` determine the shard.
+
+    Returns
+    -------
+    torch.Tensor or None
+        Static features of shape ``(1, n_static, H_local, W_local)``, or
+        ``None`` if no static features are requested.
+    """
 
     # set up normalizer
     normalize_static_features = params.get("normalize_static_features", False)

--- a/makani/models/stepper.py
+++ b/makani/models/stepper.py
@@ -47,6 +47,27 @@ def _assert_checkpoint_safe(module: nn.Module):
 
 
 class SingleStepWrapper(nn.Module):
+    r"""
+    Bind a model to its preprocessor for a single forecast step.
+
+    Wraps the network so callers can hand it raw data and get a prediction back
+    in physical units, without having to replicate the preprocessing pipeline at
+    every call site. One ``forward`` performs: state update, appending
+    unpredicted and static features, history normalization, the model forward,
+    bias correction, and denormalization of the output.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration, forwarded to :class:`~makani.models.preprocessor.Preprocessor2D`.
+    model_handle : callable
+        Zero-argument factory returning the network to wrap.
+
+    See Also
+    --------
+    MultiStepWrapper : the autoregressive multi-step counterpart.
+    """
+
     def __init__(self, params, model_handle):
         super().__init__()
         self.preprocessor = Preprocessor2D(params)
@@ -80,6 +101,27 @@ class SingleStepWrapper(nn.Module):
         return self.preprocessor.add_static_features(inpan)
 
     def forward(self, inp, update_state=True, replace_state=True):
+        r"""
+        Predict a single step from raw input.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Input of shape ``(B, (n_history + 1) * C, H, W)`` in physical units.
+        update_state : bool, optional
+            Advance the stochastic noise state before the forward pass, by
+            default ``True``.
+        replace_state : bool, optional
+            Draw a fresh noise state rather than taking one autoregressive
+            step, by default ``True``. Required if the batch size changed since
+            the last call and the noise is stateful.
+
+        Returns
+        -------
+        torch.Tensor
+            Prediction of shape ``(B, C_out, H, W)``, denormalized back to
+            physical units.
+        """
         inpans = self._preprocess(inp, update_state=update_state, replace_state=replace_state)
 
         # forward pass
@@ -94,11 +136,31 @@ class SingleStepWrapper(nn.Module):
         return y
 
     def encode_process(self, inp, update_state=True, replace_state=True):
-        """Prepare one input and return backbone features before decoding.
+        r"""Prepare one input and return backbone features before decoding.
 
         Shares :meth:`_preprocess` with :meth:`forward`, so the preprocessing is
         identical by construction; only the decoder, bias correction, and target
         denormalization are skipped.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Input of shape ``(B, (n_history + 1) * C, H, W)`` in physical units.
+        update_state : bool, optional
+            Advance the stochastic noise state first, by default ``True``.
+        replace_state : bool, optional
+            Draw a fresh noise state rather than stepping, by default ``True``.
+
+        Returns
+        -------
+        torch.Tensor
+            Latent features of shape ``(B, embed_dim, h, w)`` on the model's
+            internal grid.
+
+        Raises
+        ------
+        NotImplementedError
+            If the wrapped model does not expose ``encode_process``.
         """
         if not hasattr(self.model, "encode_process"):
             raise NotImplementedError(f"{type(self.model).__name__} does not expose encode_process().")
@@ -109,6 +171,37 @@ class SingleStepWrapper(nn.Module):
 
 
 class MultiStepWrapper(nn.Module):
+    r"""
+    Bind a model to its preprocessor for an autoregressive rollout.
+
+    Runs the wrapped model for ``n_future + 1`` steps, feeding each prediction
+    back in as the next input and sliding the history window forward. Returns
+    all steps stacked, which is what multi-step training losses need.
+
+    Two options control cost and stability:
+
+    * **Push-forward mode.** Detaches the input at each step, so gradients do
+      not flow through the whole rollout. This trains the model to be robust to
+      its own errors without the cost -- or the instability -- of
+      backpropagating through many steps.
+    * **Rollout checkpointing.** Recomputes each step's forward during the
+      backward pass instead of retaining its activations, turning the
+      ``O(n_future)`` activation multiplier of backprop-through-time into
+      ``O(1)`` at the cost of one extra forward per step.
+
+    Parameters
+    ----------
+    params : ParamsBase
+        Configuration. Reads ``n_future``, ``multistep.push_forward``, and
+        ``multistep_checkpoint``; the rest is forwarded to the preprocessor.
+    model_handle : callable
+        Zero-argument factory returning the network to wrap.
+
+    See Also
+    --------
+    SingleStepWrapper : the single-step counterpart.
+    """
+
     def __init__(self, params, model_handle):
         super().__init__()
         self.preprocessor = Preprocessor2D(params)
@@ -222,6 +315,31 @@ class MultiStepWrapper(nn.Module):
         return y
 
     def forward(self, inp, update_state=True, replace_state=True):
+        r"""
+        Roll the model forward autoregressively and return all predicted steps.
+
+        Dispatches to the training or evaluation path based on the module's
+        training mode; the training path additionally honors push-forward mode
+        and rollout checkpointing, which do not apply under ``no_grad``.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Initial input of shape ``(B, (n_history + 1) * C, H, W)`` in
+            physical units.
+        update_state : bool, optional
+            Advance the stochastic noise state before the rollout, by default
+            ``True``.
+        replace_state : bool, optional
+            Draw a fresh noise state rather than continuing an existing
+            trajectory, by default ``True``.
+
+        Returns
+        -------
+        torch.Tensor
+            Predictions for all ``n_future + 1`` steps, concatenated along the
+            channel dimension as ``(B, (n_future + 1) * C_out, H, W)``.
+        """
         # decide which routine to call
         if self.training:
             y = self._forward_train(inp, update_state=update_state, replace_state=replace_state)

--- a/makani/models/stochastic_interpolant.py
+++ b/makani/models/stochastic_interpolant.py
@@ -23,8 +23,25 @@ from makani.models import Preprocessor2D
 from makani.models.noise import IsotropicGaussianRandomFieldS2 as IGRF
 
 
-# useful helper function
 def expand_time(x: torch.Tensor, n_samples: int) -> torch.Tensor:
+    r"""
+    Replicate a tensor along a new sample dimension after the batch.
+
+    Used to evaluate several interpolant time samples per batch element: the
+    input is repeated so each sample can be paired with a different time.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input of shape ``(B, ...)``.
+    n_samples : int
+        Number of copies.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(B, n_samples, ...)``.
+    """
     shape = x.shape
     x = x.unsqueeze(1).repeat(1, n_samples, *[1 for _ in shape[1:]])
 
@@ -32,6 +49,21 @@ def expand_time(x: torch.Tensor, n_samples: int) -> torch.Tensor:
 
 
 def expand_batch(x: torch.Tensor, n_batch: int) -> torch.Tensor:
+    r"""
+    Replicate a tensor along a new leading batch dimension.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input of any shape.
+    n_batch : int
+        Number of copies.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(n_batch, *x.shape)``.
+    """
     shape = x.shape
     x = x.unsqueeze(0).repeat(n_batch, 1, *[1 for _ in shape[1:]])
 
@@ -39,6 +71,28 @@ def expand_batch(x: torch.Tensor, n_batch: int) -> torch.Tensor:
 
 
 def expand_batch_space(x: torch.Tensor, n_batch: int, n_lat: int, n_lon: int) -> torch.Tensor:
+    r"""
+    Broadcast a per-time, per-channel tensor over batch and space.
+
+    Turns a table of scalars indexed by time step and channel into a full field,
+    so it can be combined elementwise with gridded data.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input of shape ``(T, C)``.
+    n_batch : int
+        Batch size to expand to.
+    n_lat : int
+        Number of latitudes.
+    n_lon : int
+        Number of longitudes.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(n_batch, T, C, n_lat, n_lon)``.
+    """
     T, C = x.shape
     x = x.reshape(1, T, C, 1, 1).repeat(n_batch, 1, 1, n_lat, n_lon)
 
@@ -198,14 +252,49 @@ class StochasticInterpolantWrapper(nn.Module):
         self.dgamma_fn = lambda s: torch.sqrt(s) * self.dsigma_fn(s)
 
     def get_internal_rng(self, gpu=True):
+        r"""
+        Return the noise module's private generator.
+
+        Parameters
+        ----------
+        gpu : bool, optional
+            Return the CUDA generator if ``True`` (the default), otherwise the
+            CPU generator.
+
+        Returns
+        -------
+        torch.Generator
+            The generator driving the interpolant's noise.
+        """
         if gpu:
             return self.noise_module.rng_gpu
         else:
             return self.noise_module.rng_cpu
 
-    # only used in Foellmer process: compute q^2 instead of g
-    # @torch.compile
     def gsq_fn(self, s: torch.Tensor, foellmer=False) -> torch.Tensor:
+        r"""
+        Squared diffusion coefficient of the sampling SDE.
+
+        The interpolant admits a family of samplers that share the same marginal
+        distributions but differ in how much noise they inject; ``gsq_fn``
+        selects one. The default is :math:`g^2(s) = \sigma^2(s)`. The Föllmer
+        choice instead returns :math:`q^2(s)`, the diffusion of the Föllmer
+        process, which drives the sample toward the target with a different
+        noise schedule.
+
+        Parameters
+        ----------
+        s : torch.Tensor
+            Interpolant time in :math:`[0, 1]`.
+        foellmer : bool, optional
+            Use the Föllmer coefficient rather than :math:`\sigma^2`, by
+            default ``False``.
+
+        Returns
+        -------
+        torch.Tensor
+            Squared diffusion coefficient, same shape as ``s``.
+        """
         if foellmer:
             term1 = (
                 2.0 * torch.square(self.sigma_fn(s)) * torch.where(s > 0, s * self.dbeta_fn(s) / self.beta_fn(s), 2.0)
@@ -217,8 +306,34 @@ class StochasticInterpolantWrapper(nn.Module):
 
         return result
 
-    # @torch.compile
     def dlog_rho(self, x: torch.Tensor, x0: torch.Tensor, b: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
+        r"""
+        Score function :math:`\nabla_x \log \rho_s(x)` of the interpolant density.
+
+        Recovered algebraically from the learned drift ``b`` rather than
+        estimated separately: for a Gaussian stochastic interpolant the drift
+        and the score are related by a closed-form expression in the schedule
+        functions, so one network suffices for both. The score is what turns the
+        probability-flow ODE into an SDE sampler.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Current state along the interpolant path.
+        x0 : torch.Tensor
+            Base sample the path starts from.
+        b : torch.Tensor
+            Drift predicted by the model at ``(x, s)``.
+        s : torch.Tensor
+            Interpolant time, strictly inside :math:`(0, 1)`. The expression is
+            singular at both endpoints, which the samplers avoid by never
+            evaluating there.
+
+        Returns
+        -------
+        torch.Tensor
+            The score, same shape as ``x``.
+        """
         # we never call this at s=0 or s=1, so everything is fine
         As = 1.0 / (s * self.sigma_fn(s) * (self.dbeta_fn(s) * self.sigma_fn(s) - self.beta_fn(s) * self.dsigma_fn(s)))
         cs = x * self.dbeta_fn(s) + (self.beta_fn(s) * self.dalpha_fn(s) - self.dbeta_fn(s) * self.alpha_fn(s)) * x0
@@ -387,6 +502,43 @@ class StochasticInterpolantWrapper(nn.Module):
         return x
 
     def forward(self, inp, tar=None, n_samples=1, n_steps=1):
+        r"""
+        Train on interpolant samples, or generate a forecast by integrating the SDE.
+
+        The two modes are genuinely different computations, selected by the
+        module's training mode. In training, interpolant times are sampled and
+        the model learns to predict the drift at those times, so ``tar`` is
+        required and ``n_samples`` controls how many times are drawn per batch
+        element. In evaluation, no target exists: the sampler integrates the
+        interpolant from the base distribution to the target distribution in
+        ``n_steps`` steps, and ``n_samples`` is unused.
+
+        Both noise sources are resized to the current input batch and redrawn
+        from their stationary distribution on entry, so callers that fold an
+        ensemble dimension into the batch can pass a ``(B * E, ...)`` input
+        without managing noise state themselves.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+            Input of shape ``(B, inp_chans, nlat, nlon)``.
+        tar : torch.Tensor, optional
+            Target of shape ``(B, out_chans, nlat, nlon)``. Required in
+            training mode, ignored in evaluation mode.
+        n_samples : int, optional
+            Number of interpolant time samples per batch element during
+            training, by default ``1``.
+        n_steps : int, optional
+            Number of integration steps during evaluation, by default ``1``.
+
+        Returns
+        -------
+        torch.Tensor or tuple of torch.Tensor
+            In training mode, a ``(drift_pred, drift)`` pair -- the model's
+            predicted drift and the analytic drift of the interpolant path --
+            for the loss to compare. In evaluation mode, the generated forecast
+            of shape ``(B, out_chans, nlat, nlon)``.
+        """
         # Keep both noise sources sized to the current input batch so callers that
         # fold an ensemble dim into the batch (e.g. stochastic_trainer.validate_one_epoch)
         # can hand us a (B*E, ...) input without any state-resize plumbing of their own.

--- a/makani/mpu/layers.py
+++ b/makani/mpu/layers.py
@@ -33,7 +33,7 @@ from makani.utils.te_helpers import TE_AVAILABLE as _TE_AVAILABLE, get_te
 
 
 class DistributedMatmul(nn.Module):
-    """Megatron-style tensor-parallel matmul over a single feature-parallel group.
+    r"""Megatron-style tensor-parallel matmul over a single feature-parallel group.
 
     The legacy 2D (fin x fout) decomposition has been retired in favor of a 1D
     column/row fork-join over a single comm group (``comm_name``, "matmul" by
@@ -48,6 +48,38 @@ class DistributedMatmul(nn.Module):
       and the partial outputs are all-reduced (``reduce_from_parallel_region``)
       into a replicated full output. For a row layer the bias is replicated and
       added AFTER the reduction.
+
+    Pairing a column layer with a row layer is what makes this cheap: the
+    intermediate stays sharded and only one all-reduce is needed for the pair,
+    rather than one per layer.
+
+    Parameters
+    ----------
+    inp_dim : int
+        Global input feature dimension. For ``"row"`` mode this is sharded
+        across the group, so it must be divisible by the group size.
+    out_dim : int
+        Global output feature dimension. For ``"column"`` mode this is sharded
+        across the group, so it must be divisible by the group size.
+    input_format : str, optional
+        ``"nchw"`` (default) for ``(B, C, H, W)`` inputs, or ``"traditional"``
+        for channels-last inputs.
+    comm_name : str, optional
+        Name of the communicator group to shard over, by default ``"matmul"``.
+    parallel_mode : str, optional
+        ``"column"`` (default) or ``"row"``; see above.
+    bias : bool, optional
+        Whether to add a bias, by default ``True``.
+    use_te : bool, optional
+        Use a TransformerEngine linear for the local GEMM, enabling the FP8/FP4
+        path. Falls back to the standard path if TransformerEngine is not
+        installed. By default ``False``.
+
+    Raises
+    ------
+    ValueError
+        If ``parallel_mode`` is neither ``"column"`` nor ``"row"``, or if the
+        sharded dimension is not divisible by the group size.
     """
 
     def __init__(
@@ -138,6 +170,26 @@ class DistributedMatmul(nn.Module):
 
     @property
     def weight(self):
+        r"""
+        The local weight shard, regardless of which backend holds it.
+
+        TransformerEngine's linear owns its weight internally; exposing it under
+        the same attribute name keeps external initialization, the model-parallel
+        annotations, and the gradient reduction hook uniform across both paths.
+
+        Returns
+        -------
+        torch.nn.Parameter
+            The local weight shard.
+
+        Raises
+        ------
+        AttributeError
+            If the native weight is not registered yet. This must be
+            ``AttributeError`` specifically: ``register_parameter`` probes
+            ``hasattr(self, "weight")`` while registering, and ``hasattr`` only
+            swallows that exception type.
+        """
         # te.Linear owns the weight in the TE path; expose it through the same
         # attribute so external init / annotation / the gradient hook are uniform.
         # raise AttributeError (not KeyError) when the native weight is not yet
@@ -161,6 +213,22 @@ class DistributedMatmul(nn.Module):
         return self.matmul_handle(x, self.weight, bias=None)
 
     def forward(self, x):
+        r"""
+        Apply the tensor-parallel matmul.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            For ``"column"`` mode, a replicated tensor with the full
+            ``inp_dim``. For ``"row"`` mode, a tensor already sharded along the
+            input dimension, typically the output of a preceding column layer.
+
+        Returns
+        -------
+        torch.Tensor
+            For ``"column"`` mode, sharded along the output dimension. For
+            ``"row"`` mode, replicated with the full ``out_dim``.
+        """
         if self.parallel_mode == "column":
             # replicated input -> sharded output, no output reduction
             x = copy_to_parallel_region(x, self.comm_name)
@@ -178,6 +246,49 @@ class DistributedMatmul(nn.Module):
 
 # distributed encoder/decoder
 class DistributedEncoderDecoder(nn.Module):
+    r"""
+    Tensor-parallel counterpart of
+    :class:`~makani.models.common.layers.EncoderDecoder`.
+
+    A stack of :class:`DistributedMatmul` layers with activations in between,
+    arranged so the chain consumes a replicated input and produces a replicated
+    output. The parallel modes are assigned from the *end* backwards: the last
+    layer is row-parallel (which reduces to a replicated output) and the modes
+    alternate from there. This keeps intermediates sharded and costs one
+    all-reduce per column/row pair rather than one per layer.
+
+    Because the modes alternate and the last must be ``"row"``, the first layer
+    is column-parallel only if ``num_layers`` is even -- hence the requirement
+    below.
+
+    Parameters
+    ----------
+    num_layers : int
+        Total number of matmul layers. Must be even when the communicator group
+        is larger than one.
+    input_dim : int
+        Number of input features.
+    output_dim : int
+        Number of output features.
+    hidden_dim : int
+        Width of the hidden layers.
+    act_layer : callable
+        Activation module constructor, called with no arguments.
+    gain : float, optional
+        Scales the variance of the output layer's initialization, by default ``1.0``.
+    input_format : str, optional
+        ``"nchw"`` (default) or ``"traditional"``.
+    comm_name : str, optional
+        Communicator group to shard over, by default ``"matmul"``.
+    use_te : bool, optional
+        Use TransformerEngine linears for the local GEMMs, by default ``False``.
+
+    Raises
+    ------
+    ValueError
+        If ``num_layers`` is odd while matmul parallelism is active.
+    """
+
     def __init__(
         self,
         num_layers,
@@ -254,11 +365,72 @@ class DistributedEncoderDecoder(nn.Module):
         self.fwd = nn.Sequential(*encoder_modules)
 
     def forward(self, x):
+        r"""
+        Apply the tensor-parallel layer stack.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Replicated input with ``input_dim`` features, in the layout implied
+            by ``input_format``.
+
+        Returns
+        -------
+        torch.Tensor
+            Replicated output with ``output_dim`` features.
+        """
         return self.fwd(x)
 
 
 # more complicated layers
 class DistributedMLP(nn.Module):
+    r"""
+    Tensor-parallel counterpart of :class:`~makani.models.common.layers.MLP`.
+
+    Two-layer feed-forward block in which the hidden dimension is sharded across
+    the communicator group: the first matmul is column-parallel and the second
+    row-parallel, so the wide intermediate never has to be materialized in full
+    on any rank and the pair needs only a single all-reduce.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    hidden_features : int, optional
+        Width of the sharded hidden layer, defaults to ``in_features``.
+    out_features : int, optional
+        Number of output features, defaults to ``in_features``.
+    output_bias : bool, optional
+        Whether the output projection carries a bias, by default ``True``.
+    input_format : str, optional
+        ``"nchw"`` (default) or ``"traditional"``.
+    comm_name : str, optional
+        Communicator group to shard the hidden dimension over, by default
+        ``"matmul"``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    drop_rate : float, optional
+        Dropout probability, by default ``0.0``.
+    drop_type : str, optional
+        ``"iid"`` (default) or ``"features"``. ``"features"`` requires
+        ``input_format="nchw"``.
+    checkpointing : bool, optional
+        Recompute the block in the backward pass instead of storing
+        activations, by default ``False``.
+    gain : float, optional
+        Scales the variance of the output layer's initialization, by default ``1.0``.
+    use_te : bool, optional
+        Use TransformerEngine linears for the GEMMs, by default ``False``. On
+        this path the matmuls are built channels-last and the block permutes
+        once at its boundaries rather than around every GEMM.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``drop_type`` is unsupported, or if ``"traditional"`` is combined
+        with feature dropout.
+    """
+
     def __init__(
         self,
         in_features,
@@ -340,6 +512,22 @@ class DistributedMLP(nn.Module):
             self.drop = nn.Identity()
 
     def fwd(self, x):
+        r"""
+        Run the block body, without the checkpointing wrapper.
+
+        Split out from ``forward`` so gradient checkpointing has a plain
+        callable to recompute.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Replicated input with ``in_features`` features.
+
+        Returns
+        -------
+        torch.Tensor
+            Replicated output with ``out_features`` features.
+        """
         # on the TE path the matmuls are channels-last ("traditional"): permute
         # nchw -> nhwc once here and back at the end, keeping act/iid-dropout
         # channels-last in between.
@@ -366,14 +554,95 @@ class DistributedMLP(nn.Module):
         return checkpoint(self.fwd, x, use_reentrant=False)
 
     def forward(self, x):
+        r"""
+        Apply the tensor-parallel feed-forward block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Replicated input with ``in_features`` features, in the layout
+            implied by ``input_format``.
+
+        Returns
+        -------
+        torch.Tensor
+            Replicated output with ``out_features`` features.
+        """
         if self.checkpointing:
             return self._checkpoint_forward(x)
         else:
             return self.fwd(x)
 
 
-# Stochastic MLP needs comm datastructure
 class StochasticMLP(nn.Module):
+    r"""
+    Two-layer MLP whose weights are resampled from a learned distribution.
+
+    Instead of holding point-estimate weights, each layer stores a mean and a
+    log standard deviation and draws a fresh weight on every forward pass:
+
+    .. math::
+
+        W = s\, e^{\log \sigma} \odot \varepsilon + \mu,
+        \qquad \varepsilon \sim \mathcal{N}(0, 1)
+
+    where :math:`s` is a constant fan-in scale. This is a variational /
+    Bayesian-style layer: the model learns how uncertain each weight is, and
+    the resulting forward-pass variability is a principled source of ensemble
+    spread rather than an injected perturbation. Parameterizing the spread
+    through :math:`\log \sigma` keeps it positive without a constraint, and
+    leaving it at its zero initialization makes the effective standard
+    deviation exactly :math:`s`.
+
+    The draws come from private, explicitly seeded generators rather than the
+    global RNG, so the sampled weights are reproducible and can be decorrelated
+    across ensemble members.
+
+    Parameters
+    ----------
+    in_features : int
+        Number of input features.
+    hidden_features : int, optional
+        Width of the hidden layer, defaults to ``in_features``.
+    out_features : int, optional
+        Number of output features, defaults to ``in_features``.
+    output_bias : bool, optional
+        Whether the output projection carries a bias, by default ``True``.
+    input_format : str, optional
+        Only ``"nchw"`` is supported; anything else raises.
+    comm_name : str, optional
+        Communicator group name, by default ``"matmul"``.
+    act_layer : callable, optional
+        Activation constructor, by default :class:`torch.nn.GELU`.
+    drop_rate : float, optional
+        Dropout probability, by default ``0.0``.
+    drop_type : str, optional
+        ``"iid"`` or ``"features"``, by default ``"iid"``.
+    checkpointing : bool, optional
+        Recompute the block in the backward pass, by default ``False``.
+    gain : float, optional
+        Scales the variance of the output layer's initialization, by default ``1.0``.
+    seed : int, optional
+        Seed for the private weight-sampling generators. Give distinct values
+        to distinct ensemble members.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``input_format`` is not ``"nchw"``, if ``drop_type`` is unsupported,
+        or if ``"traditional"`` is combined with feature dropout.
+
+    Notes
+    -----
+    The weight parameters are tagged ``is_shared_mp = ["spatial"]``: they are
+    replicated across the spatial model-parallel group and their gradients are
+    reduced over it.
+
+    See Also
+    --------
+    DistributedMLP : the deterministic counterpart.
+    """
+
     def __init__(
         self,
         in_features,
@@ -461,6 +730,15 @@ class StochasticMLP(nn.Module):
 
     @torch.compiler.disable(recursive=False)
     def set_rng(self, seed=333):
+        r"""
+        Re-seed the private weight-sampling generators.
+
+        Parameters
+        ----------
+        seed : int, optional
+            Seed applied to both the CPU and CUDA generators, by default
+            ``333``. The CUDA generator is bound to this rank's local device.
+        """
         self.rng_cpu = torch.Generator(device=torch.device("cpu"))
         self.rng_cpu.manual_seed(seed)
         if torch.cuda.is_available():
@@ -469,9 +747,40 @@ class StochasticMLP(nn.Module):
 
     @torch.compiler.disable(recursive=False)
     def checkpoint_forward(self, x):
+        r"""
+        Run the block under gradient checkpointing.
+
+        Normally reached via ``forward`` with ``checkpointing=True``. Note that
+        the weights are resampled during recomputation, so the backward pass
+        sees a different draw than the forward did.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_features, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``(B, out_features, H, W)``.
+        """
         return checkpoint(self.fwd, x, use_reentrant=False)
 
     def fwd(self, x):
+        r"""
+        Sample weights and run the block body, without the checkpointing wrapper.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_features, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``(B, out_features, H, W)``. Two calls with the same
+            input give different results, since the weights are redrawn.
+        """
 
         # generate weight1: weight = scale * exp(log_std) * eps + mean
         weight1 = torch.empty_like(self.fc1_weight_mean)
@@ -503,6 +812,20 @@ class StochasticMLP(nn.Module):
         return x
 
     def forward(self, x):
+        r"""
+        Apply the stochastic feed-forward block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_features, H, W)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``(B, out_features, H, W)``, using a fresh weight
+            draw.
+        """
         if self.checkpointing:
             return self.checkpoint_forward(x)
         else:
@@ -510,6 +833,49 @@ class StochasticMLP(nn.Module):
 
 
 class DistributedPatchEmbed(nn.Module):
+    r"""
+    Patch embedding with the spatial grid sharded across ranks.
+
+    Distributed counterpart of
+    :class:`~makani.models.common.layers.PatchEmbed2D`. The image is sharded
+    along its width across the spatial group and each rank embeds the slice it
+    owns. Because patch embedding is a strided convolution whose stride equals
+    its kernel, patches never straddle a shard boundary, so no halo exchange is
+    needed. The projection weights are replicated across the spatial group and
+    their gradients reduced over it.
+
+    Parameters
+    ----------
+    img_size : (int, int), optional
+        Global image size, by default ``(224, 224)``. The patched width must be
+        divisible by the spatial group size.
+    patch_size : (int, int), optional
+        Patch size, by default ``(16, 16)``.
+    in_chans : int, optional
+        Number of input channels, by default ``3``.
+    embed_dim : int, optional
+        Global dimension of each output token, by default ``768``. Sharded over
+        the matmul group when the output is matmul-parallel, in which case it
+        must be divisible by that group's size.
+    input_is_matmul_parallel : bool, optional
+        Whether the input arrives sharded along channels over the matmul group,
+        in which case it is gathered first. By default ``False``.
+    output_is_matmul_parallel : bool, optional
+        Whether to leave the output sharded along the embedding dimension, by
+        default ``False``.
+
+    Raises
+    ------
+    ValueError
+        If the patched width is not divisible by the spatial group size, or if
+        ``embed_dim`` is not divisible by the matmul group size when the output
+        is matmul-parallel.
+
+    See Also
+    --------
+    makani.models.common.layers.PatchEmbed2D : the single-rank version.
+    """
+
     def __init__(
         self,
         img_size=(224, 224),
@@ -560,6 +926,23 @@ class DistributedPatchEmbed(nn.Module):
         self.gather_shapes = compute_split_shapes(in_chans, comm.get_size("matmul"))
 
     def forward(self, x):
+        r"""
+        Embed this rank's slice of the image into patch tokens.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(B, in_chans, H, W_local)``, where ``W_local`` is
+            this rank's share of the width. Gathered along channels first if the
+            input is matmul-parallel.
+
+        Returns
+        -------
+        torch.Tensor
+            Tokens of shape ``(B, embed_dim_local, num_patches)``, where
+            ``embed_dim_local`` is the full ``embed_dim`` unless the output is
+            matmul-parallel.
+        """
         if self.input_parallel:
             x = gather_from_parallel_region(x, 1, self.gather_shapes, "matmul")
 
@@ -575,7 +958,47 @@ class DistributedPatchEmbed(nn.Module):
 
 
 class DistributedAttention(nn.Module):
-    """Distributed Attention layer"""
+    r"""
+    Multi-head self-attention with the heads sharded across ranks.
+
+    Attention heads are independent by construction, which makes them the
+    natural unit to shard: each rank computes a subset of the heads end to end
+    and no communication is needed inside the attention itself. The QKV
+    projection is column-parallel (producing this rank's heads) and the output
+    projection is row-parallel (reducing the concatenated heads back to a
+    replicated result), so the layer costs a single all-reduce.
+
+    Parameters
+    ----------
+    dim : int
+        Feature dimension. Must be divisible by ``num_heads``.
+    input_format : str, optional
+        Input layout, by default ``"traditional"`` (channels last).
+    comm_name : str, optional
+        Communicator group to shard heads over, by default ``"matmul"``.
+    num_heads : int, optional
+        Global number of attention heads, by default ``8``. Must be divisible
+        by the group size.
+    qkv_bias : bool, optional
+        Whether the QKV projection carries a bias, by default ``False``.
+    qk_norm : bool, optional
+        Normalize queries and keys before the attention product, by default
+        ``False``. Stabilizes training by bounding the logits.
+    attn_drop_rate : float, optional
+        Dropout probability on the attention weights, by default ``0.0``.
+    proj_drop_rate : float, optional
+        Dropout probability after the output projection, by default ``0.0``.
+    norm_layer : callable, optional
+        Normalization used for ``qk_norm``, by default :class:`torch.nn.LayerNorm`.
+    use_te : bool, optional
+        Use TransformerEngine linears for the projections, by default ``False``.
+
+    Raises
+    ------
+    ValueError
+        If ``dim`` is not divisible by ``num_heads``, or if ``num_heads`` is not
+        divisible by the communicator group size.
+    """
 
     def __init__(
         self,
@@ -634,6 +1057,19 @@ class DistributedAttention(nn.Module):
                 self.k_norm.bias.is_shared_mp = []
 
     def forward(self, x):
+        r"""
+        Apply head-parallel multi-head self-attention.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Replicated token tensor of shape ``(B, N, dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Replicated tensor of shape ``(B, N, dim)``.
+        """
         B, N, C = x.shape
 
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads_local, self.head_dim).permute(2, 0, 3, 1, 4)

--- a/makani/mpu/mappings.py
+++ b/makani/mpu/mappings.py
@@ -208,24 +208,106 @@ def gather_from_parallel_region(input, dim, shapes, comm_id):
 
 @torch.compiler.disable
 def distributed_transpose(x, dims, shapes, comm_id):
+    r"""
+    Redistribute a tensor by swapping which dimension is sharded.
+
+    Performs an all-to-all so that the dimension currently split across the
+    group becomes local and a currently local dimension becomes split. This is
+    the primitive behind distributed transforms: an operation that needs a full
+    axis (an FFT along longitude, say) first transposes so that axis is local,
+    trading away locality of another one.
+
+    Differentiable -- the backward pass performs the inverse redistribution.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor, sharded along ``dims[0]``.
+    dims : tuple of int
+        ``(src, dst)``: the dimension currently sharded and the one to shard
+        instead.
+    shapes : list of int
+        Per-rank sizes along the dimension being gathered, needed because the
+        split may be uneven.
+    comm_id : str
+        Name of the communicator group to redistribute over.
+
+    Returns
+    -------
+    torch.Tensor
+        The redistributed tensor, now sharded along ``dims[1]``.
+    """
     return _DistributedTranspose.apply(x, dims, shapes, comm_id)
 
 
 class gradient_print_wrapper(torch.autograd.Function):
+    r"""
+    Identity in the forward pass that prints gradient statistics in the backward.
+
+    Debugging aid: insert it anywhere in a model to see the min, max and mean of
+    the gradient flowing through that point, without altering the computation.
+    Useful for locating where gradients vanish or blow up in a deep or
+    distributed stack.
+
+    Call via ``gradient_print_wrapper.apply(x, msg)``.
+    """
 
     @staticmethod
     @torch.compiler.disable
     def forward(x, msg=""):
+        r"""
+        Return the input unchanged.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tensor to pass through.
+        msg : str, optional
+            Label included in the backward-pass printout.
+
+        Returns
+        -------
+        torch.Tensor
+            ``x``, unchanged.
+        """
         return x
 
     @staticmethod
     def setup_context(ctx, inputs, output):
+        r"""
+        Stash the label for use in the backward pass.
+
+        Parameters
+        ----------
+        ctx : torch.autograd.function.FunctionCtx
+            Autograd context.
+        inputs : tuple
+            The forward arguments ``(x, msg)``.
+        output : torch.Tensor
+            The forward result; unused.
+        """
         _, msg = inputs
         ctx.msg = msg
 
     @staticmethod
     @torch.compiler.disable
     def backward(ctx, go):
+        r"""
+        Print gradient statistics and pass the gradient through unchanged.
+
+        Parameters
+        ----------
+        ctx : torch.autograd.function.FunctionCtx
+            Autograd context carrying the label.
+        go : torch.Tensor
+            Incoming gradient.
+
+        Returns
+        -------
+        tuple
+            ``(go, None)`` -- the gradient unchanged, and ``None`` for the
+            non-tensor ``msg`` argument.
+        """
         msg = ctx.msg
         print(f"Gradient stats for {msg}: min: {go.min()}, max: {go.max()}, mean: {go.mean()}")
         return go, None
@@ -246,6 +328,52 @@ def init_gradient_reduction_hooks(
     static_graph=False,
     verbose=None,
 ):
+    r"""
+    Wrap a model in DDP with the gradient reductions model parallelism requires.
+
+    Plain DDP reduces every gradient over the data-parallel group, which is
+    wrong once model parallelism is in play: a parameter replicated across model
+    ranks accumulates a gradient contribution on each of them, so it must also
+    be reduced over the group it is shared across, while a sharded parameter
+    must not be. This function inspects the ``is_shared_mp`` annotation each
+    layer stamps on its parameters and installs a communication hook that
+    performs the right reduction per parameter.
+
+    Two cases avoid the hook entirely: with no model parallelism, or when *all*
+    parameters are shared across all model ranks. In the latter case the correct
+    result is obtained by scaling gradients by the model group size and letting
+    ordinary DDP handle the rest, which is cheaper than a custom hook.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Model to wrap. Parameters without an ``is_shared_mp`` annotation are
+        assumed to be shared across all model ranks.
+    device : torch.device
+        Device the model lives on.
+    reduction_buffer_count : int, optional
+        Number of DDP gradient buckets, by default ``1``. Forced to ``1`` when
+        custom hooks are needed, since the hook reduces per parameter.
+    broadcast_buffers : bool, optional
+        Broadcast buffers from rank 0 at each forward, by default ``True``.
+        Disabled automatically when custom hooks are needed, as sharded buffers
+        legitimately differ across ranks.
+    find_unused_parameters : bool, optional
+        Passed to DDP, by default ``False``.
+    gradient_as_bucket_view : bool, optional
+        Passed to DDP, by default ``True``.
+    static_graph : bool, optional
+        Passed to DDP, by default ``False``.
+    verbose : bool, optional
+        Log the sharing modes and hook setup. Defaults to the debug setting in
+        the mpu config.
+
+    Returns
+    -------
+    torch.nn.Module
+        The wrapped model, or the original model unchanged if torch.distributed
+        is not initialized.
+    """
     # early exit if we are not in a distributed setting:
     if not dist.is_initialized():
         return model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ dependencies = [
     "torch>=2.4.0",
     "numpy>=1.22.4",
     "h5py>=3.11.0",
+    # Both 1.x and 2.x are supported; the API differences between them are
+    # normalized in makani.models.physicsnemo_compat. Deliberately left without
+    # an upper bound so makani can share an environment with packages that
+    # require physicsnemo 2.x (e.g. earth2studio's corrdiff/stormcast extras).
+    # Note that physicsnemo 2.x itself raises the floor to Python >= 3.11, and
+    # 2.1+ to torch >= 2.10, above makani's own minimums declared here.
     "nvidia-physicsnemo>=1.3.0",
     "zarr>=3",
     "torch-harmonics>=0.9.0",

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -28,6 +28,7 @@
 # limitations under the License.
 
 import unittest
+import warnings
 from parameterized import parameterized
 from importlib.metadata import entry_points
 
@@ -59,6 +60,60 @@ class TestEntryPoints(unittest.TestCase):
         model = model_type()
         with self.subTest(desc="model is not None"):
             self.assertIsNotNone(model)
+
+
+class TestPhysicsNeMoCompat(unittest.TestCase):
+    """Guards the PhysicsNeMo 1.x/2.x compatibility contract.
+
+    PhysicsNeMo 2.0 made ``Module.from_torch`` registration opt-in and changed
+    the generated class name. Both changes are silent -- the old call still
+    succeeds, it just stops registering -- so nothing else in the suite would
+    catch a regression here. These tests assert the behavior makani relies on,
+    which :mod:`makani.models.physicsnemo_compat` normalizes across versions.
+    """
+
+    @parameterized.expand(
+        [
+            ("SFNO", "makani.models.networks.sfnonet", "SphericalFourierNeuralOperatorNet"),
+            ("FNO", "makani.models.networks.sfnonet", "FourierNeuralOperatorNet"),
+            ("FCN3", "makani.models.networks.fourcastnet3", "AtmoSphericNeuralOperatorNet"),
+            ("FCN3", "makani.models.networks.fourcastnet3_1", "AtmoSphericNeuralOperatorNet31"),
+        ]
+    )
+    def test_registered_under_legacy_name(self, attr, module_name, torch_class_name):
+        """The wrapped class keeps its 1.x name and stays in the model registry."""
+        import importlib
+
+        from makani.models.physicsnemo_compat import get_model_registry, legacy_registered_name
+
+        ModelRegistry = get_model_registry()
+
+        module = importlib.import_module(module_name)
+        wrapped = getattr(module, attr)
+        expected = legacy_registered_name(getattr(module, torch_class_name))
+
+        with self.subTest(desc="class name matches the PhysicsNeMo 1.x name"):
+            self.assertEqual(wrapped.__name__, expected)
+
+        # Registration is what from_checkpoint resolves against; on 2.x it only
+        # happens because the compat helper passes register=True.
+        with self.subTest(desc="class is registered"):
+            self.assertIn(expected, ModelRegistry().list_models())
+
+    def test_metadata_does_not_set_deprecated_name(self):
+        """Constructing the metadata must not emit a DeprecationWarning.
+
+        ``ModelMetaData.name`` is deprecated and inert on 2.x. makani keeps it
+        off the dataclasses and applies it via the compat helper instead.
+        """
+        from makani.models.networks.sfnonet import SphericalFourierNeuralOperatorNetMetaData
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            SphericalFourierNeuralOperatorNetMetaData()
+
+        offenders = [w for w in caught if issubclass(w.category, DeprecationWarning) and "name" in str(w.message)]
+        self.assertEqual(offenders, [], f"metadata set a deprecated field: {[str(w.message) for w in offenders]}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
  
  Two related pieces of work:
  
  1. Docstrings for every public class, method, and function in makani/models/ and the two makani/mpu/ layer modules — ~290 newly documented symbols across 28 files.
  2. PhysicsNeMo 1.x/2.x compatibility. makani continues to run unchanged on 1.3 and now behaves correctly on 2.x, which is required to share an environment with earth2studio.
  
  No functional change to model math, training, or inference.

Documentation

  Follows the torch-harmonics convention, since that's the sibling repo and its style already dominates there: NumPy-style sections with dash underlines, r""" throughout, and Sphinx roles
  (:math:, .. math::, ``literals``, :class:/:func: cross-refs). Constructor parameters are documented on the class, leaving __init__ bare — this matches RealSHT/ResampleS2 and avoids ~90 "see the
  class docstring" stubs.

  Docstrings explain why a layer is shaped the way it is, not just what it does — why "dhconv" is the rotation-equivariant weight layout, why transforms run fp32 under autocast, why LayerScale
  initializes small, why noise is generated spectrally rather than on the grid.

  Skipped: nested closures not reachable by a caller (get_static_features.normalize, the two inside init_gradient_reduction_hooks).

 Two pre-existing docstrings were wrong and are corrected here:
  
  - GeometricInstanceNormS2 claimed a "distributed S2 weighted instance norm using Welford's online algorithm". It is a two-pass quadrature computation, and it builds its quadrature with
  distributed=False. Now documented accurately, with a Notes section stating the statistics are rank-local. If this layer is ever used under spatial model parallelism that is a real bug, not just
  a doc issue — worth a follow-up.
  - StochasticMLP is a variational layer sampling weights as s·exp(log_σ)·ε + μ, not seeded dropout.
  
  Also converted the handful of Google-style (Args:) docstrings in files already being edited (the WeatherLearn-derived patch/upsample layers) to NumPy style; untouched files were left alone.

PhysicsNeMo 2.x compatibility
  
  PhysicsNeMo 2.0 changed Module.from_torch in two ways that are silent — the old call still succeeds, it just does less:
  
  - Registration became opt-in. 1.x registered every converted class automatically; 2.x defaults register=False, and an unregistered class cannot be reloaded via Module.from_checkpoint.
  - The generated class name changed. 1.x appended a PhysicsNeMoModel suffix; 2.x uses the wrapped class name verbatim. That name is stored in checkpoint metadata and resolved on load, so letting
  it drift would strand checkpoints written under the other version.
  
  Separately, ModelMetaData.name is deprecated and inert in 2.x (warns, no effect), while 1.x still reads it for the logger label and default .mdlus filename.

 New makani/models/physicsnemo_compat.py absorbs all of this:
  
  - module_from_torch() — replaces the four direct from_torch calls; passes name/register on 2.x, relies on implicit registration on 1.x.
  - legacy_registered_name() — reproduces the 1.x class name so it is stable across versions.
  - get_model_registry() — the registry moved from physicsnemo.registry to physicsnemo.core, and the old package was removed, not aliased.
  
  Version detection is by signature inspection, not __version__ comparison — correct across release candidates and backports (the current dev version is 2.2.0a0, which a string compare handles
  badly).
  
  name was removed from the four ModelMetaData subclasses (it's a field default, so it fired a DeprecationWarning on every instantiation under 2.x) and is now applied post-construction by the
  helper, where it still has an effect.
  
  Verified against stubbed 1.x and 2.x APIs — identical on both:
  
  PN 1.3  class=SphericalFourierNeuralOperatorNetPhysicsNeMoModel  registered=True  meta.name='SFNO'  deprecations=0
  PN 2.x  class=SphericalFourierNeuralOperatorNetPhysicsNeMoModel  registered=True  meta.name='SFNO'  deprecations=0 

makani/utils/comm.py needs no changes: the entire 1.3.0→2.1.1 diff for distributed/config.py is a copyright year, and for manager.py an internal helper rename.
  ProcessGroupNode/ProcessGroupConfig/create_groups_from_config are unchanged (create_groups_from_config is deprecated in favor of DeviceMesh, but that warning predates 2.0).
  
  pyproject.toml keeps nvidia-physicsnemo>=1.3.0 deliberately unbounded — an upper bound would make makani un-co-installable with earth2studio's PN2 extras. A comment records that PN2 raises the
  effective floors to Python ≥3.11 and (2.1+) torch ≥2.10, above makani's own declared minimums. 
  
  earth2studio
  
  Unaffected. Both wrappers use makani's own API rather than PhysicsNeMo's registry — fcn3.py calls load_model_package(package); sfno.py calls ParamsBase.from_json,
  LocalPackage._load_static_data, model_registry.get_model(params, multistep=False), ModelWrapper(model, params=params). All verified present with matching signatures.
  
  Worth noting: LocalPackage._load_static_data is a private-by-name method called from outside makani, so it is de facto public API — renaming it would break earth2studio silently.
  
  The real interaction is environmental: earth2studio's corrdiff/stormcast/cosmo/interp-modafno/stormscope extras require physicsnemo ≥2.0–2.2, while sfno/fcn3 pull makani. Installing them
  together already resolves PN2 alongside makani — the case this MR makes correct.  

Testing
  
  Adds TestPhysicsNeMoCompat to tests/test_entrypoints.py, asserting the class name and registry membership for all four wrapped models plus absence of the deprecation warning. Worth having
  precisely because both 2.x changes are silent.
  
  Not yet run. This environment has neither torch nor physicsnemo installed, so verification was: black --check clean at line-length 120, compileall clean, an AST pass confirming every NumPy
  section header is well-formed, and the stub-based check above. Please run the model and mpu suites, and ideally the new tests against both physicsnemo 1.3 and 2.x, before merging.
  
  Review notes
  
  - Registering under the legacy ...PhysicsNeMoModel name is deliberate, to keep checkpoints portable both directions. If you'd rather register under friendly names ("SFNO"), pass
  registered_name="SFNO" — but that strands existing physicsnemo-format checkpoints.
  - Dockerfiles still pin physicsnemo.git@v1.3.0. That's the supported 1.3 path, so it isn't wrong; a 2.x image would be a separate change.
 