### PR TITLE
Tkurth/security updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,11 @@ jobs:
         # with, otherwise the prebuilt _C.so will hit ABI-mismatch import errors.
         python -m pip install torch==2.7.1 --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install setuptools_scm
-        python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@main
+        # All git dependencies are pinned to immutable commit SHAs rather than branches
+        # or tags, so that a force-push or a repointed tag upstream cannot change what
+        # runs in CI. Bump these deliberately.
+        # torch-harmonics main as of 2026-08-04; move to the next release tag's SHA once it is cut.
+        python -m pip install --no-build-isolation git+https://github.com/NVIDIA/torch-harmonics.git@887006c640f1d61c3f80590ecc2b207bbb647072
         # Freeze whatever torch version TH just compiled against. Strip the
         # local label (+cpu) so the constraint matches any build of that
         # public version.
@@ -35,10 +39,10 @@ jobs:
         # Make the constraint visible to later workflow steps so physicsnemo
         # or any transitive dep can't silently upgrade torch and break TH's _C.so.
         echo "PIP_CONSTRAINT=${GITHUB_WORKSPACE}/constraints.txt" >> "$GITHUB_ENV"
-        # Pin physicsnemo to the git tag before installing the package so the
-        # `nvidia-physicsnemo>=1.1.1` dep in pyproject.toml resolves to this
-        # build rather than whatever PyPI offers.
-        python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.1.1
+        # Pin physicsnemo before installing the package so the `nvidia-physicsnemo>=1.1.1`
+        # dep in pyproject.toml resolves to this build rather than whatever PyPI offers.
+        # This is the SHA of tag v1.3.0.
+        python -m pip install git+https://github.com/NVIDIA/physicsnemo.git@14e0874847ffb56b35abf7708a1665e71605999c
     - name: Install package
       run: |
         python -m pip install -e .[test,vis]
@@ -48,7 +52,9 @@ jobs:
         # avoid pulling a numpy version that breaks the stack.
         # Note: NVIDIA DALI has no CPU-only wheel and requires CUDA runtime, so
         # DALI tests are skipped on this runner (guarded by skipUnless(_have_dali)).
-        python -m pip install --no-deps git+https://github.com/google-research/weatherbench2.git
+        # weatherbench2 main as of 2026-08-04. Third-party repo, so the SHA pin matters
+        # more here than for the NVIDIA-owned dependencies above.
+        python -m pip install --no-deps git+https://github.com/google-research/weatherbench2.git@95c36d547b22abc2d191451a580b0b194fde67ef
     - name: Test with pytest
       run: |
         python -m pytest -ra ./tests --cov=makani --cov-report=term-missing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,14 +64,19 @@ RUN pip install --upgrade wandb ruamel.yaml tqdm
 # scoring tools
 RUN pip install xskillscore properscoring
 
+# Git dependencies are pinned to immutable commit SHAs rather than branches or tags,
+# so that an upstream force-push or a repointed tag cannot change what lands in the
+# image. SHAs below are the respective default branches as of 2026-08-04; bump them
+# deliberately.
+
 # weatherbench2
-RUN pip install "git+https://github.com/google-research/weatherbench2.git"
+RUN pip install "git+https://github.com/google-research/weatherbench2.git@95c36d547b22abc2d191451a580b0b194fde67ef"
 
 # some useful scripts from mlperf
-RUN pip install --ignore-installed "git+https://github.com/NVIDIA/mlperf-common.git"
+RUN pip install --ignore-installed "git+https://github.com/NVIDIA/mlperf-common.git@c02c93c0414071400a10716d9cd5cb8f668b78d4"
 
-# physicsnemo
-RUN pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.3.0
+# physicsnemo (SHA of tag v1.3.0)
+RUN pip install git+https://github.com/NVIDIA/physicsnemo.git@14e0874847ffb56b35abf7708a1665e71605999c
 
 # torch-harmonics
 RUN pip install setuptools_scm
@@ -79,6 +84,7 @@ ENV FORCE_CUDA_EXTENSION=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0a 10.0a+PTX"
 RUN cd /opt && git clone https://github.com/NVIDIA/torch-harmonics.git && \
     cd torch-harmonics && \
+    git checkout 887006c640f1d61c3f80590ecc2b207bbb647072 && \
     pip install --no-build-isolation -e .
 
 # copy source code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,10 @@ RUN pip install git+https://github.com/NVIDIA/physicsnemo.git@14e0874847ffb56b35
 
 # torch-harmonics
 RUN pip install setuptools_scm
-ENV FORCE_CUDA_EXTENSION=1
+# torch-harmonics gates the CUDA build on this variable; without it BUILD_CUDA falls back
+# to torch.cuda.is_available(), which is False inside docker build (no GPU on the builder),
+# and TH silently compiles CPU-only kernels. The old name FORCE_CUDA_EXTENSION is dead.
+ENV TORCH_HARMONICS_BUILD_CUDA_EXTENSION=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0a 10.0a+PTX"
 RUN cd /opt && git clone https://github.com/NVIDIA/torch-harmonics.git && \
     cd torch-harmonics && \

--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -169,7 +169,10 @@ RUN pip install "git+https://github.com/google-research/weatherbench2.git@95c36d
 RUN pip install --ignore-installed "git+https://github.com/NVIDIA/mlperf-common.git@c02c93c0414071400a10716d9cd5cb8f668b78d4"
 
 # torch-harmonics
-ENV FORCE_CUDA_EXTENSION=1
+# torch-harmonics gates the CUDA build on this variable; without it BUILD_CUDA falls back
+# to torch.cuda.is_available(), which is False inside docker build (no GPU on the builder),
+# and TH silently compiles CPU-only kernels. The old name FORCE_CUDA_EXTENSION is dead.
+ENV TORCH_HARMONICS_BUILD_CUDA_EXTENSION=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0a 10.0a 12.0+PTX"
 RUN cd /opt && git clone https://github.com/NVIDIA/torch-harmonics.git && \
     cd torch-harmonics && \

--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -34,8 +34,11 @@ RUN pip install onnxruntime && \
     if [ "$(uname -m)" = "x86_64" ]; then pip install onnxruntime-gpu; fi
 
 # install AWS prereqs for HDF5
+# Each of these is pinned to the commit its default branch pointed at on 2026-08-04.
+# They are built against each other, so bump them as a set rather than individually.
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-common.git && \
     cd aws-c-common && \
+    git checkout dc44b5a53f0503eecd7a043459d06879d5f21acd && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -44,6 +47,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-c-common.git && \
 # 2. aws-checksums
 RUN cd /opt && git clone https://github.com/awslabs/aws-checksums.git && \
     cd aws-checksums && \
+    git checkout 5c0d51dbf239fe845353cd5c08ee077f8f2fe9fb && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr && \
     make -j$(nproc) && \
@@ -52,6 +56,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-checksums.git && \
 # 2.5. s2n-tls (required by aws-c-io)
 RUN cd /opt && git clone https://github.com/aws/s2n-tls.git && \
     cd s2n-tls && \
+    git checkout 853d1943bbbd7f782a159e77830cdaaf520d68ed && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja && \
     ninja -j$(nproc) && \
@@ -60,6 +65,7 @@ RUN cd /opt && git clone https://github.com/aws/s2n-tls.git && \
 # 3. aws-c-cal (crypto abstraction layer)
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-cal.git && \
     cd aws-c-cal && \
+    git checkout bce67e073c4357d785276170462e5023569ea121 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -69,6 +75,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-c-cal.git && \
 RUN cd /opt && \
     git clone https://github.com/awslabs/aws-c-sdkutils.git && \
     cd aws-c-sdkutils && \
+    git checkout a1cc19f53b63658f1b1400b36f199eafeeb895a6 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local && \
     make -j$(nproc) && \
@@ -77,6 +84,7 @@ RUN cd /opt && \
 # 5. aws-c-io (needs common + checksums)
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-io.git && \
     cd aws-c-io && \
+    git checkout fbac3c30fd8c50c05168f41486403a69d91f7600 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -86,6 +94,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-c-io.git && \
 RUN cd /opt && \
     git clone https://github.com/awslabs/aws-c-compression.git && \
     cd aws-c-compression && \
+    git checkout 48d8a47d20f6a1ced4f4f2325803c95b494d02c7 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local && \
     make -j$(nproc) && \
@@ -94,6 +103,7 @@ RUN cd /opt && \
 # 6. aws-c-http (needs io + auth)
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-http.git && \
     cd aws-c-http && \
+    git checkout 4ae782b6d24dd11d5785d33703c874eb5e4c05a5 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -102,6 +112,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-c-http.git && \
 # 4. aws-c-auth
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-auth.git && \
     cd aws-c-auth && \
+    git checkout 16c7289432839ca7e49132b68ad5a776e7279394 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -110,6 +121,7 @@ RUN cd /opt && git clone https://github.com/awslabs/aws-c-auth.git && \
 # 7. aws-c-s3 (final target for HDF5)
 RUN cd /opt && git clone https://github.com/awslabs/aws-c-s3.git && \
     cd aws-c-s3 && \
+    git checkout 0c26c42bd2617de0ba7022c4ab3d952431607650 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
@@ -151,20 +163,21 @@ RUN pip install --upgrade wandb ruamel.yaml tqdm
 RUN pip install xskillscore properscoring
 
 # weatherbench2
-RUN pip install "git+https://github.com/google-research/weatherbench2.git"
+RUN pip install "git+https://github.com/google-research/weatherbench2.git@95c36d547b22abc2d191451a580b0b194fde67ef"
 
 # some useful scripts from mlperf
-RUN pip install --ignore-installed "git+https://github.com/NVIDIA/mlperf-common.git"
+RUN pip install --ignore-installed "git+https://github.com/NVIDIA/mlperf-common.git@c02c93c0414071400a10716d9cd5cb8f668b78d4"
 
 # torch-harmonics
 ENV FORCE_CUDA_EXTENSION=1
 ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 9.0a 10.0a 12.0+PTX"
 RUN cd /opt && git clone https://github.com/NVIDIA/torch-harmonics.git && \
     cd torch-harmonics && \
+    git checkout 887006c640f1d61c3f80590ecc2b207bbb647072 && \
     pip install --no-build-isolation -e .
 
-# physicsnemo
-RUN pip install git+https://github.com/NVIDIA/physicsnemo.git@v1.3.0
+# physicsnemo (SHA of tag v1.3.0)
+RUN pip install git+https://github.com/NVIDIA/physicsnemo.git@14e0874847ffb56b35abf7708a1665e71605999c
 
 # copy source code
 RUN mkdir -p /opt/makani

--- a/makani/convert_checkpoint.py
+++ b/makani/convert_checkpoint.py
@@ -28,6 +28,7 @@ from makani.models import model_registry
 
 # distributed computing stuff
 from makani.utils.driver import Driver
+from makani.utils.checkpoint_helpers import load_checkpoint
 from makani.utils.YParams import ParamsBase
 
 
@@ -116,7 +117,7 @@ def consolidate_checkpoints(input_path, output_path, checkpoint_version=0):
     # open all files in mmap mode
     checkpoints = OrderedDict()
     for checkpoint in checkpoint_paths:
-        checkpoints[checkpoint] = torch.load(checkpoint, map_location="cpu", weights_only=False, mmap=True)
+        checkpoints[checkpoint] = load_checkpoint(checkpoint, map_location="cpu", mmap=True)
 
     # parse comm grids: extract comm dimensions and get a mapping of file to comm rank
     comm_dims, comm_ranks = parse_comm_grid(checkpoints)
@@ -208,13 +209,13 @@ def average_checkpoints(input_path, output_path):
     checkpoint_output_path = os.path.join(output_path, checkpoint_template)
 
     print(f"opening base checkpoint {checkpoint_paths[0]}")
-    base_checkpoint = torch.load(checkpoint_paths[0], map_location="cpu", weights_only=False)
+    base_checkpoint = load_checkpoint(checkpoint_paths[0], map_location="cpu")
     model_state_dict = base_checkpoint["model_state"]
 
     # this is reworked to avoid loading modules related t
     for checkpoint_file in checkpoint_paths[1:]:
         print(f"processing {checkpoint_file}")
-        current_checkpoint = torch.load(checkpoint_file, map_location="cpu", weights_only=False)
+        current_checkpoint = load_checkpoint(checkpoint_file, map_location="cpu")
         current_model_state = current_checkpoint["model_state"]
 
         for k, v in model_state_dict.items():
@@ -251,7 +252,7 @@ def strip_module(input_path):
 
     for checkpoint_file in checkpoint_paths:
         print(f"processing {checkpoint_file}")
-        checkpoint = torch.load(checkpoint_file, map_location="cpu", weights_only=False)
+        checkpoint = load_checkpoint(checkpoint_file, map_location="cpu")
         nn.modules.utils.consume_prefix_in_state_dict_if_present(checkpoint["model_state"], "module.")
         torch.save(checkpoint, checkpoint_file)
 

--- a/makani/utils/checkpoint_helpers.py
+++ b/makani/utils/checkpoint_helpers.py
@@ -17,9 +17,11 @@ import os
 import glob
 import re
 import zlib
+import pickle
 
 from collections import OrderedDict
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
+from warnings import warn
 
 import torch
 import torch.nn as nn
@@ -30,6 +32,77 @@ from makani.utils import comm
 from makani.mpu.helpers import gather_uneven
 
 from torch_harmonics.distributed import split_tensor_along_dim
+
+
+# escape hatch for loading legacy checkpoints which contain pickled objects that are not
+# on the allowlist below. Only set this for checkpoints from a trusted source: it restores
+# the unrestricted (arbitrary code execution) unpickler.
+UNSAFE_LOAD_ENV_VAR = "MAKANI_ALLOW_UNSAFE_CHECKPOINT_LOAD"
+
+_safe_globals_registered = False
+
+
+def _register_checkpoint_safe_globals():
+    """Allowlist the non-tensor types makani stores inside checkpoints.
+
+    ``torch.load(weights_only=True)`` uses a restricted unpickler which only knows about
+    tensors and a handful of builtin containers. Everything makani writes into a checkpoint
+    beyond that has to be declared here. Note that the sharding metadata (``sharded_dims_mp``)
+    attached to the checkpoint tensors needs no entry: it is a plain list of strings/None and
+    is restored through ``torch._tensor._rebuild_from_type_v2``, which the restricted
+    unpickler permits.
+    """
+
+    global _safe_globals_registered
+    if _safe_globals_registered:
+        return
+
+    # imported lazily to avoid a circular import through makani.utils
+    from makani.utils.YParams import ParamsBase, YParams
+
+    torch.serialization.add_safe_globals([ParamsBase, YParams])
+
+    _safe_globals_registered = True
+
+
+def load_checkpoint(checkpoint_fname: str, map_location: str = "cpu", mmap: bool = False) -> Dict[str, Any]:
+    """Load a makani checkpoint with the safe (``weights_only=True``) unpickler.
+
+    Parameters
+    ============
+    checkpoint_fname: str
+        Path of the checkpoint file to load
+    map_location: str
+        Device to map the storages to, forwarded to ``torch.load``
+    mmap: bool
+        Whether to memory-map the tensor storages instead of reading them eagerly
+
+    Returns
+    ========
+    Dict[str, Any]
+        The deserialized checkpoint dictionary
+    """
+
+    _register_checkpoint_safe_globals()
+
+    if os.environ.get(UNSAFE_LOAD_ENV_VAR, "0").lower() in ("1", "true", "yes"):
+        warn(
+            f"{UNSAFE_LOAD_ENV_VAR} is set, loading {checkpoint_fname} with the unrestricted unpickler. "
+            "This executes arbitrary code contained in the checkpoint file and should only be done for "
+            "checkpoints from a trusted source.",
+            RuntimeWarning,
+        )
+        return torch.load(checkpoint_fname, map_location=map_location, weights_only=False, mmap=mmap)
+
+    try:
+        return torch.load(checkpoint_fname, map_location=map_location, weights_only=True, mmap=mmap)
+    except pickle.UnpicklingError as err:
+        raise RuntimeError(
+            f"Checkpoint {checkpoint_fname} contains pickled objects which are not on the allowlist in "
+            f"{__name__}._register_checkpoint_safe_globals. If the type reported below is a legitimate "
+            "makani type, add it to that allowlist. If the checkpoint comes from a trusted source, loading "
+            f"can be forced by setting {UNSAFE_LOAD_ENV_VAR}=1, which disables the safety check entirely."
+        ) from err
 
 
 def get_latest_checkpoint_version(checkpoint_path):

--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -37,6 +37,7 @@ from makani.utils import comm
 from makani.utils.dataloaders.data_helpers import get_data_normalization
 from makani.utils.training.training_helpers import get_parameter_groups
 from makani.utils.checkpoint_helpers import (
+    load_checkpoint,
     gather_model_state_dict,
     scatter_model_state_dict,
     gather_optimizer_state_dict,
@@ -432,7 +433,7 @@ class Driver(metaclass=abc.ABCMeta):
         validate_comms: bool = True,
     ):
         checkpoint_fname = checkpoint_path.format(mp_rank=comm.get_rank("model"))
-        checkpoint = torch.load(checkpoint_fname, map_location="cpu", weights_only=False)
+        checkpoint = load_checkpoint(checkpoint_fname, map_location="cpu")
 
         # check compatibility of the comm grid stored inside the file
         if validate_comms:
@@ -503,7 +504,7 @@ class Driver(metaclass=abc.ABCMeta):
     ):
         # when loading the weights in flexble mode we exclusively use mp_rank=0 and load them onto the cpu
         checkpoint_fname = checkpoint_path.format(mp_rank=0)
-        checkpoint = torch.load(checkpoint_fname, map_location="cpu", weights_only=False)
+        checkpoint = load_checkpoint(checkpoint_fname, map_location="cpu")
 
         # this is reworked to avoid loading modules related to the SHT
         state_dict = checkpoint["model_state"]

--- a/makani/utils/losses/energy_score.py
+++ b/makani/utils/losses/energy_score.py
@@ -532,9 +532,6 @@ class SpectralL2EnergyScoreLoss(SpectralBaseLoss):
         if forecasts.dim() != 5:
             raise ValueError(f"Error, forecasts tensor expected to have 5 dimensions but found {forecasts.dim()}.")
 
-        # get the data type before stripping amp types
-        dtype = forecasts.dtype
-
         # before anything else compute the transform
         # as the CDF definition doesn't generalize well to more than one-dimensional variables, we treat complex and imaginary part as the same
         forecasts = forecasts.float()
@@ -544,8 +541,12 @@ class SpectralL2EnergyScoreLoss(SpectralBaseLoss):
             forecasts = self.sht(forecasts) / math.sqrt(4.0 * math.pi)
             observations = self.sht(observations) / math.sqrt(4.0 * math.pi)
 
-        forecasts = forecasts.to(dtype)
-        observations = observations.to(dtype)
+        # the SH coefficients stay COMPLEX from here on. Casting them back to the input
+        # (real) dtype would silently discard the imaginary part, and the score below is
+        # built around the squared modulus |z|^2 via .abs().square(): the m_weights in
+        # SpectralBaseLoss carry the factor 2 for m > 0 that accounts for the conjugate-
+        # symmetric negative-m modes, so dropping Im(z) would both halve the information
+        # in every m > 0 mode and break that Parseval normalization.
 
         # we assume the following shapes:
         # forecasts: batch, ensemble, channels, mmax, lmax
@@ -935,15 +936,14 @@ class CorrectedSpectralL2EnergyScoreLoss(SpectralBaseLoss):
         if forecasts.dim() != 5:
             raise ValueError(f"Error, forecasts tensor expected to have 5 dimensions but found {forecasts.dim()}.")
 
-        dtype = forecasts.dtype
         forecasts = forecasts.float()
         observations = observations.float()
         with amp.autocast(device_type="cuda", enabled=False):
             forecasts = self.sht(forecasts) / math.sqrt(4.0 * math.pi)
             observations = self.sht(observations) / math.sqrt(4.0 * math.pi)
 
-        forecasts = forecasts.to(dtype)
-        observations = observations.to(dtype)
+        # the SH coefficients stay COMPLEX from here on -- see the note in
+        # SpectralL2EnergyScoreLoss.forward for why casting back to a real dtype is wrong.
 
         B, E, C, H, W = forecasts.shape
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,39 @@ same spirit as the DALI dataloader, which already runs its workers with
 case.
 
 Override with ``MAKANI_TEST_START_METHOD`` (e.g. ``spawn`` or ``fork``) to debug.
+
+Also resets the torch.compile state between tests -- see ``reset_dynamo`` below.
 """
 
 import os
 import multiprocessing as mp
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_dynamo():
+    """Clear the dynamo compile cache before every test.
+
+    ``LossHandler`` compiles each loss (``makani/utils/loss.py``), and dynamo keys its
+    cache of compiled variants on the *code object* -- e.g. ``LpLoss.forward`` -- which
+    every ``LpLoss`` instance in the process shares. Tests that build a fresh trainer or
+    loss per parameterization therefore each add a cache entry to the same code object:
+    new instance, new device, new shapes, new guard set. Across a parameterized matrix
+    that accumulates past ``torch._dynamo.config.recompile_limit`` (default 8), at which
+    point dynamo gives up and falls back to eager for that code object *for the rest of
+    the session* -- so later tests silently stop exercising the compiled path they are
+    meant to cover.
+
+    Resetting per test keeps each one compiling from a clean cache. The cost is that
+    tests which trigger compilation genuinely recompile instead of reusing a warm cache.
+    """
+
+    import torch
+
+    torch._dynamo.reset()
+
+    yield
 
 
 def pytest_configure(config):

--- a/tests/test_checkpoint_helpers.py
+++ b/tests/test_checkpoint_helpers.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 """
-Non-distributed unit tests for the three pure-Python helpers in
+Non-distributed unit tests for the pure-Python helpers in
 ``makani.utils.checkpoint_helpers``:
 
   * ``get_latest_checkpoint_version``
   * ``get_model_state_dict_prefix``
   * ``prepend_prefix_to_state_dict``
+  * ``load_checkpoint``
 
 The distributed gather/scatter round-trip is covered separately by
 ``tests/distributed/tests_distributed_checkpoint.py``.
@@ -30,7 +31,9 @@ import sys
 import unittest
 import tempfile
 from collections import OrderedDict
+from unittest import mock
 
+import torch
 import torch.nn as nn
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -39,7 +42,22 @@ from makani.utils.checkpoint_helpers import (
     get_latest_checkpoint_version,
     get_model_state_dict_prefix,
     prepend_prefix_to_state_dict,
+    load_checkpoint,
+    UNSAFE_LOAD_ENV_VAR,
 )
+
+
+class UnsupportedPayload:
+    """Stand-in for an arbitrary object smuggled into a checkpoint.
+
+    Must live at module scope so that pickle can resolve it by qualified name.
+    """
+
+    def __init__(self, value="payload"):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, UnsupportedPayload) and other.value == self.value
 
 
 class TestGetLatestCheckpointVersion(unittest.TestCase):
@@ -217,6 +235,126 @@ class TestPrependPrefixToStateDict(unittest.TestCase):
         with self.subTest(desc="metadata values preserved"):
             self.assertEqual(d._metadata["module."], {"version": 1})
             self.assertEqual(d._metadata["module.b"], {"version": 1})
+
+
+class TestLoadCheckpoint(unittest.TestCase):
+    """
+    ``load_checkpoint`` wraps ``torch.load`` with the restricted (``weights_only=True``)
+    unpickler so that a hostile checkpoint cannot execute code on load. These tests pin
+    both halves of that contract: legitimate checkpoint content still round-trips, and
+    anything outside the allowlist is refused with an actionable error.
+    """
+
+    def setUp(self):
+        self.tmpdir_ctx = tempfile.TemporaryDirectory()
+        self.tmpdir = self.tmpdir_ctx.name
+        self.path = os.path.join(self.tmpdir, "ckpt.tar")
+        # make sure the env escape hatch is off regardless of the ambient environment
+        self.env_ctx = mock.patch.dict(os.environ, {UNSAFE_LOAD_ENV_VAR: "0"})
+        self.env_ctx.start()
+
+    def tearDown(self):
+        self.env_ctx.stop()
+        self.tmpdir_ctx.cleanup()
+
+    def test_loads_plain_checkpoint_contents(self):
+        # the shape of what Driver.save_checkpoint writes, without any exotic objects
+        store_dict = {
+            "model_state": OrderedDict([("w", torch.randn(2, 3))]),
+            "comm_grid": OrderedDict([("matmul", {"size": 1, "rank": 0})]),
+            "iters": 42,
+            "epoch": 2,
+        }
+        torch.save(store_dict, self.path)
+
+        checkpoint = load_checkpoint(self.path)
+
+        self.assertEqual(checkpoint["iters"], 42)
+        self.assertEqual(checkpoint["comm_grid"]["matmul"], {"size": 1, "rank": 0})
+        self.assertTrue(torch.allclose(checkpoint["model_state"]["w"], store_dict["model_state"]["w"]))
+
+    def test_preserves_sharding_metadata_on_tensors(self):
+        # makani attaches sharded_dims_mp directly to the checkpoint tensors. Tensors with
+        # extra attributes serialize through torch._tensor._rebuild_from_type_v2, which the
+        # restricted unpickler permits -- convert_checkpoint depends on this surviving.
+        tensor = torch.randn(2, 3)
+        tensor.sharded_dims_mp = ["matmul", None]
+        torch.save({"model_state": OrderedDict([("w", tensor)])}, self.path)
+
+        restored = load_checkpoint(self.path)["model_state"]["w"]
+
+        self.assertTrue(hasattr(restored, "sharded_dims_mp"))
+        self.assertEqual(restored.sharded_dims_mp, ["matmul", None])
+
+    def test_mmap_load(self):
+        torch.save({"model_state": OrderedDict([("w", torch.randn(2, 3))])}, self.path)
+
+        # convert_checkpoint opens the shards with mmap=True; that must work under the
+        # restricted unpickler as well
+        checkpoint = load_checkpoint(self.path, mmap=True)
+
+        self.assertEqual(tuple(checkpoint["model_state"]["w"].shape), (2, 3))
+
+    def test_loads_allowlisted_params_struct(self):
+        """Legacy checkpoints may carry a params struct, which the allowlist covers.
+
+        Reconstructing an allowlisted class from its ``__dict__`` needs the restricted
+        unpickler to support the BUILD opcode for user-registered globals. If this test
+        fails, the ParamsBase/YParams entries in ``_register_checkpoint_safe_globals`` do
+        not actually help on this torch version and such checkpoints need the env escape
+        hatch instead.
+        """
+        from makani.utils.YParams import ParamsBase
+
+        params = ParamsBase()
+        params.update_params({"N_in_channels": 3, "nettype": "sfno"})
+        torch.save({"model_state": OrderedDict(), "params": params}, self.path)
+
+        checkpoint = load_checkpoint(self.path)
+
+        self.assertEqual(checkpoint["params"].N_in_channels, 3)
+        self.assertEqual(checkpoint["params"].nettype, "sfno")
+
+    def test_rejects_object_outside_allowlist(self):
+        torch.save({"model_state": OrderedDict(), "payload": UnsupportedPayload()}, self.path)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            load_checkpoint(self.path)
+
+        # the error has to tell the user what to do about it
+        message = str(ctx.exception)
+        self.assertIn(UNSAFE_LOAD_ENV_VAR, message)
+        self.assertIn("allowlist", message)
+        # and the underlying unpickler error, naming the offending type, must be chained
+        self.assertIsNotNone(ctx.exception.__cause__)
+        self.assertIn("UnsupportedPayload", str(ctx.exception.__cause__))
+
+    def test_rejects_object_nested_in_model_state(self):
+        # the interesting attack position is inside the state dict itself, not next to it
+        torch.save({"model_state": OrderedDict([("w", UnsupportedPayload())])}, self.path)
+
+        with self.assertRaises(RuntimeError):
+            load_checkpoint(self.path)
+
+    def test_env_var_escape_hatch_allows_unsafe_load(self):
+        torch.save({"model_state": OrderedDict(), "payload": UnsupportedPayload("legacy")}, self.path)
+
+        with mock.patch.dict(os.environ, {UNSAFE_LOAD_ENV_VAR: "1"}):
+            # the escape hatch must be loud about what it is doing
+            with self.assertWarns(RuntimeWarning):
+                checkpoint = load_checkpoint(self.path)
+
+        self.assertEqual(checkpoint["payload"], UnsupportedPayload("legacy"))
+
+    def test_env_var_escape_hatch_off_by_default(self):
+        # anything other than an explicit opt-in keeps the safe path
+        torch.save({"model_state": OrderedDict(), "payload": UnsupportedPayload()}, self.path)
+
+        for value in ["0", "false", "no", ""]:
+            with self.subTest(value=value):
+                with mock.patch.dict(os.environ, {UNSAFE_LOAD_ENV_VAR: value}):
+                    with self.assertRaises(RuntimeError):
+                        load_checkpoint(self.path)
 
 
 if __name__ == "__main__":

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -138,6 +138,34 @@ def _rand(batch=_BATCH, channels=_NUM_CH, requires_grad=False):
     return t
 
 
+def _imaginary_only_pair(ensemble=5, wavenumber=3, delta=1.0):
+    """Build an (forecast, observation) pair differing ONLY in Im(SH coefficients).
+
+    On the uniform longitude grid the SHT's azimuthal transform is a DFT, so for a
+    field ``g(theta) * cos(m*lambda)`` the coefficients at order m are purely real,
+    while ``g(theta) * sin(m*lambda)`` gives purely imaginary ones. Adding a scaled
+    sine component therefore perturbs the imaginary part of the coefficients and
+    leaves the real part bit-for-bit identical.
+
+    A spectral loss built on the squared modulus |z|^2 must see this as an error.
+    A loss that discards Im(z) scores it as a perfect forecast.
+
+    Every ensemble member is the same perturbed field, so the pairwise spread term
+    vanishes and the returned loss is the accuracy (eskill) term alone.
+    """
+
+    lon = 2.0 * math.pi * torch.arange(_IMG_W, dtype=torch.float32) / _IMG_W
+    profile = torch.sin(torch.linspace(0.0, math.pi, _IMG_H, dtype=torch.float32))
+
+    base = profile.unsqueeze(-1) * torch.cos(wavenumber * lon).unsqueeze(0)
+    perturbation = profile.unsqueeze(-1) * torch.sin(wavenumber * lon).unsqueeze(0)
+
+    observations = base.expand(_BATCH, _NUM_CH, _IMG_H, _IMG_W).contiguous()
+    forecasts = (base + delta * perturbation).expand(_BATCH, ensemble, _NUM_CH, _IMG_H, _IMG_W).contiguous()
+
+    return forecasts, observations
+
+
 def _rand_ensemble(ensemble=5, batch=_BATCH, channels=_NUM_CH, requires_grad=False):
     t = torch.randn(batch, ensemble, channels, _IMG_H, _IMG_W)
     t.requires_grad_(requires_grad)
@@ -2523,6 +2551,43 @@ class TestSpectralL2EnergyScoreLoss(unittest.TestCase):
         self.assertFalse(torch.isnan(fc.grad).any(), "NaN in spec_l2_es gradient at perfect forecast")
         self.assertFalse(torch.isinf(fc.grad).any(), "Inf in spec_l2_es gradient at perfect forecast")
 
+    def test_penalizes_imaginary_only_error(self):
+        """An error confined to Im(SH coefficients) must not be scored as perfect.
+
+        Regression test: the forward used to cast the complex SHT output back to the
+        real input dtype, which discarded the imaginary part of every coefficient. The
+        score is built on |z|^2 (``.abs().square()``) and the m > 0 weights carry the
+        Parseval factor 2 for the conjugate-symmetric negative-m modes, so dropping
+        Im(z) silently halved the information in every m > 0 mode and made the error
+        constructed here invisible -- the loss came out exactly 0.
+        """
+
+        fn = self._fn()
+        fc, obs = _imaginary_only_pair(ensemble=self._E)
+
+        # verify the construction: the real parts of the coefficients must be identical,
+        # so anything the loss reports comes purely from the imaginary part
+        with torch.no_grad():
+            obs_coeffs = fn.sht(obs)
+            fc_coeffs = fn.sht(fc[:, 0])
+        with self.subTest(desc="perturbation is imaginary-only"):
+            self.assertTrue(
+                torch.allclose(obs_coeffs.real, fc_coeffs.real, atol=1e-5),
+                "test construction is wrong: the real parts of the coefficients differ",
+            )
+            self.assertFalse(
+                torch.allclose(obs_coeffs.imag, fc_coeffs.imag, atol=1e-5),
+                "test construction is wrong: the imaginary parts are identical",
+            )
+
+        out = fn(fc, obs)
+        with self.subTest(desc="loss is nonzero"):
+            self.assertGreater(
+                out.abs().max().item(),
+                1e-3,
+                "imaginary-only error scored as a perfect forecast -- Im(z) is being discarded",
+            )
+
     def test_batch_independence(self, verbose=False):
         fn = self._fn()
         fc = _rand_ensemble(self._E)
@@ -3011,6 +3076,20 @@ class TestCorrectedSpectralL2EnergyScoreLoss(unittest.TestCase):
             ensemble_distributed=False,
             channel_reduction=channel_reduction,
             **kw,
+        )
+
+    def test_penalizes_imaginary_only_error(self):
+        """Same regression as TestSpectralL2EnergyScoreLoss -- the corrected variant
+        carried an identical complex-to-real cast in its forward."""
+
+        fn = self._fn()
+        fc, obs = _imaginary_only_pair(ensemble=self._E)
+
+        out = fn(fc, obs)
+        self.assertGreater(
+            out.abs().max().item(),
+            1e-3,
+            "imaginary-only error scored as a perfect forecast -- Im(z) is being discarded",
         )
 
     def _fn_uncorrected(self, channel_reduction=True, **kw):

--- a/tests/test_save_restore.py
+++ b/tests/test_save_restore.py
@@ -25,7 +25,7 @@ from torch import nn
 
 from makani.models.common import MLP
 from makani.utils.driver import Driver
-from makani.utils.checkpoint_helpers import get_latest_checkpoint_version
+from makani.utils.checkpoint_helpers import get_latest_checkpoint_version, load_checkpoint
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from .testutils import disable_tf32, set_seed, get_default_parameters, compare_arrays
@@ -138,6 +138,76 @@ class TestSaveRestore(unittest.TestCase):
 
         # compare
         self.assertTrue(compare_arrays("output", out_before, out_after, rtol=1e-6, atol=1e-6, verbose=verbose))
+
+    @parameterized.expand(["legacy", "flexible"])
+    def test_saved_checkpoint_loads_with_safe_unpickler(self, checkpoint_mode):
+        """
+        Everything ``Driver.save_checkpoint`` writes must be readable by the restricted
+        (``weights_only=True``) unpickler used in ``load_checkpoint``, otherwise checkpoints
+        written by makani could not be read back by makani.
+
+        This exercises the full store dict -- model state carrying the ``sharded_dims_mp``
+        sharding metadata, comm grid, loss/optimizer/scheduler state and the counters.
+        """
+
+        model = MLP(
+            self.params.N_in_channels,
+            hidden_features=2 * self.params.N_in_channels,
+            out_features=self.params.N_out_channels,
+            act_layer=nn.GELU,
+            output_bias=True,
+            input_format="nchw",
+            drop_rate=0.0,
+        )
+
+        # tag a parameter as sharded. In a single-rank test no layer sets this by itself, but the
+        # attribute is what convert_checkpoint keys off, so the round-trip has to preserve it.
+        sharded_name, sharded_param = next(iter(model.named_parameters()))
+        sharded_param.sharded_dims_mp = ["matmul", None]
+
+        loss = nn.MSELoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        counters = {"iters": 7, "epoch": 3}
+
+        # take one step so the optimizer actually carries state tensors
+        inp = torch.randn(
+            self.params.batch_size, self.params.N_in_channels, self.params.img_shape_x, self.params.img_shape_y
+        )
+        loss(model(inp), torch.zeros_like(model(inp))).backward()
+        optimizer.step()
+        scheduler.step()
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            checkpoint_path = os.path.join(tempdir, "ckpt_mp{mp_rank}.tar")
+
+            Driver.save_checkpoint(
+                checkpoint_path,
+                model=model,
+                loss=loss,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                counters=counters,
+                checkpoint_mode=checkpoint_mode,
+            )
+
+            # load it back through the safe loader. A raise here means the safe globals
+            # allowlist is out of sync with what save_checkpoint writes.
+            checkpoint = load_checkpoint(checkpoint_path.format(mp_rank=0))
+
+        self.assertIn("model_state", checkpoint)
+        self.assertEqual(checkpoint["iters"], 7)
+        self.assertEqual(checkpoint["epoch"], 3)
+        self.assertIn("optimizer_state_dict", checkpoint)
+        self.assertIn("scheduler_state_dict", checkpoint)
+
+        # the sharding metadata must survive the round-trip, otherwise convert_checkpoint
+        # would silently treat a sharded tensor as unsharded
+        restored = checkpoint["model_state"][sharded_name]
+        self.assertTrue(
+            hasattr(restored, "sharded_dims_mp"), f"sharding metadata lost for {sharded_name} in {checkpoint_mode} mode"
+        )
+        self.assertEqual(restored.sharded_dims_mp, ["matmul", None])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Security review fixes, checkpoint loading hardening, and an energy-score bug
    
  Addresses findings from a security review of makani, plus two real bugs
  surfaced while verifying the fixes.
    
  ## 1. `torch.load` no longer executes arbitrary code (security)

 `torch.load(..., weights_only=False)` uses pickle under the hood, so a
  malicious checkpoint from a shared filesystem, model hub, or compromised
  storage could achieve code execution on the loading machine.
  
  All checkpoint loads now go through a single `load_checkpoint()` helper in
  `makani/utils/checkpoint_helpers.py`, which uses the restricted
  (`weights_only=True`) unpickler:
  
  - `_register_checkpoint_safe_globals()` allowlists `ParamsBase`/`YParams`
    via `torch.serialization.add_safe_globals` for older checkpoints that
    carried a params struct. Nothing written by the current `save_checkpoint`
    needs it — params live in the model package's `config.json`, not the
    `.tar`. 
  - On `pickle.UnpicklingError` it raises an actionable error naming the
    allowlist function, with the offending type in the chained exception.
  - `MAKANI_ALLOW_UNSAFE_CHECKPOINT_LOAD=1` restores the old behavior with a
    `RuntimeWarning`, for legacy checkpoints from a trusted source. Default
    is secure.
  
  Converted call sites: `driver.py` (2), `convert_checkpoint.py` (4 — two
  more than the review listed).
  
  The sharding metadata (`sharded_dims_mp`) that `convert_checkpoint` depends
  on survives the restricted unpickler: tensors with extra attributes
  serialize through `torch._tensor._rebuild_from_type_v2`, which is permitted.
  `tests/test_save_restore.py` now asserts this explicitly for both `legacy`
  and `flexible` modes.

## 2. Git dependencies pinned to commit SHAs (security)
    
  Branches and tags are mutable, so an upstream force-push or repointed tag
  could change what runs in CI or lands in an image. Now SHA-pinned across
  `.github/workflows/tests.yml`, `docker/Dockerfile`, `docker/Dockerfile.aws`:
  
  | dep | was | now |
  |---|---|---|
  | torch-harmonics | `@main` | `887006c6` |
  | physicsnemo | `@v1.1.1` (workflow) | `14e08748` = tag v1.3.0 |
  | weatherbench2 | unpinned | `95c36d54` |
  | mlperf-common | unpinned | `c02c93c0` |
  | 10 AWS C libraries (`.aws` image) | unpinned | see diff |
  
  The physicsnemo change also fixes an inconsistency: the workflow pinned
  v1.1.1 while `pyproject.toml` requires `>=1.3.0`, so the later 
  `pip install -e .` was overwriting the git install from PyPI — the "pin"
  wasn't holding. CI now matches the container.

 The AWS libraries are built against each other and are pinned/bumped as a
  set; there's a comment saying so.
  
  **Follow-up:** when the next torch-harmonics release is tagged, replace the
  pinned main SHA with the release tag's SHA in three places (`tests.yml:31`,
  `docker/Dockerfile:90`, `docker/Dockerfile.aws:179`). Marked with comments.
  
  ## 3. Fix silent CPU-only torch-harmonics builds
  
  The Dockerfiles set `FORCE_CUDA_EXTENSION=1`, which torch-harmonics no
  longer reads — the variable was renamed to
  `TORCH_HARMONICS_BUILD_CUDA_EXTENSION`. With it ignored, `BUILD_CUDA` falls
  back to `torch.cuda.is_available()`, which is False inside `docker build`,
  so TH silently compiled **CPU-only kernels**. Nothing fails at build time;
  it surfaces much later as `NotImplementedError: Could not run
  'disco_kernels::forward' with arguments from the 'CUDA' backend` in
  `test_models`. Fixed in both Dockerfiles with a comment explaining the trap.

## 4. Energy score discarded the imaginary part of SH coefficients (bug)
  
  `SpectralL2EnergyScoreLoss.forward` and
  `CorrectedSpectralL2EnergyScoreLoss.forward` captured `dtype` from the real
  input and then applied it to the *complex* SHT output, so `.to(dtype)`
  silently dropped `Im(z)` for every coefficient.
  
  This is wrong because:
  - the downstream arithmetic is `.abs().square()`, the complex-modulus
    idiom — on a real tensor it degenerates to `x**2`;
  - `SpectralBaseLoss` builds `m_weights = 2` for `m > 0`, the Parseval factor
    for the conjugate-symmetric negative-m modes, which is only correct when
    summing the full squared modulus;
  - the five sibling spectral losses (`SobolevEnergyScoreLoss`,
    `SpectralCoherenceLoss`, `regularization.py`, `h1_loss.py`) all keep the
    coefficients complex. Only these two cast back.
  
  **Effect:** every `m > 0` mode lost half its information — a forecast with
  correct amplitude but wrong phase scored as perfect on that mode. Since
  this is in the forward, it biased the training gradient, not just the
  reported number.
  
  Fix: drop the cast (and the now-dead `dtype` capture) in both classes,
  matching the siblings. New regression test
  `test_penalizes_imaginary_only_error` builds a forecast/observation pair
  differing *only* in `Im(coeffs)` — `g(θ)·cos(mλ)` has purely real
  coefficients, `g(θ)·sin(mλ)` purely imaginary — and asserts the loss is
  nonzero. Before the fix this returned exactly 0.

## 5. Reset dynamo state between tests
  
  `LossHandler` compiles each loss, and dynamo keys its cache on the *code
  object* (`LpLoss.forward`), shared by every instance in the process. Each
  parameterization added a cache entry until `recompile_limit` (8) tripped,
  after which dynamo falls back to eager **for the rest of the session** — so
  later tests silently stopped exercising the compiled path. An autouse
  fixture in `tests/conftest.py` calls `torch._dynamo.reset()` per test.
  
  Tradeoff: tests that compile now genuinely recompile rather than reusing a
  warm cache, so the suite is slower.

## Testing
    
  - `tests/test_losses.py` fully green, including both new tests and the
    existing energy-score suite (`test_equivalence_at_correct_amplitude`,
    `test_cheap_spread_penalty`, `TestEnsembleLossE1FastPath`) — the loss
    change didn't disturb any existing assertion.
  - `tests/test_checkpoint_helpers.py` — new `TestLoadCheckpoint` covering the
    round-trip, `mmap=True`, sharding metadata, rejection of a non-allowlisted
    object both beside and nested inside `model_state`, and the env escape
    hatch in both directions.
  - `tests/test_save_restore.py` — full store dict (model + loss + optimizer +
    scheduler + counters) round-trips through the safe loader in both
    checkpoint modes.
  - `tests/test_models.py` passes again once the image is rebuilt with the
    corrected CUDA build variable.

## Deliberately not addressed
  
  - **Containers run as root.** The NGC PyTorch base image runs as root by
    design, and the image `USER` is not the enforcement point on the
    deployment paths that matter (Slurm/pyxis/enroot runs as the submitting
    UID and discards it; k8s uses `securityContext`). Baking a fixed UID would
    break bind-mounted data on cluster filesystems. Tracking the base image;
    will follow if NGC changes.
  - **torch-harmonics SHT truncation warnings.** These come from the default
    truncation change in TH v0.9.0 and will be retired upstream.
  
  Two things I'd flag before you post it:
  
  Section 4's claim that the old code returned exactly 0 is my reasoning about the eps masking path, not something I ran. If you want that sentence to be load-bearing in the MR, stash
  energy_score.py and run the new test once to confirm — otherwise consider softening it to "scored the error as a perfect forecast."
    
  The line numbers in the follow-up note (docker/Dockerfile:90, Dockerfile.aws:179) are from the current working tree and will drift if anything above them changes before merge.
