### PR TITLE
Shared channel mapping, plus ICON netCDF helpers

### DIFF
--- a/data_process/convert_makani_output_to_wb2.py
+++ b/data_process/convert_makani_output_to_wb2.py
@@ -32,7 +32,11 @@ from mpi4py import MPI
 from makani.utils.dataloaders.data_helpers import get_date_from_timestamp
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from makani.utils.dataloaders.wb2_helpers import surface_variables, atmospheric_variables, split_convert_channel_names
+from makani.utils.dataloaders.wb2_helpers import (
+    atmospheric_wb2_name,
+    split_convert_channel_names,
+    surface_wb2_name,
+)
 
 
 def convert(
@@ -212,7 +216,7 @@ def convert(
                     data = np.transpose(data, axes=(0, 2, 1, 3, 4))
 
                     # create xarray
-                    scwb2 = surface_variables[sc]
+                    scwb2 = surface_wb2_name(sc)
                     chunk_data_arrays[scwb2] = (
                         ["time", "number", "prediction_timedelta", "latitude", "longitude"],
                         data,
@@ -228,7 +232,7 @@ def convert(
                         data[..., idl, :, :] = tmpdata[...]
 
                     # create array
-                    acwb2 = atmospheric_variables[ac]
+                    acwb2 = atmospheric_wb2_name(ac)
                     chunk_data_arrays[acwb2] = (
                         ["time", "number", "prediction_timedelta", "level", "latitude", "longitude"],
                         data,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,14 +52,17 @@ ENV PATH=/opt/hdf5/bin:${PATH}
 # install cdsapi for downloading the dataset
 RUN pip install cdsapi>=0.7.2
 
-# install zarr and data stuff
-RUN pip install more_itertools zarr xarray gcsfs s3fs boto3
+# install zarr and data stuff. zarr is pinned to >=3 because makani is installed with
+# --no-deps below, so the requirement in pyproject.toml is never enforced: an unpinned
+# zarr is left at whatever the base image ships, and a v2 base silently breaks the zarr
+# reader (v2 has no zarr.core.buffer, so importing dali_es_helper_2d fails outright).
+RUN pip install more_itertools "zarr>=3" "xarray>=2025.1.0" gcsfs s3fs boto3
 
 # moviepy for wandb video logging
-RUN pip install moviepy
+RUN pip install "moviepy>=1.0.3"
 
 # other python stuff
-RUN pip install --upgrade wandb ruamel.yaml tqdm
+RUN pip install --upgrade "wandb>=0.13.7" ruamel.yaml "tqdm>=4.60.0"
 
 # scoring tools
 RUN pip install xskillscore properscoring

--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -150,14 +150,15 @@ ENV PATH=/opt/hdf5/bin:${PATH}
 # install cdsapi for downloading the dataset
 RUN pip install cdsapi>=0.7.2
 
-# install zarr and data stuff
-RUN pip install more_itertools zarr xarray gcsfs s3fs boto3
+# install zarr and data stuff. the zarr reader needs v3 (v2 has no zarr.core.buffer), so
+# the version is stated here rather than left to whatever the base image happens to ship
+RUN pip install more_itertools "zarr>=3" "xarray>=2025.1.0" gcsfs s3fs boto3
 
 # moviepy for wandb video logging
-RUN pip install moviepy
+RUN pip install "moviepy>=1.0.3"
 
 # other python stuff
-RUN pip install --upgrade wandb ruamel.yaml tqdm
+RUN pip install --upgrade "wandb>=0.13.7" ruamel.yaml "tqdm>=4.60.0"
 
 # scoring tools
 RUN pip install xskillscore properscoring

--- a/makani/utils/dataloaders/channel_helpers.py
+++ b/makani/utils/dataloaders/channel_helpers.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared channel grouping for the data source readers.
+
+Every reader (NCAR, WeatherBench2, ICON) has to answer the same question: given
+the makani channel names a run asks for, which source variables provide them,
+and which channel index does each fill. This module holds that logic once, so
+the readers only contribute their name tables.
+
+Source variable descriptors
+---------------------------
+Each reader defines its own descriptor type, because *locating* a variable
+differs completely between sources: NCAR needs an S3 stream, parameter code and
+grid suffix, ICON and WB2 need only a variable name. Descriptors are NamedTuples
+and are expected to expose:
+
+``kind``
+    ``"pl"``, ``"sfc"`` or ``"accum"``. Informational; the group kind comes from
+    which table the entry was found in.
+``units`` (optional)
+    Units the source is expected to carry, for the converter to check against
+    the file. Catches quantity confusions such as geopotential in m2/s2 versus
+    geopotential height in m.
+``accumulation`` (optional)
+    ``"none"`` for instantaneous fields, ``"since_start"`` for running totals
+    that must be differenced, ``"rate"`` for fluxes that must be integrated over
+    the window, ``"window"`` for totals already accumulated over a fixed window
+    that the source, not the reader, decided.
+``name``
+    Required only by readers that resolve against the variables a file actually
+    contains, see ``available`` in :func:`build_channel_groups`.
+
+Table format: alternatives versus components
+--------------------------------------------
+A makani channel can map to a source in two different ways, and they look alike
+but mean the opposite:
+
+* **alternatives** -- several possible sources, of which one is chosen. ICON is
+  run with different physics packages, so ``tp`` may appear as ``tot_prec`` *or*
+  as ``pr``.
+* **components** -- several variables that are summed to form the channel. NCAR
+  does not ship total precipitation, so ``tp`` is ``lsp`` *plus* ``cp``.
+
+A table therefore maps a channel to a sequence of *candidates*, where each
+candidate is either a single descriptor or a sequence of descriptors that are
+summed::
+
+    atmospheric = {"z": (geopot_variable,)}                 # one candidate
+    accumulated = {"tp": ((lsp_variable, cp_variable),)}    # one candidate, summed
+    accumulated = {"tp": (tot_prec_variable, pr_variable)}  # two alternatives
+
+A bare descriptor is accepted wherever a candidate is expected. Descriptors are
+told apart from plain sequences by ``_fields``, since a NamedTuple is itself a
+tuple and ``isinstance(x, tuple)`` cannot distinguish the two.
+
+Getting this wrong is silent rather than loud -- summing two alternatives, or
+picking one of two components, produces a field that is wrong by a factor or by
+a missing term but still looks like weather. Hence the explicit nesting, and
+hence a candidate matches only if the file provides *every* one of its
+components.
+
+See also
+--------
+makani.utils.dataloaders.ncar_helpers : NSF NCAR ERA5 on S3, one canonical name
+    per channel, ``tp`` summed from two components.
+makani.utils.dataloaders.wb2_helpers : WeatherBench2 zarr, one long name per
+    channel, levels addressed by index rather than by name.
+makani.utils.dataloaders.icon_helpers : ICON netCDF, several candidate names per
+    channel depending on the physics package the run used.
+"""
+
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence
+
+from makani.utils.features import split_channel_name
+
+
+class ChannelGroup(NamedTuple):
+    """A set of makani channels served by the same source variable(s).
+
+    Attributes
+    ----------
+    kind : str
+        ``"pl"``, ``"sfc"`` or ``"accum"``, from the table the entry came from.
+    name : str
+        The makani side name: the channel prefix for pressure level groups
+        (``"z"``), the channel name otherwise (``"t2m"``).
+    variables : list
+        Source descriptors for this group. More than one entry means the values
+        are summed to form the channel, see the module docstring.
+    channel_indices : list of int
+        Index of each member channel along the channel axis of the makani
+        ``fields`` array.
+    levels : list of int or None
+        Pressure level in hPa for each member channel, ``None`` for single level
+        and accumulated groups.
+    """
+
+    kind: str
+    name: str
+    variables: List[Any]
+    channel_indices: List[int]
+    levels: Optional[List[int]]
+
+
+def _components(candidate) -> tuple:
+    """Normalize a candidate into the tuple of descriptors it is made of."""
+    if hasattr(candidate, "_fields"):
+        # a descriptor: a NamedTuple, which is also a tuple, hence the _fields check
+        return (candidate,)
+    return tuple(candidate)
+
+
+def _candidates(entry) -> tuple:
+    """Normalize a table entry into a tuple of candidates."""
+    if entry is None:
+        return ()
+    if hasattr(entry, "_fields"):
+        return (entry,)
+    return tuple(entry)
+
+
+def resolve_variable(entry, available: Optional[Sequence[str]] = None):
+    """Pick the candidate a file actually provides.
+
+    Parameters
+    ----------
+    entry : descriptor, or sequence of candidates
+        A table entry, see the module docstring.
+    available : sequence of str, optional
+        Variable names present in the file. When omitted the first candidate is
+        returned, which is what to do before a file has been opened. A candidate
+        made of several summed components matches only if the file provides all
+        of them.
+
+    Returns
+    -------
+    tuple or None
+        The components of the first matching candidate, or None if the file
+        provides none of them.
+    """
+    candidates = _candidates(entry)
+    if not candidates:
+        return None
+
+    if available is None:
+        return _components(candidates[0])
+
+    names = set(available)
+    for candidate in candidates:
+        components = _components(candidate)
+        if all(component.name in names for component in components):
+            return components
+
+    return None
+
+
+def build_channel_groups(
+    channel_names: List[str],
+    atmospheric: Dict[str, Any],
+    surface: Optional[Dict[str, Any]] = None,
+    accumulated: Optional[Dict[str, Any]] = None,
+    available: Optional[Sequence[str]] = None,
+    skip_missing_channels: bool = False,
+    source: str = "source",
+) -> List[ChannelGroup]:
+    """Group makani channel names by the source variable that provides them.
+
+    All levels of a variable are collected into a single group, because every
+    source stores them together: one chunk per (time, level) slab in ICON, one
+    file holding all levels in NCAR, one array with a level axis in WB2. Reading
+    them as a group is what keeps the number of reads down.
+
+    Parameters
+    ----------
+    channel_names : list of str
+        Channel names in channel index order, i.e. ``coords["channel"]`` from
+        the dataset metadata.
+    atmospheric, surface, accumulated : dict
+        Tables mapping a channel prefix (atmospheric) or channel name (surface,
+        accumulated) to a table entry, see the module docstring.
+    available : sequence of str, optional
+        Variable names present in the file, used to choose between alternatives.
+    skip_missing_channels : bool, optional
+        If True, channels no candidate covers are dropped instead of raising.
+    source : str, optional
+        Name of the data source, used in error messages only.
+
+    Returns
+    -------
+    list of ChannelGroup
+        One entry per source variable, pressure level groups first.
+
+    Raises
+    ------
+    ValueError
+        If a channel cannot be resolved and ``skip_missing_channels`` is False.
+    """
+    surface = surface or {}
+    accumulated = accumulated or {}
+
+    pl_groups: Dict[str, ChannelGroup] = {}
+    other_groups: List[ChannelGroup] = []
+
+    for cidx, channel_name in enumerate(channel_names):
+        prefix, level = split_channel_name(channel_name)
+
+        if level is not None:
+            variables = resolve_variable(atmospheric.get(prefix), available)
+            if variables is None:
+                if skip_missing_channels:
+                    continue
+                raise ValueError(
+                    f"No {source} variable found for atmospheric channel '{channel_name}' "
+                    f"(prefix '{prefix}'). Known prefixes: {list(atmospheric)}."
+                )
+            group = pl_groups.get(prefix)
+            if group is None:
+                group = ChannelGroup("pl", prefix, list(variables), [], [])
+                pl_groups[prefix] = group
+            group.channel_indices.append(cidx)
+            group.levels.append(level)
+            continue
+
+        variables = resolve_variable(surface.get(channel_name), available)
+        if variables is not None:
+            other_groups.append(ChannelGroup("sfc", channel_name, list(variables), [cidx], None))
+            continue
+
+        variables = resolve_variable(accumulated.get(channel_name), available)
+        if variables is not None:
+            other_groups.append(ChannelGroup("accum", channel_name, list(variables), [cidx], None))
+            continue
+
+        if not skip_missing_channels:
+            raise ValueError(
+                f"No {source} variable found for surface channel '{channel_name}'. "
+                f"Known names: {list(surface) + list(accumulated)}."
+            )
+
+    return list(pl_groups.values()) + other_groups

--- a/makani/utils/dataloaders/data_helpers.py
+++ b/makani/utils/dataloaders/data_helpers.py
@@ -152,15 +152,28 @@ def get_timestamp(year, hour):
     return jan_01_epoch + dt.timedelta(hours=hour)
 
 
-# this is a small helper to convert datetime to correct time zone
 def get_date_from_string(isostring):
-    date = dt.datetime.fromisoformat(isostring)
-    try:
-        date = date.astimezone(dt.timezone.utc)
-    except:
-        date = date.replace(tzinfo=dt.timezone.utc)
+    """Parse an ISO 8601 date string into a timezone aware UTC datetime.
 
-    return date
+    A string carrying a designator (``2017-01-01T00:00:00Z``, or an explicit
+    offset) is converted to UTC. One without (``2017-01-01T00:00:00``) is taken
+    to be UTC already and merely labelled as such.
+
+    ..note::
+        The naive case has to be handled explicitly. Since Python 3.6,
+        ``astimezone`` on a naive datetime does not raise: it assumes the value
+        is in the *local* zone and converts from there, so a date string without
+        a designator would silently shift by the offset of whichever machine
+        parsed it -- an hour on a CET laptop, nothing on a UTC cluster. That is
+        the failure this helper exists to prevent, so the check is on
+        ``tzinfo`` rather than on an exception that no longer fires.
+    """
+    date = dt.datetime.fromisoformat(isostring)
+
+    if date.tzinfo is None:
+        return date.replace(tzinfo=dt.timezone.utc)
+
+    return date.astimezone(dt.timezone.utc)
 
 
 def get_date_from_timestamp(timestamp):

--- a/makani/utils/dataloaders/icon_helpers.py
+++ b/makani/utils/dataloaders/icon_helpers.py
@@ -1,0 +1,577 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for reading ICON model output in netCDF form.
+
+ICON writes netCDF4, which is HDF5 underneath, so the files open with ``h5py``
+and no netCDF library is needed. What ``h5py`` does *not* do is the decoding
+that ``netCDF4``/``xarray`` would normally hide, and ICON adds conventions of
+its own on top. This module isolates that decoding and the mapping from ICON
+variable names onto makani channels, so that the converter in
+``data_process/`` is left with I/O and regridding only, and so that the fiddly
+parts can be tested without any ICON data.
+
+Three things here are worth knowing before touching the converter:
+
+* **Time is not CF.** ICON writes ``time:units = "day as %Y%m%d.%f"``, i.e. the
+  float ``20170821.333333`` means 2017-08-21 08:00. Interpreting that as an
+  offset from an epoch, the way CF ``days since ...`` works, yields dates that
+  are wrong but look plausible. See :func:`decode_time`.
+* **Values may be packed.** netCDF ``scale_factor``/``add_offset`` packing and
+  ``_FillValue`` are applied by the netCDF library, not by HDF5, so reading
+  through ``h5py`` returns the raw (possibly integer) values. See
+  :func:`decode_values`.
+* **Variable names are not standardized.** ICON is run with different physics
+  packages and output namelists: NWP setups write ``temp``, ``pres_sfc``,
+  ``t_2m``, while AES/CMIP style setups write ``ta``, ``ps``, ``tas`` for the
+  same fields. Each makani channel therefore maps to a *list* of candidate
+  names, resolved against the variables a given file actually contains. See
+  :func:`resolve_variable`.
+
+..note::
+    The name tables below are assembled from the common ICON output namelists
+    and have not yet been checked against a real file from the producer. Expect
+    to extend them; the resolution machinery is what matters and is what the
+    tests pin down.
+"""
+
+import re
+import datetime as dt
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
+
+import numpy as np
+
+# channel name parsing is shared with the NCAR reader so that "z500" is split the
+# same way everywhere; both follow makani.utils.features.get_channel_groups
+from makani.utils.dataloaders.ncar_helpers import split_channel_name
+
+
+# ICON's own time encoding: the integer part is a YYYYMMDD date, the fraction is
+# the elapsed part of that day
+ICON_TIME_UNITS = "day as %Y%m%d.%f"
+
+# standard gravity, for converting between geopotential (m2/s2, ICON "geopot")
+# and geopotential height (m, CMIP "zg")
+GRAVITY = 9.80665
+
+_CF_UNITS_PATTERN = re.compile(r"^\s*(day|hour|minute|second)s?\s+since\s+(.+?)\s*$", re.IGNORECASE)
+
+_CF_UNIT_SECONDS = {"day": 86400, "hour": 3600, "minute": 60, "second": 1}
+
+_CF_REFERENCE_FORMATS = (
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%d",
+)
+
+
+class IconVariable(NamedTuple):
+    """One candidate ICON variable for a makani channel.
+
+    Attributes
+    ----------
+    name : str
+        Variable name as it appears in the netCDF file.
+    kind : str
+        ``"pl"`` for fields on pressure levels, ``"sfc"`` for single level
+        fields, ``"accum"`` for fields that need temporal post-processing.
+    accumulation : str
+        How the variable relates to the makani channel in time. ``"none"`` for
+        instantaneous fields; ``"since_start"`` for totals accumulated from the
+        beginning of the run, which have to be differenced between consecutive
+        outputs; ``"rate"`` for fluxes, which have to be multiplied by the
+        length of the window.
+    units : str, optional
+        Units the variable is expected to carry, for the converter to check
+        against the file. Mismatches usually mean a different variable was
+        resolved than intended, e.g. geopotential against geopotential height.
+    """
+
+    name: str
+    kind: str
+    accumulation: str = "none"
+    units: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# ERA5-style makani channel -> candidate ICON variables
+#
+# Candidates are listed in preference order: NWP style names first, since that
+# is what the operational and most limited area setups write, then AES/CMIP
+# style, then plain ERA5 short names for files that were converted elsewhere.
+# ---------------------------------------------------------------------------
+
+atmospheric_variables: Dict[str, Tuple[IconVariable, ...]] = {
+    # NOTE: makani's "z" is geopotential (m2/s2). "zg" is geopotential *height*
+    # (m) and needs multiplying by GRAVITY; the units field flags which is which.
+    "z": (
+        IconVariable("geopot", "pl", units="m2 s-2"),
+        IconVariable("zg", "pl", units="m"),
+        IconVariable("z", "pl", units="m2 s-2"),
+    ),
+    "t": (
+        IconVariable("temp", "pl", units="K"),
+        IconVariable("ta", "pl", units="K"),
+        IconVariable("t", "pl", units="K"),
+    ),
+    "u": (
+        IconVariable("u", "pl", units="m s-1"),
+        IconVariable("ua", "pl", units="m s-1"),
+    ),
+    "v": (
+        IconVariable("v", "pl", units="m s-1"),
+        IconVariable("va", "pl", units="m s-1"),
+    ),
+    "w": (
+        IconVariable("omega", "pl", units="Pa s-1"),
+        IconVariable("wap", "pl", units="Pa s-1"),
+    ),
+    "q": (
+        IconVariable("qv", "pl", units="kg kg-1"),
+        IconVariable("hus", "pl", units="kg kg-1"),
+    ),
+    "r": (
+        IconVariable("rh", "pl", units="%"),
+        IconVariable("hur", "pl", units="%"),
+    ),
+}
+
+surface_variables: Dict[str, Tuple[IconVariable, ...]] = {
+    "u10m": (IconVariable("u_10m", "sfc", units="m s-1"), IconVariable("uas", "sfc", units="m s-1")),
+    "v10m": (IconVariable("v_10m", "sfc", units="m s-1"), IconVariable("vas", "sfc", units="m s-1")),
+    "t2m": (IconVariable("t_2m", "sfc", units="K"), IconVariable("tas", "sfc", units="K")),
+    "d2": (IconVariable("td_2m", "sfc", units="K"), IconVariable("tdps", "sfc", units="K")),
+    "sp": (IconVariable("pres_sfc", "sfc", units="Pa"), IconVariable("ps", "sfc", units="Pa")),
+    "msl": (IconVariable("pres_msl", "sfc", units="Pa"), IconVariable("psl", "sfc", units="Pa")),
+    "tcwv": (IconVariable("tqv", "sfc", units="kg m-2"), IconVariable("prw", "sfc", units="kg m-2")),
+    "sst": (IconVariable("t_seasfc", "sfc", units="K"), IconVariable("tos", "sfc", units="K")),
+}
+
+accumulated_variables: Dict[str, Tuple[IconVariable, ...]] = {
+    # tot_prec is a running total since the start of the run and has to be
+    # differenced; pr is an instantaneous flux and has to be integrated over the
+    # window instead. Which one a file carries changes the arithmetic, hence the
+    # accumulation field rather than a single code path.
+    "tp": (
+        IconVariable("tot_prec", "accum", accumulation="since_start", units="kg m-2"),
+        IconVariable("pr", "accum", accumulation="rate", units="kg m-2 s-1"),
+    ),
+}
+
+
+class ChannelGroup(NamedTuple):
+    """A set of makani channels served by one ICON variable.
+
+    Attributes
+    ----------
+    kind : str
+        ``"pl"``, ``"sfc"`` or ``"accum"``, taken from the resolved variable.
+    name : str
+        The makani side name: the channel prefix for pressure level groups
+        (``"z"``), the channel name otherwise (``"t2m"``).
+    variable : IconVariable
+        The ICON variable the group reads from.
+    channel_indices : list of int
+        Index of each member channel along the channel axis of the makani
+        ``fields`` array.
+    levels : list of int or None
+        Pressure level in hPa for each member channel, ``None`` for single
+        level and accumulated groups.
+    """
+
+    kind: str
+    name: str
+    variable: IconVariable
+    channel_indices: List[int]
+    levels: Optional[List[int]]
+
+
+def _as_text(value) -> str:
+    """Normalize an HDF5 attribute to ``str``.
+
+    ``h5py`` hands back ``bytes`` for the fixed length strings netCDF writes,
+    and 0-d/1-element arrays for scalar attributes, so attributes have to be
+    unwrapped before they can be compared against anything.
+    """
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            raise ValueError(f"Expected a scalar attribute, got an array of size {value.size}.")
+        value = value.reshape(-1)[0]
+    if isinstance(value, (bytes, np.bytes_)):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def resolve_variable(candidates: Sequence[IconVariable], available: Optional[Sequence[str]] = None):
+    """Pick the ICON variable a file actually provides for a makani channel.
+
+    Parameters
+    ----------
+    candidates : sequence of IconVariable
+        Candidates in preference order, as listed in the tables above.
+    available : sequence of str, optional
+        Variable names present in the file. When omitted the first candidate is
+        returned, which is what to do when the file has not been opened yet.
+
+    Returns
+    -------
+    IconVariable or None
+        The first candidate the file provides, or None if it provides none.
+    """
+    if not candidates:
+        return None
+
+    if available is None:
+        return candidates[0]
+
+    names = set(available)
+    for candidate in candidates:
+        if candidate.name in names:
+            return candidate
+
+    return None
+
+
+def build_icon_channel_groups(
+    channel_names: List[str],
+    available: Optional[Sequence[str]] = None,
+    skip_missing_channels: bool = False,
+) -> List[ChannelGroup]:
+    """Group makani channel names by the ICON variable that provides them.
+
+    All levels of a variable come from the same ICON variable, which is stored
+    as ``(time, plev, ncells)``, so they are collected into one group and read
+    together.
+
+    Parameters
+    ----------
+    channel_names : list of str
+        Channel names in channel index order, i.e. ``coords["channel"]`` from
+        the dataset metadata.
+    available : sequence of str, optional
+        Variable names present in the file, used to resolve between the
+        alternative ICON namings. When omitted the preferred name is assumed.
+    skip_missing_channels : bool, optional
+        If True, channels that no candidate variable covers are dropped instead
+        of raising.
+
+    Returns
+    -------
+    list of ChannelGroup
+        One entry per source variable, pressure level groups first.
+
+    Raises
+    ------
+    ValueError
+        If a channel cannot be resolved and ``skip_missing_channels`` is False.
+    """
+    pl_groups: Dict[str, ChannelGroup] = {}
+    other_groups: List[ChannelGroup] = []
+
+    for cidx, channel_name in enumerate(channel_names):
+        prefix, level = split_channel_name(channel_name)
+
+        if level is not None:
+            variable = resolve_variable(atmospheric_variables.get(prefix, ()), available)
+            if variable is None:
+                if skip_missing_channels:
+                    continue
+                raise ValueError(
+                    f"No ICON variable found for atmospheric channel '{channel_name}'. "
+                    f"Known prefixes: {list(atmospheric_variables)}."
+                )
+            group = pl_groups.get(prefix)
+            if group is None:
+                group = ChannelGroup("pl", prefix, variable, [], [])
+                pl_groups[prefix] = group
+            group.channel_indices.append(cidx)
+            group.levels.append(level)
+            continue
+
+        variable = resolve_variable(surface_variables.get(channel_name, ()), available)
+        if variable is not None:
+            other_groups.append(ChannelGroup("sfc", channel_name, variable, [cidx], None))
+            continue
+
+        variable = resolve_variable(accumulated_variables.get(channel_name, ()), available)
+        if variable is not None:
+            other_groups.append(ChannelGroup("accum", channel_name, variable, [cidx], None))
+            continue
+
+        if not skip_missing_channels:
+            raise ValueError(
+                f"No ICON variable found for surface channel '{channel_name}'. "
+                f"Known names: {list(surface_variables) + list(accumulated_variables)}."
+            )
+
+    return list(pl_groups.values()) + other_groups
+
+
+# ---------------------------------------------------------------------------
+# Decoding
+# ---------------------------------------------------------------------------
+
+
+def decode_time(values, units) -> List[dt.datetime]:
+    """Decode an ICON time coordinate into timezone aware UTC datetimes.
+
+    Two encodings are accepted: ICON's own ``"day as %Y%m%d.%f"``, where the
+    integer part is the calendar date and the fraction is the elapsed part of
+    the day, and the CF ``"<unit> since <reference>"`` form that ICON writes
+    when configured for CF output.
+
+    Times are rounded to the nearest second, because the fractional day is
+    stored as a float and an exact 08:00 comes back as 07:59:59.99 otherwise.
+
+    Parameters
+    ----------
+    values : array_like
+        Raw values of the time variable.
+    units : str or bytes
+        The ``units`` attribute of the time variable.
+
+    Returns
+    -------
+    list of datetime.datetime
+        One timezone aware datetime per input value.
+
+    Raises
+    ------
+    ValueError
+        If the units string is neither of the two supported encodings, or if a
+        value is not a valid date under it.
+    """
+    text = _as_text(units).strip()
+    values = np.atleast_1d(np.asarray(values, dtype=np.float64))
+
+    if text == ICON_TIME_UNITS:
+        return [_decode_icon_time_value(value) for value in values]
+
+    match = _CF_UNITS_PATTERN.match(text)
+    if match is not None:
+        unit, reference = match.group(1).lower(), match.group(2)
+        seconds_per_unit = _CF_UNIT_SECONDS[unit]
+        origin = _parse_cf_reference(reference)
+        return [origin + dt.timedelta(seconds=round(value * seconds_per_unit)) for value in values]
+
+    raise ValueError(
+        f"Unsupported time encoding '{text}'. Expected ICON's '{ICON_TIME_UNITS}' "
+        "or a CF style '<unit> since <reference>'."
+    )
+
+
+def _decode_icon_time_value(value: float) -> dt.datetime:
+    """Decode a single ``YYYYMMDD.fraction`` value."""
+    stamp = int(np.floor(value))
+    fraction = float(value) - stamp
+
+    try:
+        day = dt.datetime.strptime(str(stamp), "%Y%m%d").replace(tzinfo=dt.timezone.utc)
+    except ValueError as err:
+        raise ValueError(f"Time value {value} does not start with a valid YYYYMMDD date.") from err
+
+    return day + dt.timedelta(seconds=round(fraction * 86400))
+
+
+def _parse_cf_reference(reference: str) -> dt.datetime:
+    """Parse the reference date of a CF ``<unit> since <reference>`` string."""
+    text = reference.strip()
+
+    # trailing timezone designators, which strptime does not take in this position
+    for suffix in ("Z", "UTC", "+00:00", "+0000"):
+        if text.endswith(suffix):
+            text = text[: -len(suffix)].strip()
+
+    for fmt in _CF_REFERENCE_FORMATS:
+        try:
+            return dt.datetime.strptime(text, fmt).replace(tzinfo=dt.timezone.utc)
+        except ValueError:
+            continue
+
+    raise ValueError(f"Cannot parse CF reference date '{reference}'.")
+
+
+def decode_values(
+    raw: np.ndarray,
+    fill_value=None,
+    scale_factor=None,
+    add_offset=None,
+    dtype=np.float32,
+) -> np.ndarray:
+    """Apply netCDF packing and missing value conventions to a raw HDF5 read.
+
+    The netCDF library normally does this on the way out, but reading a netCDF4
+    file through ``h5py`` bypasses it: a packed variable comes back as the
+    stored integers, and fill values come back as whatever sentinel was written.
+
+    Fill values are matched against the *raw* data, before unpacking, as CF
+    requires, and become NaN. Unpacking is ``raw * scale_factor + add_offset``,
+    with either factor optional.
+
+    Parameters
+    ----------
+    raw : numpy.ndarray
+        Values as read from the file.
+    fill_value : scalar, optional
+        Value denoting missing data, from ``_FillValue`` or ``missing_value``.
+    scale_factor, add_offset : scalar, optional
+        Packing parameters from the variable attributes.
+    dtype : numpy dtype, optional
+        Floating point type of the result, float32 by default.
+
+    Returns
+    -------
+    numpy.ndarray
+        Decoded values, with missing data as NaN.
+    """
+    if not np.issubdtype(np.dtype(dtype), np.floating):
+        raise ValueError(f"Decoded values need a floating point dtype to hold NaN, got {dtype}.")
+
+    raw = np.asarray(raw)
+    missing = None
+    if fill_value is not None:
+        missing = raw == np.asarray(fill_value).reshape(()).astype(raw.dtype, copy=False)
+
+    values = raw.astype(dtype, copy=True)
+
+    if scale_factor is not None:
+        values *= dtype(scale_factor)
+    if add_offset is not None:
+        values += dtype(add_offset)
+
+    if missing is not None and missing.any():
+        values[missing] = np.nan
+
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Grid and level metadata
+# ---------------------------------------------------------------------------
+
+
+def grid_coordinates_in_degrees(clon, clat) -> Tuple[np.ndarray, np.ndarray]:
+    """Convert ICON cell center coordinates from radians to degrees.
+
+    ICON stores ``clon``/``clat`` in radians with longitude in [-pi, pi]. The
+    result uses degrees with longitude in [0, 360), matching makani's own
+    convention and the ERA5 datasets it is trained on.
+
+    Parameters
+    ----------
+    clon, clat : array_like
+        Cell center longitude and latitude in radians.
+
+    Returns
+    -------
+    lon, lat : numpy.ndarray
+        Coordinates in degrees, longitude wrapped into [0, 360).
+
+    Raises
+    ------
+    ValueError
+        If the inputs do not look like radians, which almost always means the
+        file stores degrees already and the caller would otherwise silently
+        collapse the whole globe into a few degrees around the prime meridian.
+    """
+    clon = np.asarray(clon, dtype=np.float64)
+    clat = np.asarray(clat, dtype=np.float64)
+
+    if clon.shape != clat.shape:
+        raise ValueError(f"clon and clat must have the same shape, got {clon.shape} and {clat.shape}.")
+
+    if np.nanmax(np.abs(clat)) > np.pi / 2 + 1e-6:
+        raise ValueError(
+            "Cell latitudes exceed pi/2, so they are not radians. ICON writes radians; "
+            "if this file stores degrees, pass them through unchanged instead."
+        )
+
+    lat = np.rad2deg(clat)
+    lon = np.mod(np.rad2deg(clon), 360.0)
+
+    return lon, lat
+
+
+def pressure_levels_in_hpa(levels) -> np.ndarray:
+    """Normalize a pressure level coordinate to hPa.
+
+    ICON writes pressure levels in Pa while makani channel names carry hPa
+    (``z500``), so one of the two has to be converted, and getting it backwards
+    silently selects the wrong level. Pa is detected by magnitude: no
+    meteorologically useful level exceeds 2000 hPa, and none is below 0.01 hPa.
+    """
+    levels = np.asarray(levels, dtype=np.float64)
+
+    if levels.size == 0:
+        raise ValueError("Empty pressure level coordinate.")
+
+    if np.nanmax(levels) > 2000.0:
+        return levels / 100.0
+
+    return levels
+
+
+def pressure_level_index(levels, wanted_hpa: int, tolerance: float = 0.5) -> int:
+    """Return the index of ``wanted_hpa`` in a pressure level coordinate.
+
+    The coordinate may be in Pa or hPa, see :func:`pressure_levels_in_hpa`.
+
+    Raises
+    ------
+    ValueError
+        If no level matches within ``tolerance`` hPa.
+    """
+    levels_hpa = pressure_levels_in_hpa(levels)
+    distance = np.abs(levels_hpa - wanted_hpa)
+    closest = int(np.argmin(distance))
+
+    if distance[closest] > tolerance:
+        raise ValueError(
+            f"No pressure level within {tolerance} hPa of {wanted_hpa} hPa. "
+            f"Available levels (hPa): {np.array2string(levels_hpa, threshold=20)}."
+        )
+
+    return closest
+
+
+def check_grid_uuid(data_uuid, grid_uuid) -> None:
+    """Check that a data file and a grid file describe the same horizontal grid.
+
+    ICON stamps output files with the ``uuidOfHGrid`` of the grid they were run
+    on. Regridding against the wrong grid file produces a plausible looking but
+    scrambled field, so the UUIDs are compared rather than assumed to match.
+    Comparison ignores case and surrounding whitespace; either side being absent
+    is accepted, since not every setup writes the attribute.
+
+    Raises
+    ------
+    ValueError
+        If both UUIDs are present and differ.
+    """
+    if data_uuid is None or grid_uuid is None:
+        return
+
+    data_text = _as_text(data_uuid).strip().lower()
+    grid_text = _as_text(grid_uuid).strip().lower()
+
+    if not data_text or not grid_text:
+        return
+
+    if data_text != grid_text:
+        raise ValueError(
+            f"The data file was written on grid {data_text} but the grid file describes {grid_text}. "
+            "Regridding with a mismatched grid file silently scrambles the field."
+        )

--- a/makani/utils/dataloaders/icon_helpers.py
+++ b/makani/utils/dataloaders/icon_helpers.py
@@ -183,12 +183,23 @@ atmospheric_variables: Dict[str, Tuple[IconVariable, ...]] = {
         IconVariable("cli", "pl", units="kg kg-1"),
     ),
     "crwc": (IconVariable("qr", "pl", units="kg kg-1"),),
-    "cswc": (IconVariable("qs", "pl", units="kg kg-1"),),
-    # Graupel is the one hydrometeor with no ERA5 counterpart: the IFS
-    # microphysics does not carry it as a separate species, it is folded into
-    # snow. The channel therefore keeps ICON's own name. If a run wants the
-    # ERA5-comparable quantity instead, "cswc" has to be built as qs + qg,
-    # which is a modelling decision rather than a naming one.
+    # ERA5 has no graupel category: its snow content is documented as including
+    # graupel, so the ERA5-equivalent of "cswc" is ICON's qs PLUS qg, and the
+    # first candidate is that sum. This matters at the resolutions ICON output
+    # comes at: with convection resolved, graupel is a leading species in deep
+    # convective cores, so taking qs alone would bias the field exactly where
+    # the run has the most to say. Setups whose microphysics carries no graupel
+    # fall through to the second candidate, qs on its own.
+    "cswc": (
+        (
+            IconVariable("qs", "pl", units="kg kg-1"),
+            IconVariable("qg", "pl", units="kg kg-1"),
+        ),
+        IconVariable("qs", "pl", units="kg kg-1"),
+    ),
+    # graupel is also available on its own, for runs that want the ICON species
+    # split rather than the ERA5 vocabulary. Requesting both "cswc" and "qg"
+    # means qg is read twice, which is redundant but not wrong.
     "qg": (IconVariable("qg", "pl", units="kg kg-1"),),
 }
 

--- a/makani/utils/dataloaders/icon_helpers.py
+++ b/makani/utils/dataloaders/icon_helpers.py
@@ -87,6 +87,12 @@ _CF_UNITS_PATTERN = re.compile(r"^\s*(day|hour|minute|second)s?\s+since\s+(.+?)\
 
 _CF_UNIT_SECONDS = {"day": 86400, "hour": 3600, "minute": 60, "second": 1}
 
+# designators meaning "this reference is already UTC"
+_UTC_DESIGNATORS = ("Z", "UTC", "GMT")
+
+# a udunits style trailing offset: +2:00, -05:00, +0200
+_CF_OFFSET_PATTERN = re.compile(r"^(?P<sign>[+-])(?P<hours>\d{1,2})(?::?(?P<minutes>\d{2}))?$")
+
 _CF_REFERENCE_FORMATS = (
     "%Y-%m-%d %H:%M:%S",
     "%Y-%m-%dT%H:%M:%S",
@@ -360,21 +366,62 @@ def _decode_icon_time_value(value: float) -> dt.datetime:
 
 
 def _parse_cf_reference(reference: str) -> dt.datetime:
-    """Parse the reference date of a CF ``<unit> since <reference>`` string."""
+    """Parse the reference date of a CF ``<unit> since <reference>`` string.
+
+    Follows the same policy as
+    :func:`makani.utils.dataloaders.data_helpers.get_date_from_string`: a
+    reference carrying a designator or an offset is converted to UTC, one
+    without is taken to be UTC already. udunits permits an offset as a separate
+    trailing token (``"hours since 2020-01-01 00:00:00 +2:00"``), and ISO
+    strings carry it attached; both are handled.
+
+    ..note::
+        A trailing offset is only recognised as a separate whitespace token,
+        because a bare date ends in something that looks exactly like one:
+        reading ``2020-01-01`` greedily would take the ``-01`` for "minus one
+        hour" and silently move the epoch.
+    """
     text = reference.strip()
+    offset = None
 
-    # trailing timezone designators, which strptime does not take in this position
-    for suffix in ("Z", "UTC", "+00:00", "+0000"):
-        if text.endswith(suffix):
-            text = text[: -len(suffix)].strip()
+    tokens = text.split()
+    if len(tokens) > 1 and tokens[-1].upper() in _UTC_DESIGNATORS:
+        text, offset = " ".join(tokens[:-1]), dt.timedelta(0)
+    elif len(tokens) > 1 and _CF_OFFSET_PATTERN.match(tokens[-1]):
+        match = _CF_OFFSET_PATTERN.match(tokens[-1])
+        sign = -1 if match.group("sign") == "-" else 1
+        minutes = int(match.group("minutes") or 0)
+        offset = sign * dt.timedelta(hours=int(match.group("hours")), minutes=minutes)
+        text = " ".join(tokens[:-1])
+    elif text.upper().endswith("Z"):
+        # attached designator on a single token, for python versions whose
+        # fromisoformat does not accept it
+        text, offset = text[:-1].strip(), dt.timedelta(0)
 
-    for fmt in _CF_REFERENCE_FORMATS:
-        try:
-            return dt.datetime.strptime(text, fmt).replace(tzinfo=dt.timezone.utc)
-        except ValueError:
-            continue
+    parsed = None
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        # udunits does not require zero padding, and ICON writes
+        # "minutes since 2020-1-1 00:00:00", which is not valid ISO 8601
+        for fmt in _CF_REFERENCE_FORMATS:
+            try:
+                parsed = dt.datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
 
-    raise ValueError(f"Cannot parse CF reference date '{reference}'.")
+    if parsed is None:
+        raise ValueError(f"Cannot parse CF reference date '{reference}'.")
+
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(dt.timezone.utc)
+
+    if offset is not None:
+        # the reference names a local instant: subtract the offset to reach UTC
+        return (parsed - offset).replace(tzinfo=dt.timezone.utc)
+
+    return parsed.replace(tzinfo=dt.timezone.utc)
 
 
 def decode_values(

--- a/makani/utils/dataloaders/icon_helpers.py
+++ b/makani/utils/dataloaders/icon_helpers.py
@@ -36,15 +36,33 @@ Three things here are worth knowing before touching the converter:
 * **Variable names are not standardized.** ICON is run with different physics
   packages and output namelists: NWP setups write ``temp``, ``pres_sfc``,
   ``t_2m``, while AES/CMIP style setups write ``ta``, ``ps``, ``tas`` for the
-  same fields. Each makani channel therefore maps to a *list* of candidate
-  names, resolved against the variables a given file actually contains. See
-  :func:`resolve_variable`.
+  same fields. Each makani channel therefore maps to a list of candidate names,
+  resolved against the variables a given file actually contains by
+  :func:`makani.utils.dataloaders.channel_helpers.resolve_variable`.
 
-..note::
-    The name tables below are assembled from the common ICON output namelists
-    and have not yet been checked against a real file from the producer. Expect
-    to extend them; the resolution machinery is what matters and is what the
-    tests pin down.
+What a real dataset looks like
+------------------------------
+The tables were checked against the EXCLAIM coupled DYAMOND run (R02B10,
+83,886,080 cells, grid 56), which is representative of the km-scale output
+makani is likely to be handed:
+
+* one file per variable per day, ``(time, plev, ncells)`` float32, **not
+  compressed** -- no filters at all, so a (time, level) slab is a contiguous
+  read and the netCDF unpacking below is a no-op for that dataset;
+* the vertical axis is ``plev`` in **Pa**, carrying the 37 standard ERA5
+  pressure levels, so makani's ``z500``-style channels map onto it by index and
+  no vertical interpolation is needed;
+* the horizontal grid is ``CDI_grid_type = "unstructured"`` at **cell centres**
+  (``number_of_grid_in_reference = 1``), which means ``u``/``v`` are already
+  earth-relative components and need no reconstruction from edge normals;
+* ``clon``/``clat`` are present in *some* files only. Variables that lack them
+  refer to the grid solely through ``uuidOfHGrid``, so the coordinates have to
+  be taken from a file that has them (or from the external grid file) and
+  checked with :func:`check_grid_uuid`.
+
+The tables remain provisional in the sense that a different ICON setup will use
+names not listed here; extending them is expected, and the resolution machinery
+rather than any individual entry is what the tests pin down.
 """
 
 import re
@@ -53,8 +71,8 @@ from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import numpy as np
 
-# channel name classification lives in one place for all data sources
-from makani.utils.features import split_channel_name
+# channel grouping and name classification are shared across the data source readers
+from makani.utils.dataloaders.channel_helpers import ChannelGroup, build_channel_groups
 
 
 # ICON's own time encoding: the integer part is a YYYYMMDD date, the fraction is
@@ -197,79 +215,6 @@ accumulated_variables: Dict[str, Tuple[IconVariable, ...]] = {
 }
 
 
-class ChannelGroup(NamedTuple):
-    """A set of makani channels served by one ICON variable.
-
-    Attributes
-    ----------
-    kind : str
-        ``"pl"``, ``"sfc"`` or ``"accum"``, taken from the resolved variable.
-    name : str
-        The makani side name: the channel prefix for pressure level groups
-        (``"z"``), the channel name otherwise (``"t2m"``).
-    variable : IconVariable
-        The ICON variable the group reads from.
-    channel_indices : list of int
-        Index of each member channel along the channel axis of the makani
-        ``fields`` array.
-    levels : list of int or None
-        Pressure level in hPa for each member channel, ``None`` for single
-        level and accumulated groups.
-    """
-
-    kind: str
-    name: str
-    variable: IconVariable
-    channel_indices: List[int]
-    levels: Optional[List[int]]
-
-
-def _as_text(value) -> str:
-    """Normalize an HDF5 attribute to ``str``.
-
-    ``h5py`` hands back ``bytes`` for the fixed length strings netCDF writes,
-    and 0-d/1-element arrays for scalar attributes, so attributes have to be
-    unwrapped before they can be compared against anything.
-    """
-    if isinstance(value, np.ndarray):
-        if value.size != 1:
-            raise ValueError(f"Expected a scalar attribute, got an array of size {value.size}.")
-        value = value.reshape(-1)[0]
-    if isinstance(value, (bytes, np.bytes_)):
-        return value.decode("utf-8")
-    return str(value)
-
-
-def resolve_variable(candidates: Sequence[IconVariable], available: Optional[Sequence[str]] = None):
-    """Pick the ICON variable a file actually provides for a makani channel.
-
-    Parameters
-    ----------
-    candidates : sequence of IconVariable
-        Candidates in preference order, as listed in the tables above.
-    available : sequence of str, optional
-        Variable names present in the file. When omitted the first candidate is
-        returned, which is what to do when the file has not been opened yet.
-
-    Returns
-    -------
-    IconVariable or None
-        The first candidate the file provides, or None if it provides none.
-    """
-    if not candidates:
-        return None
-
-    if available is None:
-        return candidates[0]
-
-    names = set(available)
-    for candidate in candidates:
-        if candidate.name in names:
-            return candidate
-
-    return None
-
-
 def build_icon_channel_groups(
     channel_names: List[str],
     available: Optional[Sequence[str]] = None,
@@ -303,51 +248,43 @@ def build_icon_channel_groups(
     ValueError
         If a channel cannot be resolved and ``skip_missing_channels`` is False.
     """
-    pl_groups: Dict[str, ChannelGroup] = {}
-    other_groups: List[ChannelGroup] = []
-
-    for cidx, channel_name in enumerate(channel_names):
-        prefix, level = split_channel_name(channel_name)
-
-        if level is not None:
-            variable = resolve_variable(atmospheric_variables.get(prefix, ()), available)
-            if variable is None:
-                if skip_missing_channels:
-                    continue
-                raise ValueError(
-                    f"No ICON variable found for atmospheric channel '{channel_name}'. "
-                    f"Known prefixes: {list(atmospheric_variables)}."
-                )
-            group = pl_groups.get(prefix)
-            if group is None:
-                group = ChannelGroup("pl", prefix, variable, [], [])
-                pl_groups[prefix] = group
-            group.channel_indices.append(cidx)
-            group.levels.append(level)
-            continue
-
-        variable = resolve_variable(surface_variables.get(channel_name, ()), available)
-        if variable is not None:
-            other_groups.append(ChannelGroup("sfc", channel_name, variable, [cidx], None))
-            continue
-
-        variable = resolve_variable(accumulated_variables.get(channel_name, ()), available)
-        if variable is not None:
-            other_groups.append(ChannelGroup("accum", channel_name, variable, [cidx], None))
-            continue
-
-        if not skip_missing_channels:
-            raise ValueError(
-                f"No ICON variable found for surface channel '{channel_name}'. "
-                f"Known names: {list(surface_variables) + list(accumulated_variables)}."
-            )
-
-    return list(pl_groups.values()) + other_groups
+    return build_channel_groups(
+        channel_names,
+        atmospheric=atmospheric_variables,
+        surface=surface_variables,
+        accumulated=accumulated_variables,
+        available=available,
+        skip_missing_channels=skip_missing_channels,
+        source="ICON",
+    )
 
 
 # ---------------------------------------------------------------------------
 # Decoding
 # ---------------------------------------------------------------------------
+
+
+def _as_text(value) -> str:
+    """Normalize an HDF5 attribute to ``str``.
+
+    ``h5py`` hands back ``bytes`` for the fixed length strings netCDF writes, and
+    0-d or 1-element arrays for scalar attributes, so an attribute has to be
+    unwrapped before it can be compared against anything. Anything else is
+    stringified, which keeps callers free of isinstance checks.
+
+    Raises
+    ------
+    ValueError
+        If the value is an array holding more than one element, which means the
+        caller asked for a scalar attribute and got something else.
+    """
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            raise ValueError(f"Expected a scalar attribute, got an array of size {value.size}.")
+        value = value.reshape(-1)[0]
+    if isinstance(value, (bytes, np.bytes_)):
+        return value.decode("utf-8")
+    return str(value)
 
 
 def decode_time(values, units) -> List[dt.datetime]:

--- a/makani/utils/dataloaders/icon_helpers.py
+++ b/makani/utils/dataloaders/icon_helpers.py
@@ -53,9 +53,8 @@ from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import numpy as np
 
-# channel name parsing is shared with the NCAR reader so that "z500" is split the
-# same way everywhere; both follow makani.utils.features.get_channel_groups
-from makani.utils.dataloaders.ncar_helpers import split_channel_name
+# channel name classification lives in one place for all data sources
+from makani.utils.features import split_channel_name
 
 
 # ICON's own time encoding: the integer part is a YYYYMMDD date, the fraction is
@@ -135,7 +134,12 @@ atmospheric_variables: Dict[str, Tuple[IconVariable, ...]] = {
         IconVariable("v", "pl", units="m s-1"),
         IconVariable("va", "pl", units="m s-1"),
     ),
+    # ICON writes "w" as the vertical *velocity* in m/s (upward_air_velocity),
+    # which is a different quantity from ERA5's omega in Pa/s: they differ by
+    # -rho*g and cannot be substituted for one another. Both are listed so that
+    # the units carried through resolution say which one a file provides.
     "w": (
+        IconVariable("w", "pl", units="m s-1"),
         IconVariable("omega", "pl", units="Pa s-1"),
         IconVariable("wap", "pl", units="Pa s-1"),
     ),
@@ -147,6 +151,27 @@ atmospheric_variables: Dict[str, Tuple[IconVariable, ...]] = {
         IconVariable("rh", "pl", units="%"),
         IconVariable("hur", "pl", units="%"),
     ),
+    # Hydrometeors. ERA5 carries the first four as pressure level parameters
+    # (clwc 246, ciwc 247, crwc 75, cswc 76) and, like ICON, as specific
+    # contents in kg kg-1, so these map one to one and no conversion is needed.
+    # The channels are therefore named after ERA5 rather than after ICON, which
+    # keeps the channel vocabulary the same as for the ERA5 datasets.
+    "clwc": (
+        IconVariable("qc", "pl", units="kg kg-1"),
+        IconVariable("clw", "pl", units="kg kg-1"),
+    ),
+    "ciwc": (
+        IconVariable("qi", "pl", units="kg kg-1"),
+        IconVariable("cli", "pl", units="kg kg-1"),
+    ),
+    "crwc": (IconVariable("qr", "pl", units="kg kg-1"),),
+    "cswc": (IconVariable("qs", "pl", units="kg kg-1"),),
+    # Graupel is the one hydrometeor with no ERA5 counterpart: the IFS
+    # microphysics does not carry it as a separate species, it is folded into
+    # snow. The channel therefore keeps ICON's own name. If a run wants the
+    # ERA5-comparable quantity instead, "cswc" has to be built as qs + qg,
+    # which is a modelling decision rather than a naming one.
+    "qg": (IconVariable("qg", "pl", units="kg kg-1"),),
 }
 
 surface_variables: Dict[str, Tuple[IconVariable, ...]] = {

--- a/makani/utils/dataloaders/ncar_helpers.py
+++ b/makani/utils/dataloaders/ncar_helpers.py
@@ -27,10 +27,12 @@ with one file per variable per *day* for pressure levels, per *month* for
 surface analysis, and per *half month* for the accumulated forecast fields.
 """
 
-import re
 import calendar
 import datetime as dt
 from typing import Dict, List, NamedTuple, Optional
+
+# channel name classification lives in one place for all data sources
+from makani.utils.features import split_channel_name
 
 
 NCAR_ERA5_BUCKET = "nsf-ncar-era5"
@@ -136,33 +138,6 @@ class ChannelGroup(NamedTuple):
     variables: List[NcarVariable]
     channel_indices: List[int]
     levels: Optional[List[int]]
-
-
-def split_channel_name(channel_name: str):
-    """Split a makani channel name into its variable prefix and pressure level.
-
-    Parameters
-    ----------
-    channel_name : str
-        Channel name such as ``"z500"`` or ``"u10m"``.
-
-    Returns
-    -------
-    prefix : str
-        Variable prefix, e.g. ``"z"``. Equals ``channel_name`` for surface
-        channels.
-    level : int or None
-        Pressure level in hPa, or ``None`` for surface channels.
-
-    Notes
-    -----
-    Uses the same classification as :func:`makani.utils.features.get_channel_groups`
-    so that channel grouping stays consistent across the code base.
-    """
-    match = re.search(r"[0-9]{1,4}$", channel_name)
-    if (re.search(r"[a-z]{1,3}[0-9]{1,4}$", channel_name) is not None) and (channel_name != "d2"):
-        return channel_name[: match.start()], int(match.group())
-    return channel_name, None
 
 
 def build_ncar_channel_groups(channel_names: List[str], skip_missing_channels: bool = False) -> List[ChannelGroup]:

--- a/makani/utils/dataloaders/ncar_helpers.py
+++ b/makani/utils/dataloaders/ncar_helpers.py
@@ -25,14 +25,30 @@ Object keys follow::
 
 with one file per variable per *day* for pressure levels, per *month* for
 surface analysis, and per *half month* for the accumulated forecast fields.
+
+Two things make this source awkward, and they are what most of this module is:
+
+* **Object keys have to be constructed, not discovered.** Listing a bucket this
+  large per read is not viable, so the key of every file is derived from the
+  variable descriptor and the date. The three stream layouts each need their own
+  rule, see :func:`analysis_pl_key`, :func:`analysis_sfc_key` and
+  :func:`accumulation_key`.
+* **Precipitation has to be reassembled.** d633000 ships no total precipitation
+  and no ready-made accumulation window: ``tp`` is ``lsp + cp``, summed over an
+  hour range that may straddle two forecast runs, since a run reaches forecast
+  hour 12 while runs start 12 hours apart. :func:`resolve_accumulation_segments`
+  does that arithmetic.
+
+Channel grouping itself is shared with the other readers and lives in
+:mod:`makani.utils.dataloaders.channel_helpers`.
 """
 
 import calendar
 import datetime as dt
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, List, NamedTuple
 
-# channel name classification lives in one place for all data sources
-from makani.utils.features import split_channel_name
+# channel grouping and name classification are shared across the data source readers
+from makani.utils.dataloaders.channel_helpers import ChannelGroup, build_channel_groups
 
 
 NCAR_ERA5_BUCKET = "nsf-ncar-era5"
@@ -103,41 +119,16 @@ atmospheric_variables: Dict[str, NcarVariable] = {
 # Accumulated fields live in the forecast stream and are summed to form the
 # makani channel. d633000 does not ship total precipitation directly, so tp is
 # reconstructed from its two ERA5 components, tp = lsp + cp (both in metres).
-accumulated_variables: Dict[str, List[NcarVariable]] = {
-    "tp": [
-        NcarVariable("e5.oper.fc.sfc.accumu", "128_142", "lsp", "sc", "LSP"),
-        NcarVariable("e5.oper.fc.sfc.accumu", "128_143", "cp", "sc", "CP"),
-    ],
+# the nesting matters: this is ONE candidate made of two components that are
+# summed, not two alternative sources. See makani.utils.dataloaders.channel_helpers.
+accumulated_variables: Dict[str, tuple] = {
+    "tp": (
+        (
+            NcarVariable("e5.oper.fc.sfc.accumu", "128_142", "lsp", "sc", "LSP"),
+            NcarVariable("e5.oper.fc.sfc.accumu", "128_143", "cp", "sc", "CP"),
+        ),
+    ),
 }
-
-
-class ChannelGroup(NamedTuple):
-    """A set of makani channels that are served by the same source files.
-
-    Attributes
-    ----------
-    kind : str
-        One of ``"pl"``, ``"sfc"`` or ``"accum"``. Determines which reader and
-        which key layout applies.
-    name : str
-        The ERA5 short name the group is built around: the variable prefix for
-        pressure level groups (``"z"``), the channel name otherwise (``"t2m"``).
-    variables : list of NcarVariable
-        Source variables. More than one entry only for accumulated channels,
-        whose values are summed.
-    channel_indices : list of int
-        Index of each member channel along axis 1 of the makani ``fields``
-        array.
-    levels : list of int or None
-        Pressure level in hPa for each member channel, ``None`` for surface and
-        accumulated groups.
-    """
-
-    kind: str
-    name: str
-    variables: List[NcarVariable]
-    channel_indices: List[int]
-    levels: Optional[List[int]]
 
 
 def build_ncar_channel_groups(channel_names: List[str], skip_missing_channels: bool = False) -> List[ChannelGroup]:
@@ -146,6 +137,9 @@ def build_ncar_channel_groups(channel_names: List[str], skip_missing_channels: b
     Grouping matters for throughput: the pressure level files are chunked as
     ``(1, n_levels, nlat, nlon)``, so every level of a variable arrives in the
     same chunk and all levels of a variable should be filled from a single read.
+
+    NCAR names every variable canonically, so there is nothing to resolve
+    against the file, and ``available`` is left unset.
 
     Parameters
     ----------
@@ -159,7 +153,9 @@ def build_ncar_channel_groups(channel_names: List[str], skip_missing_channels: b
     Returns
     -------
     list of ChannelGroup
-        One entry per source variable, pressure level groups first.
+        One entry per source variable, pressure level groups first. ``tp`` is
+        the only group with more than one variable, since it is summed from
+        ``lsp`` and ``cp``.
 
     Raises
     ------
@@ -167,39 +163,14 @@ def build_ncar_channel_groups(channel_names: List[str], skip_missing_channels: b
         If a channel has no known NCAR counterpart and ``skip_missing_channels``
         is False.
     """
-    pl_groups: Dict[str, ChannelGroup] = {}
-    other_groups: List[ChannelGroup] = []
-
-    for cidx, channel_name in enumerate(channel_names):
-        prefix, level = split_channel_name(channel_name)
-
-        if level is not None:
-            if prefix not in atmospheric_variables:
-                if skip_missing_channels:
-                    continue
-                raise ValueError(
-                    f"Unknown atmospheric variable prefix '{prefix}' for channel '{channel_name}'. "
-                    f"Known prefixes: {list(atmospheric_variables)}"
-                )
-            group = pl_groups.get(prefix)
-            if group is None:
-                group = ChannelGroup("pl", prefix, [atmospheric_variables[prefix]], [], [])
-                pl_groups[prefix] = group
-            group.channel_indices.append(cidx)
-            group.levels.append(level)
-        elif channel_name in surface_variables:
-            other_groups.append(ChannelGroup("sfc", channel_name, [surface_variables[channel_name]], [cidx], None))
-        elif channel_name in accumulated_variables:
-            other_groups.append(
-                ChannelGroup("accum", channel_name, list(accumulated_variables[channel_name]), [cidx], None)
-            )
-        elif not skip_missing_channels:
-            raise ValueError(
-                f"Unknown surface variable '{channel_name}'. "
-                f"Known names: {list(surface_variables) + list(accumulated_variables)}"
-            )
-
-    return list(pl_groups.values()) + other_groups
+    return build_channel_groups(
+        channel_names,
+        atmospheric=atmospheric_variables,
+        surface=surface_variables,
+        accumulated=accumulated_variables,
+        skip_missing_channels=skip_missing_channels,
+        source="NCAR",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/makani/utils/dataloaders/wb2_helpers.py
+++ b/makani/utils/dataloaders/wb2_helpers.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
+# channel name classification lives in one place for all data sources
+from makani.utils.features import get_channel_groups, split_channel_name
 
 
 # ---------------------------------------------------------------------------
@@ -69,15 +70,12 @@ def split_convert_channel_names(makani_channel_names):
     atmospheric_levels : list[int]
         Sorted list of distinct pressure levels found in the channel list.
     """
-    from makani.utils.features import get_channel_groups
-
     atmospheric_channel_indices, surface_channel_indices, _, _, atmospheric_levels = get_channel_groups(
         makani_channel_names
     )
 
-    pat = re.compile(r"^(.*?)\d{1,}$")
     atmospheric_channel_names = sorted(
-        list(set(pat.match(makani_channel_names[k]).group(1) for k in atmospheric_channel_indices))
+        list(set(split_channel_name(makani_channel_names[k])[0] for k in atmospheric_channel_indices))
     )
     atmospheric_channel_names_wb2 = [atmospheric_variables[c] for c in atmospheric_channel_names]
 
@@ -124,10 +122,8 @@ def build_wb2_channel_map(channel_names, level_values=None):
 
     channel_map = []
     for ch_name in channel_names:
-        m = re.search(r"[0-9]{1,4}$", ch_name)
-        if m is not None and ch_name != "d2":
-            pressure = int(m.group())
-            prefix = ch_name[: m.start()]
+        prefix, pressure = split_channel_name(ch_name)
+        if pressure is not None:
             if prefix not in atmospheric_variables:
                 raise ValueError(
                     f"Unknown atmospheric variable prefix '{prefix}' for channel '{ch_name}'. "

--- a/makani/utils/dataloaders/wb2_helpers.py
+++ b/makani/utils/dataloaders/wb2_helpers.py
@@ -13,6 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Helpers for reading WeatherBench2 style zarr stores.
+
+WeatherBench2 republishes ERA5 (and model output) as cloud hosted zarr, with one
+array per variable and a shared ``level`` coordinate. Two things differ from
+every other source makani reads, and this module exists to absorb both:
+
+* **Names are spelled out in full.** Where makani and ERA5 say ``z``, ``t2m``,
+  ``tp``, WB2 says ``geopotential``, ``2m_temperature``,
+  ``total_precipitation_6hr``. The tables below are the dictionary between the
+  two vocabularies, in both directions -- makani -> WB2 for reading a store or
+  writing one, WB2 -> makani for interpreting one.
+* **Levels are an axis, not part of the name.** A makani channel list names each
+  level separately (``z500``, ``z850``), while a WB2 store has a single
+  ``geopotential`` array indexed by position along ``level``. Translating a
+  channel therefore yields a *(variable, level index)* pair, not just a name,
+  and the index depends on the level coordinate of the particular store. That is
+  what :func:`build_wb2_channel_map` produces.
+
+Note the ``total_precipitation_6hr`` entry: the accumulation window is part of
+the WB2 variable name, so a store fixes it and the reader cannot choose it. That
+is recorded as ``accumulation="window"``, to distinguish it from sources that
+hand out running totals or instantaneous rates.
+
+Reach for :func:`surface_wb2_name` / :func:`atmospheric_wb2_name` rather than
+indexing the tables, so their layout stays an implementation detail here.
+"""
+
+from typing import Dict, NamedTuple, Optional
+
 # channel name classification lives in one place for all data sources
 from makani.utils.features import get_channel_groups, split_channel_name
 
@@ -21,32 +50,57 @@ from makani.utils.features import get_channel_groups, split_channel_name
 # ERA5 short name <-> WeatherBench2 long name mappings
 # ---------------------------------------------------------------------------
 
-surface_variables = {
-    "u10m": "10m_u_component_of_wind",
-    "v10m": "10m_v_component_of_wind",
-    "t2m": "2m_temperature",
-    "d2": "2m_dewpoint_temperature",
-    "u100m": "100m_u_component_of_wind",
-    "v100m": "100m_v_component_of_wind",
-    "tp": "total_precipitation_6hr",
-    "sp": "surface_pressure",
-    "msl": "mean_sea_level_pressure",
-    "tcwv": "total_column_water_vapour",
-    "sst": "sea_surface_temperature",
+
+class Wb2Variable(NamedTuple):
+    """A WeatherBench2 variable backing a makani channel.
+
+    Attributes
+    ----------
+    name : str
+        WB2 long name, i.e. the variable name in the zarr store.
+    kind : str
+        ``"pl"``, ``"sfc"`` or ``"accum"``.
+    units : str, optional
+        Units the store is expected to carry.
+    accumulation : str
+        ``"none"`` for instantaneous fields, ``"window"`` for totals already
+        accumulated over a fixed window that is baked into the variable name.
+    """
+
+    name: str
+    kind: str
+    units: Optional[str] = None
+    accumulation: str = "none"
+
+
+surface_variables: Dict[str, Wb2Variable] = {
+    "u10m": Wb2Variable("10m_u_component_of_wind", "sfc", units="m s-1"),
+    "v10m": Wb2Variable("10m_v_component_of_wind", "sfc", units="m s-1"),
+    "t2m": Wb2Variable("2m_temperature", "sfc", units="K"),
+    "d2": Wb2Variable("2m_dewpoint_temperature", "sfc", units="K"),
+    "u100m": Wb2Variable("100m_u_component_of_wind", "sfc", units="m s-1"),
+    "v100m": Wb2Variable("100m_v_component_of_wind", "sfc", units="m s-1"),
+    # the accumulation window is part of the WB2 name rather than something the
+    # reader chooses, hence "window" rather than "since_start" or "rate"
+    "tp": Wb2Variable("total_precipitation_6hr", "accum", units="m", accumulation="window"),
+    "sp": Wb2Variable("surface_pressure", "sfc", units="Pa"),
+    "msl": Wb2Variable("mean_sea_level_pressure", "sfc", units="Pa"),
+    "tcwv": Wb2Variable("total_column_water_vapour", "sfc", units="kg m-2"),
+    "sst": Wb2Variable("sea_surface_temperature", "sfc", units="K"),
 }
 
-atmospheric_variables = {
-    "z": "geopotential",
-    "u": "u_component_of_wind",
-    "v": "v_component_of_wind",
-    "t": "temperature",
-    "r": "relative_humidity",
-    "q": "specific_humidity",
+atmospheric_variables: Dict[str, Wb2Variable] = {
+    "z": Wb2Variable("geopotential", "pl", units="m2 s-2"),
+    "u": Wb2Variable("u_component_of_wind", "pl", units="m s-1"),
+    "v": Wb2Variable("v_component_of_wind", "pl", units="m s-1"),
+    "t": Wb2Variable("temperature", "pl", units="K"),
+    "r": Wb2Variable("relative_humidity", "pl", units="%"),
+    "q": Wb2Variable("specific_humidity", "pl", units="kg kg-1"),
 }
 
 # reverse lookups
-surface_variables_inv = {v: k for k, v in surface_variables.items()}
-atmospheric_variables_inv = {v: k for k, v in atmospheric_variables.items()}
+surface_variables_inv = {v.name: k for k, v in surface_variables.items()}
+atmospheric_variables_inv = {v.name: k for k, v in atmospheric_variables.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -77,10 +131,10 @@ def split_convert_channel_names(makani_channel_names):
     atmospheric_channel_names = sorted(
         list(set(split_channel_name(makani_channel_names[k])[0] for k in atmospheric_channel_indices))
     )
-    atmospheric_channel_names_wb2 = [atmospheric_variables[c] for c in atmospheric_channel_names]
+    atmospheric_channel_names_wb2 = [atmospheric_wb2_name(c) for c in atmospheric_channel_names]
 
     surface_channel_names = sorted([makani_channel_names[k] for k in surface_channel_indices])
-    surface_channel_names_wb2 = [surface_variables[c] for c in surface_channel_names]
+    surface_channel_names_wb2 = [surface_wb2_name(c) for c in surface_channel_names]
 
     atmospheric_levels = sorted(list(atmospheric_levels))
 
@@ -91,6 +145,45 @@ def split_convert_channel_names(makani_channel_names):
         surface_channel_names_wb2,
         atmospheric_levels,
     )
+
+
+def surface_wb2_name(channel_name):
+    """Return the WB2 long name of a makani surface channel.
+
+    ``"t2m"`` -> ``"2m_temperature"``. Callers should go through this rather
+    than indexing :data:`surface_variables` directly, so that the table layout stays
+    an implementation detail of this module and an unknown name produces a
+    readable error instead of a bare ``KeyError``.
+
+    Raises
+    ------
+    ValueError
+        If the channel has no WB2 counterpart.
+    """
+    try:
+        return surface_variables[channel_name].name
+    except KeyError:
+        raise ValueError(f"Unknown surface variable '{channel_name}'. Known names: {list(surface_variables)}") from None
+
+
+def atmospheric_wb2_name(prefix):
+    """Return the WB2 long name of a makani atmospheric variable prefix.
+
+    ``"z"`` -> ``"geopotential"``. The prefix is the channel name without its
+    pressure level, as produced by
+    :func:`makani.utils.features.split_channel_name`.
+
+    Raises
+    ------
+    ValueError
+        If the prefix has no WB2 counterpart.
+    """
+    try:
+        return atmospheric_variables[prefix].name
+    except KeyError:
+        raise ValueError(
+            f"Unknown atmospheric variable prefix '{prefix}'. Known prefixes: {list(atmospheric_variables)}"
+        ) from None
 
 
 def build_wb2_channel_map(channel_names, level_values=None):
@@ -124,12 +217,7 @@ def build_wb2_channel_map(channel_names, level_values=None):
     for ch_name in channel_names:
         prefix, pressure = split_channel_name(ch_name)
         if pressure is not None:
-            if prefix not in atmospheric_variables:
-                raise ValueError(
-                    f"Unknown atmospheric variable prefix '{prefix}' for channel '{ch_name}'. "
-                    f"Known prefixes: {list(atmospheric_variables)}"
-                )
-            zarr_name = atmospheric_variables[prefix]
+            zarr_name = atmospheric_wb2_name(prefix)
             if pressure not in level_to_idx:
                 raise ValueError(
                     f"Pressure level {pressure} hPa (channel '{ch_name}') not found in zarr store. "
@@ -137,9 +225,7 @@ def build_wb2_channel_map(channel_names, level_values=None):
                 )
             channel_map.append((zarr_name, level_to_idx[pressure]))
         else:
-            if ch_name not in surface_variables:
-                raise ValueError(f"Unknown surface variable '{ch_name}'. " f"Known names: {list(surface_variables)}")
-            channel_map.append((surface_variables[ch_name], None))
+            channel_map.append((surface_wb2_name(ch_name), None))
 
     return channel_map
 

--- a/makani/utils/features.py
+++ b/makani/utils/features.py
@@ -94,6 +94,41 @@ def get_wind_channels(channel_names):
     return wind_chans
 
 
+def split_channel_name(channel_name: str):
+    """Split a makani channel name into its variable prefix and pressure level.
+
+    This is the single definition of how channel names are classified. Every
+    reader that has to decide whether a channel is atmospheric or a surface
+    field goes through here, so that the classification cannot drift apart
+    between data sources.
+
+    Parameters
+    ----------
+    channel_name : str
+        Channel name such as ``"z500"`` or ``"u10m"``.
+
+    Returns
+    -------
+    prefix : str
+        Variable prefix, e.g. ``"z"``. Equals ``channel_name`` for surface
+        channels. Prefixes longer than three characters are supported
+        (``"clwc500"`` -> ``("clwc", 500)``): the pattern only requires that the
+        digits are preceded by letters, the prefix itself is everything before
+        them.
+    level : int or None
+        Pressure level in hPa, or ``None`` for surface channels.
+
+    Notes
+    -----
+    ``"d2"`` (2 metre dewpoint) is the one surface name that would otherwise
+    parse as variable ``"d"`` on 2 hPa, so it is excluded explicitly.
+    """
+    match = re.search(r"[0-9]{1,4}$", channel_name)
+    if (re.search(r"[a-z]{1,3}[0-9]{1,4}$", channel_name) is not None) and (channel_name != "d2"):
+        return channel_name[: match.start()], int(match.group())
+    return channel_name, None
+
+
 def get_channel_groups(channel_names, aux_channel_names=[]):
     """
     Helper routine to extract indices of atmospheric, surface and auxiliary variables and group them into their respective groups.
@@ -109,8 +144,8 @@ def get_channel_groups(channel_names, aux_channel_names=[]):
     # parse channel names and group variables by pressure level/surface variables
     for idx, chn in enumerate(channel_names):
         # check if pattern matches an atmospheric variable
-        if (re.search("[a-z]{1,3}[0-9]{1,4}$", chn) is not None) and (chn != "d2"):
-            pressure_level = int(re.search("[0-9]{1,4}$", chn).group())
+        _, pressure_level = split_channel_name(chn)
+        if pressure_level is not None:
             if pressure_level not in atmo_groups.keys():
                 atmo_groups[pressure_level] = []
             atmo_groups[pressure_level].append(idx)

--- a/tests/test_channel_helpers.py
+++ b/tests/test_channel_helpers.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for ``makani.utils.dataloaders.channel_helpers``, the channel
+grouping shared by the NCAR, WB2 and ICON readers.
+
+The distinction the tests care about most is alternatives versus components: a
+table entry listing several variables can mean "pick whichever the file has"
+(ICON's tot_prec or pr) or "sum all of them" (NCAR's tp = lsp + cp). The two
+look identical in the data and mean the opposite, so both are pinned here with
+a fake descriptor rather than through any one reader's tables.
+"""
+
+import os
+import sys
+import unittest
+from typing import NamedTuple, Optional
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from makani.utils.dataloaders.channel_helpers import (
+    ChannelGroup,
+    build_channel_groups,
+    resolve_variable,
+)
+
+
+class FakeVariable(NamedTuple):
+    """Stand-in for a reader's descriptor, with the fields the contract names."""
+
+    name: str
+    kind: str
+    units: Optional[str] = None
+    accumulation: str = "none"
+
+
+Z = FakeVariable("geopot", "pl", units="m2 s-2")
+ZG = FakeVariable("zg", "pl", units="m")
+T = FakeVariable("temp", "pl", units="K")
+T2M = FakeVariable("t_2m", "sfc", units="K")
+LSP = FakeVariable("lsp", "accum", units="m", accumulation="since_start")
+CP = FakeVariable("cp", "accum", units="m", accumulation="since_start")
+TOT_PREC = FakeVariable("tot_prec", "accum", accumulation="since_start")
+PR = FakeVariable("pr", "accum", accumulation="rate")
+
+ATMOSPHERIC = {"z": (Z, ZG), "t": (T,)}
+SURFACE = {"t2m": (T2M,)}
+
+
+class TestResolveVariable(unittest.TestCase):
+    """Resolution returns the *components* of the chosen candidate, always a tuple."""
+
+    def test_prefers_the_first_available_candidate(self):
+        self.assertEqual(resolve_variable((Z, ZG), ["zg", "geopot"]), (Z,))
+
+    def test_falls_through_to_a_later_candidate(self):
+        self.assertEqual(resolve_variable((Z, ZG), ["zg", "temp"]), (ZG,))
+
+    def test_returns_none_when_nothing_matches(self):
+        self.assertIsNone(resolve_variable((Z, ZG), ["temp"]))
+
+    def test_without_a_file_the_first_candidate_wins(self):
+        self.assertEqual(resolve_variable((Z, ZG), None), (Z,))
+
+    def test_a_bare_descriptor_is_a_valid_entry(self):
+        # readers whose channels map one to one (NCAR, WB2) write the descriptor
+        # directly rather than wrapping it in a one element tuple
+        self.assertEqual(resolve_variable(Z, ["geopot"]), (Z,))
+        self.assertEqual(resolve_variable(Z, None), (Z,))
+
+    def test_empty_entry_resolves_to_none(self):
+        self.assertIsNone(resolve_variable(None, None))
+        self.assertIsNone(resolve_variable((), None))
+
+    # ---- alternatives versus components ------------------------------------
+
+    def test_summed_components_are_returned_together(self):
+        # one candidate made of two components: both are needed
+        entry = ((LSP, CP),)
+        self.assertEqual(resolve_variable(entry, ["lsp", "cp"]), (LSP, CP))
+
+    def test_summed_components_require_every_part(self):
+        # a partial match is not a match: summing lsp alone would be wrong
+        entry = ((LSP, CP),)
+        self.assertIsNone(resolve_variable(entry, ["lsp"]))
+
+    def test_alternatives_need_only_one(self):
+        # the same shape of data, opposite meaning: either one suffices
+        entry = (TOT_PREC, PR)
+        self.assertEqual(resolve_variable(entry, ["pr"]), (PR,))
+        self.assertEqual(resolve_variable(entry, ["tot_prec"]), (TOT_PREC,))
+
+    def test_a_summed_candidate_can_have_alternatives(self):
+        # prefer the sum, fall back to the single variable when the file lacks
+        # the second component
+        entry = ((LSP, CP), LSP)
+        self.assertEqual(resolve_variable(entry, ["lsp", "cp"]), (LSP, CP))
+        self.assertEqual(resolve_variable(entry, ["lsp"]), (LSP,))
+
+
+class TestBuildChannelGroups(unittest.TestCase):
+
+    def test_levels_of_one_variable_share_a_group(self):
+        groups = build_channel_groups(["z500", "z850", "z1000"], ATMOSPHERIC)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0], ChannelGroup("pl", "z", [Z], [0, 1, 2], [500, 850, 1000]))
+
+    def test_channel_indices_track_positions_in_the_original_list(self):
+        groups = build_channel_groups(["z500", "t850", "z1000", "t2m"], ATMOSPHERIC, SURFACE)
+        by_name = {group.name: group for group in groups}
+
+        self.assertEqual(by_name["z"].channel_indices, [0, 2])
+        self.assertEqual(by_name["z"].levels, [500, 1000])
+        self.assertEqual(by_name["t"].channel_indices, [1])
+        self.assertEqual(by_name["t2m"].channel_indices, [3])
+
+    def test_pressure_level_groups_come_first(self):
+        groups = build_channel_groups(["t2m", "z500", "tp", "t850"], ATMOSPHERIC, SURFACE, {"tp": ((LSP, CP),)})
+        kinds = [group.kind for group in groups]
+
+        self.assertEqual(kinds[:2], ["pl", "pl"])
+        self.assertEqual(sorted(kinds[2:]), ["accum", "sfc"])
+
+    def test_surface_groups_have_no_levels(self):
+        group = build_channel_groups(["t2m"], ATMOSPHERIC, SURFACE)[0]
+
+        self.assertEqual(group.kind, "sfc")
+        self.assertIsNone(group.levels)
+        self.assertEqual(group.variables, [T2M])
+
+    def test_accumulated_group_carries_every_component(self):
+        group = build_channel_groups(["tp"], ATMOSPHERIC, SURFACE, {"tp": ((LSP, CP),)})[0]
+
+        self.assertEqual(group.kind, "accum")
+        self.assertEqual(group.variables, [LSP, CP])
+
+    def test_resolution_follows_the_file(self):
+        nwp = build_channel_groups(["z500"], ATMOSPHERIC, available=["geopot"])[0]
+        cmip = build_channel_groups(["z500"], ATMOSPHERIC, available=["zg"])[0]
+
+        self.assertEqual(nwp.variables, [Z])
+        self.assertEqual(cmip.variables, [ZG])
+
+    def test_unresolvable_channels_raise(self):
+        with self.subTest(desc="unknown atmospheric prefix"):
+            with self.assertRaises(ValueError):
+                build_channel_groups(["xyz500"], ATMOSPHERIC, SURFACE)
+
+        with self.subTest(desc="unknown surface name"):
+            with self.assertRaises(ValueError):
+                build_channel_groups(["not_a_variable"], ATMOSPHERIC, SURFACE)
+
+        with self.subTest(desc="known channel the file does not provide"):
+            with self.assertRaises(ValueError):
+                build_channel_groups(["z500"], ATMOSPHERIC, available=["temp"])
+
+    def test_error_message_names_the_source(self):
+        with self.assertRaises(ValueError) as ctx:
+            build_channel_groups(["xyz500"], ATMOSPHERIC, source="ICON")
+        self.assertIn("ICON", str(ctx.exception))
+
+    def test_unresolvable_channels_can_be_skipped(self):
+        groups = build_channel_groups(
+            ["z500", "xyz500", "not_a_variable", "t2m"], ATMOSPHERIC, SURFACE, skip_missing_channels=True
+        )
+
+        self.assertEqual(sorted(group.name for group in groups), ["t2m", "z"])
+        # the surviving channels keep their original indices, holes and all
+        by_name = {group.name: group for group in groups}
+        self.assertEqual(by_name["z"].channel_indices, [0])
+        self.assertEqual(by_name["t2m"].channel_indices, [3])
+
+    def test_empty_channel_list(self):
+        self.assertEqual(build_channel_groups([], ATMOSPHERIC, SURFACE), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dali_helpers.py
+++ b/tests/test_dali_helpers.py
@@ -141,7 +141,7 @@ def _make_distinctive_zarr_wb2_dir(root):
     """Per-year WB2-layout zarr directory with distinctive-channel data."""
     import zarr
     import re
-    from makani.utils.dataloaders.wb2_helpers import surface_variables, atmospheric_variables
+    from makani.utils.dataloaders.wb2_helpers import atmospheric_wb2_name, surface_wb2_name
 
     os.makedirs(root, exist_ok=True)
 
@@ -150,10 +150,10 @@ def _make_distinctive_zarr_wb2_dir(root):
     for ch_idx, ch_name in enumerate(CHANNEL_NAMES):
         m = re.search(r"[0-9]{1,4}$", ch_name)
         if m and ch_name != "d2":
-            wb2n = atmospheric_variables[ch_name[: m.start()]]
+            wb2n = atmospheric_wb2_name(ch_name[: m.start()])
             atm_vars.setdefault(wb2n, {})[int(m.group())] = ch_idx
         else:
-            surf_vars[surface_variables[ch_name]] = ch_idx
+            surf_vars[surface_wb2_name(ch_name)] = ch_idx
 
     all_levels = sorted({lv for lvs in atm_vars.values() for lv in lvs})
     levels = np.array(all_levels, dtype=np.int64)

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime as dt
+import time
 import unittest
 
 import numpy as np
@@ -216,6 +218,22 @@ class TestGetTimestamp(unittest.TestCase):
 # ===========================================================================
 # 5. get_date_from_string
 # ===========================================================================
+@contextlib.contextmanager
+def _local_timezone(name):
+    """Run the enclosed block as if the machine were in another timezone."""
+    previous = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous
+        time.tzset()
+
+
 class TestGetDateFromString(unittest.TestCase):
 
     def test_utc_aware_string_preserved(self):
@@ -230,10 +248,39 @@ class TestGetDateFromString(unittest.TestCase):
         self.assertEqual(ts.hour, 12)
         self.assertEqual(ts.date(), dt.date(2020, 6, 15))
 
-    def test_naive_string_returns_timezone_aware(self):
-        """A naive ISO string must produce a timezone-aware result."""
+    def test_naive_string_is_taken_to_be_utc(self):
+        """A naive ISO string is labelled UTC, not converted from local time.
+
+        Asserting only that the result is timezone aware is not enough: the
+        moment itself has to be unchanged, which is what distinguishes
+        labelling from converting.
+        """
         ts = get_date_from_string("2020-06-15T12:00:00")
-        self.assertIsNotNone(ts.tzinfo)
+
+        self.assertEqual(ts, dt.datetime(2020, 6, 15, 12, 0, 0, tzinfo=UTC))
+
+    @unittest.skipUnless(hasattr(time, "tzset"), "TZ manipulation is POSIX only")
+    def test_parsing_does_not_depend_on_the_machine_timezone(self):
+        """The same string must give the same moment on any machine.
+
+        This is the reason the helper exists. ``astimezone`` on a naive datetime
+        does not raise, it assumes the *local* zone, so a date written without a
+        designator would land an hour out on a CET laptop and be correct on a
+        UTC cluster -- a discrepancy that only shows up when comparing runs
+        across systems.
+        """
+        cases = {
+            "2020-06-15T12:00:00+00:00": dt.datetime(2020, 6, 15, 12, tzinfo=UTC),
+            "2020-06-15T17:00:00+05:00": dt.datetime(2020, 6, 15, 12, tzinfo=UTC),
+            "2020-06-15T12:00:00": dt.datetime(2020, 6, 15, 12, tzinfo=UTC),
+            "2020-06-15": dt.datetime(2020, 6, 15, 0, tzinfo=UTC),
+        }
+
+        for zone in ("UTC", "Europe/Berlin", "America/Los_Angeles"):
+            with _local_timezone(zone):
+                for isostring, expected in cases.items():
+                    with self.subTest(timezone=zone, isostring=isostring):
+                        self.assertEqual(get_date_from_string(isostring), expected)
 
     def test_result_is_datetime(self):
         ts = get_date_from_string("2020-01-01")

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -1231,5 +1231,36 @@ class TestGetStats(unittest.TestCase):
             )
 
 
+class TestConverterImports(unittest.TestCase):
+    """
+    Import every conversion script in ``data_process``.
+
+    The converters are driven by MPI against multi terabyte archives, so they
+    are not otherwise exercised by any test: a renamed helper or a changed
+    table layout would surface on a production run rather than here. Importing
+    them executes the module body, which is where the imports and the
+    module level lookups live, and is the cheapest guard against that.
+
+    Each is skipped when its dependencies are missing, since ``mpi4py``,
+    ``xarray`` and ``dask`` are in the ``data_process`` extra rather than the
+    base install.
+    """
+
+    CONVERTERS = [
+        ("data_process.convert_ncar_era5_to_makani_input", ["mpi4py", "h5py"]),
+        ("data_process.convert_makani_output_to_wb2", ["mpi4py", "xarray", "dask", "h5py"]),
+        ("data_process.convert_wb2_to_makani_input", ["mpi4py", "xarray", "h5py"]),
+        ("data_process.generate_wb2_climatology", ["mpi4py", "xarray", "h5py"]),
+    ]
+
+    def test_converters_import(self):
+        for module_name, requirements in self.CONVERTERS:
+            missing = [r for r in requirements if importlib.util.find_spec(r) is None]
+            with self.subTest(module=module_name):
+                if missing:
+                    self.skipTest(f"missing dependencies: {', '.join(missing)}")
+                importlib.import_module(module_name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -1231,35 +1231,39 @@ class TestGetStats(unittest.TestCase):
             )
 
 
+# conversion scripts, with the extras each needs to be importable at all
+_CONVERTERS = [
+    ("data_process.convert_ncar_era5_to_makani_input", ["mpi4py", "h5py"]),
+    ("data_process.convert_makani_output_to_wb2", ["mpi4py", "xarray", "dask", "h5py"]),
+    ("data_process.convert_wb2_to_makani_input", ["mpi4py", "xarray", "h5py"]),
+    ("data_process.generate_wb2_climatology", ["mpi4py", "xarray", "h5py"]),
+]
+
+
 class TestConverterImports(unittest.TestCase):
     """
-    Import every conversion script in ``data_process``.
+    Import each conversion script in ``data_process``.
 
-    The converters are driven by MPI against multi terabyte archives, so they
-    are not otherwise exercised by any test: a renamed helper or a changed
-    table layout would surface on a production run rather than here. Importing
-    them executes the module body, which is where the imports and the
-    module level lookups live, and is the cheapest guard against that.
+    The converters are driven by MPI against multi terabyte archives and are not
+    otherwise exercised by any test, so this is the only thing standing between a
+    rename here and a failure on a production run.
+
+    What it covers is the *import surface*: module level ``from ... import``
+    statements and any code that runs at import time. It says nothing about what
+    happens inside the functions -- a helper called with the wrong arguments in
+    the middle of a conversion loop is still invisible here.
 
     Each is skipped when its dependencies are missing, since ``mpi4py``,
-    ``xarray`` and ``dask`` are in the ``data_process`` extra rather than the
-    base install.
+    ``xarray`` and ``dask`` live in the ``data_process`` extra rather than the
+    base install; that means these normally skip in CI and run in the container.
     """
 
-    CONVERTERS = [
-        ("data_process.convert_ncar_era5_to_makani_input", ["mpi4py", "h5py"]),
-        ("data_process.convert_makani_output_to_wb2", ["mpi4py", "xarray", "dask", "h5py"]),
-        ("data_process.convert_wb2_to_makani_input", ["mpi4py", "xarray", "h5py"]),
-        ("data_process.generate_wb2_climatology", ["mpi4py", "xarray", "h5py"]),
-    ]
-
-    def test_converters_import(self):
-        for module_name, requirements in self.CONVERTERS:
-            missing = [r for r in requirements if importlib.util.find_spec(r) is None]
-            with self.subTest(module=module_name):
-                if missing:
-                    self.skipTest(f"missing dependencies: {', '.join(missing)}")
-                importlib.import_module(module_name)
+    @parameterized.expand(_CONVERTERS)
+    def test_converter_imports(self, module_name, requirements):
+        missing = [name for name in requirements if importlib.util.find_spec(name) is None]
+        if missing:
+            self.skipTest(f"{module_name} needs {', '.join(missing)}")
+        importlib.import_module(module_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the channel name classification in ``makani.utils.features``.
+
+``split_channel_name`` is the single definition of how a channel name is split
+into a variable prefix and a pressure level. Every data source reader goes
+through it, so the cases pinned down here are the contract the NCAR, WB2 and
+ICON helpers all rely on; they used to be reimplemented per source and had
+started to drift apart.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from makani.utils.features import get_channel_groups, split_channel_name
+
+
+class TestSplitChannelName(unittest.TestCase):
+    """
+    Channel names are classified by a trailing number: ``z500`` is the variable
+    ``z`` on 500 hPa, while ``u10m`` and ``t2m`` end in a letter and are surface
+    fields. ``d2`` is the one name that looks like a level but is not.
+    """
+
+    def test_pressure_level_channels(self):
+        self.assertEqual(split_channel_name("z500"), ("z", 500))
+        self.assertEqual(split_channel_name("t850"), ("t", 850))
+        self.assertEqual(split_channel_name("u1000"), ("u", 1000))
+        self.assertEqual(split_channel_name("q50"), ("q", 50))
+
+    def test_surface_channels_have_no_level(self):
+        for name in ["t2m", "u10m", "v10m", "u100m", "sp", "msl", "tcwv", "sst", "tp"]:
+            with self.subTest(channel=name):
+                self.assertEqual(split_channel_name(name), (name, None))
+
+    def test_d2_is_not_read_as_a_level(self):
+        # "d2" would otherwise parse as variable "d" on 2 hPa
+        self.assertEqual(split_channel_name("d2"), ("d2", None))
+
+    def test_prefixes_longer_than_three_characters(self):
+        # the pattern only requires letters before the digits; the prefix itself
+        # is everything ahead of them, which the hydrometeor channels rely on
+        self.assertEqual(split_channel_name("clwc500"), ("clwc", 500))
+        self.assertEqual(split_channel_name("ciwc1000"), ("ciwc", 1000))
+        self.assertEqual(split_channel_name("cswc250"), ("cswc", 250))
+
+    def test_digits_without_a_letter_prefix_are_not_a_level(self):
+        # this is where the per-source copies used to disagree: without the
+        # letter gate, names like these parsed as an atmospheric variable
+        for name in ["1000", "x12345"]:
+            with self.subTest(channel=name):
+                self.assertIsNone(split_channel_name(name)[1])
+
+
+class TestGetChannelGroupsUsesTheSplitter(unittest.TestCase):
+    """``get_channel_groups`` classifies through the same function, so the two
+    cannot disagree about what is atmospheric."""
+
+    def test_groups_match_the_splitter(self):
+        names = ["u10m", "t2m", "z500", "t500", "z850", "t850", "d2"]
+        atmo, surf, _, _, levels = get_channel_groups(names)
+
+        expected_atmo = {idx for idx, name in enumerate(names) if split_channel_name(name)[1] is not None}
+        expected_surf = set(range(len(names))) - expected_atmo
+
+        self.assertEqual(set(atmo), expected_atmo)
+        self.assertEqual(set(surf), expected_surf)
+        self.assertEqual(sorted(levels), [500, 850])
+
+    def test_dewpoint_is_grouped_as_surface(self):
+        atmo, surf, _, _, _ = get_channel_groups(["d2", "z500", "t500"])
+        self.assertEqual(sorted(surf), [0])
+        self.assertEqual(sorted(atmo), [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -250,6 +250,29 @@ class TestDecodeTime(unittest.TestCase):
             with self.subTest(units=units):
                 self.assertEqual(decode_time([1.5], units), [_utc(2017, 1, 2, 12)])
 
+    def test_cf_reference_without_padding(self):
+        # udunits does not require zero padding and ICON writes exactly this
+        times = decode_time([0, 180], "minutes since 2020-1-1 00:00:00")
+        self.assertEqual(times, [_utc(2020, 1, 1, 0), _utc(2020, 1, 1, 3)])
+
+    def test_cf_reference_with_offset_is_converted(self):
+        # a reference naming a local instant is moved to UTC, matching
+        # makani.utils.dataloaders.data_helpers.get_date_from_string
+        self.assertEqual(decode_time([0], "hours since 2020-01-01 00:00:00 +2:00"), [_utc(2019, 12, 31, 22)])
+        self.assertEqual(decode_time([0], "hours since 2020-01-01 00:00:00 -05:00"), [_utc(2020, 1, 1, 5)])
+        self.assertEqual(decode_time([0], "hours since 2020-01-01 00:00:00 +0200"), [_utc(2019, 12, 31, 22)])
+        self.assertEqual(decode_time([0], "hours since 2020-01-01T00:00:00+02:00"), [_utc(2019, 12, 31, 22)])
+
+    def test_cf_reference_designators_mean_utc(self):
+        for reference in ("2020-01-01 00:00:00 UTC", "2020-01-01 00:00:00 GMT", "2020-01-01T00:00:00Z"):
+            with self.subTest(reference=reference):
+                self.assertEqual(decode_time([0], f"hours since {reference}"), [_utc(2020, 1, 1)])
+
+    def test_bare_date_is_not_read_as_an_offset(self):
+        # "2020-01-01" ends in something shaped like "-01"; taking it for an
+        # offset would silently move the epoch by an hour
+        self.assertEqual(decode_time([0], "days since 2020-01-01"), [_utc(2020, 1, 1)])
+
     def test_cf_seconds_and_minutes(self):
         self.assertEqual(decode_time([90], "seconds since 2017-01-01"), [_utc(2017, 1, 1, 0, 1, 30)])
         self.assertEqual(decode_time([90], "minutes since 2017-01-01"), [_utc(2017, 1, 1, 1, 30)])

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -18,6 +18,10 @@ Unit tests for ``makani.utils.dataloaders.icon_helpers``: the decoding of ICON
 netCDF conventions and the mapping from ICON variable names onto makani
 channels.
 
+The candidate resolution and channel grouping themselves are shared with the
+other readers and are covered in ``test_channel_helpers.py``; what is pinned
+here is which ICON names each makani channel maps to.
+
 Everything here works on plain arrays and attribute values, so no ICON file, no
 h5py and no grid is needed. The reads and the regridding live in the converter
 and are not covered.
@@ -35,7 +39,6 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from makani.utils.dataloaders.icon_helpers import (
     GRAVITY,
     ICON_TIME_UNITS,
-    IconVariable,
     build_icon_channel_groups,
     check_grid_uuid,
     decode_time,
@@ -43,39 +46,11 @@ from makani.utils.dataloaders.icon_helpers import (
     grid_coordinates_in_degrees,
     pressure_level_index,
     pressure_levels_in_hpa,
-    resolve_variable,
 )
 
 
 def _utc(year, month, day, hour=0, minute=0, second=0):
     return dt.datetime(year, month, day, hour, minute, second, tzinfo=dt.timezone.utc)
-
-
-class TestResolveVariable(unittest.TestCase):
-    """
-    A makani channel maps to several possible ICON names depending on which
-    physics package and output namelist produced the file; the resolver picks
-    the one the file actually has.
-    """
-
-    candidates = (
-        IconVariable("temp", "pl", units="K"),
-        IconVariable("ta", "pl", units="K"),
-    )
-
-    def test_prefers_the_first_candidate_present(self):
-        self.assertEqual(resolve_variable(self.candidates, ["ta", "temp", "qv"]).name, "temp")
-
-    def test_falls_through_to_the_alternative_naming(self):
-        # an AES/CMIP style file has no "temp"
-        self.assertEqual(resolve_variable(self.candidates, ["ta", "hus", "ps"]).name, "ta")
-
-    def test_returns_none_when_the_file_has_neither(self):
-        self.assertIsNone(resolve_variable(self.candidates, ["qv", "ps"]))
-
-    def test_without_a_file_the_preferred_name_is_assumed(self):
-        # used before a file has been opened, e.g. to report what will be read
-        self.assertEqual(resolve_variable(self.candidates, None).name, "temp")
 
 
 class TestBuildIconChannelGroups(unittest.TestCase):
@@ -115,8 +90,8 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         nwp = build_icon_channel_groups(["t850", "t2m", "msl"], available=["temp", "t_2m", "pres_msl"])
         aes = build_icon_channel_groups(["t850", "t2m", "msl"], available=["ta", "tas", "psl"])
 
-        self.assertEqual([group.variable.name for group in nwp], ["temp", "t_2m", "pres_msl"])
-        self.assertEqual([group.variable.name for group in aes], ["ta", "tas", "psl"])
+        self.assertEqual([group.variables[0].name for group in nwp], ["temp", "t_2m", "pres_msl"])
+        self.assertEqual([group.variables[0].name for group in aes], ["ta", "tas", "psl"])
 
     def test_accumulation_semantics_come_from_the_resolved_variable(self):
         # a running total has to be differenced, a flux has to be integrated;
@@ -124,8 +99,8 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         total = build_icon_channel_groups(["tp"], available=["tot_prec"])[0]
         flux = build_icon_channel_groups(["tp"], available=["pr"])[0]
 
-        self.assertEqual(total.variable.accumulation, "since_start")
-        self.assertEqual(flux.variable.accumulation, "rate")
+        self.assertEqual(total.variables[0].accumulation, "since_start")
+        self.assertEqual(flux.variables[0].accumulation, "rate")
 
     def test_geopotential_and_geopotential_height_are_distinguishable(self):
         # z is geopotential; a file offering only zg gives metres and needs a
@@ -133,8 +108,8 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         geopotential = build_icon_channel_groups(["z500"], available=["geopot"])[0]
         height = build_icon_channel_groups(["z500"], available=["zg"])[0]
 
-        self.assertEqual(geopotential.variable.units, "m2 s-2")
-        self.assertEqual(height.variable.units, "m")
+        self.assertEqual(geopotential.variables[0].units, "m2 s-2")
+        self.assertEqual(height.variables[0].units, "m")
         self.assertAlmostEqual(GRAVITY, 9.80665)
 
     def test_hydrometeors_map_onto_era5_channel_names(self):
@@ -144,10 +119,10 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         groups = build_icon_channel_groups(channels, available=["qc", "qi", "qr", "qs"])
 
         self.assertEqual([group.name for group in groups], ["clwc", "ciwc", "crwc", "cswc"])
-        self.assertEqual([group.variable.name for group in groups], ["qc", "qi", "qr", "qs"])
+        self.assertEqual([group.variables[0].name for group in groups], ["qc", "qi", "qr", "qs"])
         for group in groups:
             with self.subTest(channel=group.name):
-                self.assertEqual(group.variable.units, "kg kg-1")
+                self.assertEqual(group.variables[0].units, "kg kg-1")
                 self.assertEqual(group.levels, [500])
 
     def test_hydrometeor_channel_names_parse_despite_four_letters(self):
@@ -164,11 +139,11 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         group = build_icon_channel_groups(["qg500"], available=["qg"])[0]
 
         self.assertEqual(group.name, "qg")
-        self.assertEqual(group.variable.name, "qg")
+        self.assertEqual(group.variables[0].name, "qg")
 
     def test_cmip_style_cloud_names_resolve(self):
         groups = build_icon_channel_groups(["clwc500", "ciwc500"], available=["clw", "cli"])
-        self.assertEqual([group.variable.name for group in groups], ["clw", "cli"])
+        self.assertEqual([group.variables[0].name for group in groups], ["clw", "cli"])
 
     def test_unresolvable_channels_raise(self):
         with self.subTest(desc="unknown atmospheric prefix"):

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -117,6 +117,8 @@ class TestBuildIconChannelGroups(unittest.TestCase):
     def test_hydrometeors_map_onto_era5_channel_names(self):
         # ERA5 carries these as specific contents in kg kg-1, the same quantity
         # and unit ICON writes, so the channels keep the ERA5 vocabulary
+        # no qg in this file, so cswc falls back to qs alone; the sum is covered
+        # in test_snow_is_summed_with_graupel_to_match_era5
         channels = ["clwc500", "ciwc500", "crwc500", "cswc500"]
         groups = build_icon_channel_groups(channels, available=["qc", "qi", "qr", "qs"])
 
@@ -126,6 +128,31 @@ class TestBuildIconChannelGroups(unittest.TestCase):
             with self.subTest(channel=group.name):
                 self.assertEqual(group.variables[0].units, "kg kg-1")
                 self.assertEqual(group.levels, [500])
+
+    def test_snow_is_summed_with_graupel_to_match_era5(self):
+        """
+        ERA5's snow content includes graupel, ICON's qs does not, so the
+        ERA5-named channel is the sum. At convection-resolving resolution
+        graupel dominates in deep convective cores, so reading qs alone would
+        bias the field exactly where the run is most informative.
+        """
+        group = build_icon_channel_groups(["cswc500"], available=["qs", "qg"])[0]
+
+        self.assertEqual(group.name, "cswc")
+        self.assertEqual([variable.name for variable in group.variables], ["qs", "qg"])
+
+    def test_snow_falls_back_to_qs_without_graupel(self):
+        # a microphysics scheme with no graupel category still provides cswc
+        group = build_icon_channel_groups(["cswc500"], available=["qs"])[0]
+
+        self.assertEqual([variable.name for variable in group.variables], ["qs"])
+
+    def test_graupel_is_still_available_on_its_own(self):
+        # for runs that prefer ICON's species split over the ERA5 vocabulary
+        group = build_icon_channel_groups(["qg500"], available=["qs", "qg"])[0]
+
+        self.assertEqual(group.name, "qg")
+        self.assertEqual([variable.name for variable in group.variables], ["qg"])
 
     def test_hydrometeor_channel_names_parse_despite_four_letters(self):
         # the channel name splitter is built around 1-3 letter prefixes; these

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -137,6 +137,39 @@ class TestBuildIconChannelGroups(unittest.TestCase):
         self.assertEqual(height.variable.units, "m")
         self.assertAlmostEqual(GRAVITY, 9.80665)
 
+    def test_hydrometeors_map_onto_era5_channel_names(self):
+        # ERA5 carries these as specific contents in kg kg-1, the same quantity
+        # and unit ICON writes, so the channels keep the ERA5 vocabulary
+        channels = ["clwc500", "ciwc500", "crwc500", "cswc500"]
+        groups = build_icon_channel_groups(channels, available=["qc", "qi", "qr", "qs"])
+
+        self.assertEqual([group.name for group in groups], ["clwc", "ciwc", "crwc", "cswc"])
+        self.assertEqual([group.variable.name for group in groups], ["qc", "qi", "qr", "qs"])
+        for group in groups:
+            with self.subTest(channel=group.name):
+                self.assertEqual(group.variable.units, "kg kg-1")
+                self.assertEqual(group.levels, [500])
+
+    def test_hydrometeor_channel_names_parse_despite_four_letters(self):
+        # the channel name splitter is built around 1-3 letter prefixes; these
+        # names are longer, so pin down that the level still separates correctly
+        group = build_icon_channel_groups(["clwc850", "clwc1000"], available=["qc"])[0]
+
+        self.assertEqual(group.name, "clwc")
+        self.assertEqual(group.levels, [850, 1000])
+
+    def test_graupel_keeps_the_icon_name(self):
+        # ERA5 has no graupel parameter, the IFS folds it into snow, so there is
+        # no ERA5 channel to map onto
+        group = build_icon_channel_groups(["qg500"], available=["qg"])[0]
+
+        self.assertEqual(group.name, "qg")
+        self.assertEqual(group.variable.name, "qg")
+
+    def test_cmip_style_cloud_names_resolve(self):
+        groups = build_icon_channel_groups(["clwc500", "ciwc500"], available=["clw", "cli"])
+        self.assertEqual([group.variable.name for group in groups], ["clw", "cli"])
+
     def test_unresolvable_channels_raise(self):
         with self.subTest(desc="unknown atmospheric prefix"):
             with self.assertRaises(ValueError):

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -38,6 +38,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from makani.utils.dataloaders.icon_helpers import (
     GRAVITY,
+    IconVariable,
+    accumulated_variables,
     ICON_TIME_UNITS,
     build_icon_channel_groups,
     check_grid_uuid,
@@ -144,6 +146,24 @@ class TestBuildIconChannelGroups(unittest.TestCase):
     def test_cmip_style_cloud_names_resolve(self):
         groups = build_icon_channel_groups(["clwc500", "ciwc500"], available=["clw", "cli"])
         self.assertEqual([group.variables[0].name for group in groups], ["clw", "cli"])
+
+    def test_precipitation_offers_alternatives_not_components(self):
+        """
+        The mirror image of the NCAR tp entry, and the reason the nesting is
+        explicit.
+
+        tot_prec and pr are two ways a run may report precipitation, not two
+        quantities to add up: a file carries one or the other. Nested one level
+        deeper they would read as components, resolution would demand both, and
+        every file would fail to provide tp at all.
+        """
+        candidates = accumulated_variables["tp"]
+
+        self.assertGreater(len(candidates), 1, "tp must offer more than one possible source")
+        for candidate in candidates:
+            with self.subTest(variable=candidate.name):
+                # a bare descriptor is a candidate of a single component
+                self.assertIsInstance(candidate, IconVariable)
 
     def test_unresolvable_channels_raise(self):
         with self.subTest(desc="unknown atmospheric prefix"):

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for ``makani.utils.dataloaders.icon_helpers``: the decoding of ICON
+netCDF conventions and the mapping from ICON variable names onto makani
+channels.
+
+Everything here works on plain arrays and attribute values, so no ICON file, no
+h5py and no grid is needed. The reads and the regridding live in the converter
+and are not covered.
+"""
+
+import os
+import sys
+import unittest
+import datetime as dt
+
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from makani.utils.dataloaders.icon_helpers import (
+    GRAVITY,
+    ICON_TIME_UNITS,
+    IconVariable,
+    build_icon_channel_groups,
+    check_grid_uuid,
+    decode_time,
+    decode_values,
+    grid_coordinates_in_degrees,
+    pressure_level_index,
+    pressure_levels_in_hpa,
+    resolve_variable,
+)
+
+
+def _utc(year, month, day, hour=0, minute=0, second=0):
+    return dt.datetime(year, month, day, hour, minute, second, tzinfo=dt.timezone.utc)
+
+
+class TestResolveVariable(unittest.TestCase):
+    """
+    A makani channel maps to several possible ICON names depending on which
+    physics package and output namelist produced the file; the resolver picks
+    the one the file actually has.
+    """
+
+    candidates = (
+        IconVariable("temp", "pl", units="K"),
+        IconVariable("ta", "pl", units="K"),
+    )
+
+    def test_prefers_the_first_candidate_present(self):
+        self.assertEqual(resolve_variable(self.candidates, ["ta", "temp", "qv"]).name, "temp")
+
+    def test_falls_through_to_the_alternative_naming(self):
+        # an AES/CMIP style file has no "temp"
+        self.assertEqual(resolve_variable(self.candidates, ["ta", "hus", "ps"]).name, "ta")
+
+    def test_returns_none_when_the_file_has_neither(self):
+        self.assertIsNone(resolve_variable(self.candidates, ["qv", "ps"]))
+
+    def test_without_a_file_the_preferred_name_is_assumed(self):
+        # used before a file has been opened, e.g. to report what will be read
+        self.assertEqual(resolve_variable(self.candidates, None).name, "temp")
+
+
+class TestBuildIconChannelGroups(unittest.TestCase):
+    """
+    Grouping mirrors the NCAR reader: all levels of a variable are read from one
+    ICON variable, and every group remembers which makani channel indices it
+    fills.
+    """
+
+    def test_levels_of_one_variable_share_a_group(self):
+        groups = build_icon_channel_groups(["z500", "z850", "z1000"])
+
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+        self.assertEqual(group.kind, "pl")
+        self.assertEqual(group.name, "z")
+        self.assertEqual(group.levels, [500, 850, 1000])
+        self.assertEqual(group.channel_indices, [0, 1, 2])
+
+    def test_channel_indices_track_positions_in_the_original_list(self):
+        groups = build_icon_channel_groups(["z500", "t850", "z1000", "t2m"])
+        by_name = {group.name: group for group in groups}
+
+        self.assertEqual(by_name["z"].channel_indices, [0, 2])
+        self.assertEqual(by_name["z"].levels, [500, 1000])
+        self.assertEqual(by_name["t"].channel_indices, [1])
+        self.assertEqual(by_name["t2m"].channel_indices, [3])
+
+    def test_pressure_level_groups_come_first(self):
+        groups = build_icon_channel_groups(["t2m", "z500", "tp", "u850"])
+        kinds = [group.kind for group in groups]
+
+        self.assertEqual(kinds[:2], ["pl", "pl"])
+        self.assertEqual(sorted(kinds[2:]), ["accum", "sfc"])
+
+    def test_resolution_follows_the_naming_of_the_file(self):
+        nwp = build_icon_channel_groups(["t850", "t2m", "msl"], available=["temp", "t_2m", "pres_msl"])
+        aes = build_icon_channel_groups(["t850", "t2m", "msl"], available=["ta", "tas", "psl"])
+
+        self.assertEqual([group.variable.name for group in nwp], ["temp", "t_2m", "pres_msl"])
+        self.assertEqual([group.variable.name for group in aes], ["ta", "tas", "psl"])
+
+    def test_accumulation_semantics_come_from_the_resolved_variable(self):
+        # a running total has to be differenced, a flux has to be integrated;
+        # which one applies is a property of the file, not of the channel
+        total = build_icon_channel_groups(["tp"], available=["tot_prec"])[0]
+        flux = build_icon_channel_groups(["tp"], available=["pr"])[0]
+
+        self.assertEqual(total.variable.accumulation, "since_start")
+        self.assertEqual(flux.variable.accumulation, "rate")
+
+    def test_geopotential_and_geopotential_height_are_distinguishable(self):
+        # z is geopotential; a file offering only zg gives metres and needs a
+        # factor of GRAVITY, so the units have to survive resolution
+        geopotential = build_icon_channel_groups(["z500"], available=["geopot"])[0]
+        height = build_icon_channel_groups(["z500"], available=["zg"])[0]
+
+        self.assertEqual(geopotential.variable.units, "m2 s-2")
+        self.assertEqual(height.variable.units, "m")
+        self.assertAlmostEqual(GRAVITY, 9.80665)
+
+    def test_unresolvable_channels_raise(self):
+        with self.subTest(desc="unknown atmospheric prefix"):
+            with self.assertRaises(ValueError):
+                build_icon_channel_groups(["xyz500"])
+
+        with self.subTest(desc="unknown surface name"):
+            with self.assertRaises(ValueError):
+                build_icon_channel_groups(["not_a_variable"])
+
+        with self.subTest(desc="known channel the file does not provide"):
+            with self.assertRaises(ValueError):
+                build_icon_channel_groups(["t850"], available=["qv"])
+
+    def test_unresolvable_channels_can_be_skipped(self):
+        groups = build_icon_channel_groups(["z500", "xyz500", "not_a_variable", "t2m"], skip_missing_channels=True)
+
+        self.assertEqual(sorted(group.name for group in groups), ["t2m", "z"])
+
+
+class TestDecodeTime(unittest.TestCase):
+    """
+    ICON's native encoding packs the date into the integer part and the time of
+    day into the fraction. Reading it as a CF offset would produce wrong but
+    plausible dates, which is the whole reason this function exists.
+    """
+
+    def test_icon_float_encoding(self):
+        # 0.333333 of a day is 08:00
+        times = decode_time([20170821.333333], ICON_TIME_UNITS)
+        self.assertEqual(times, [_utc(2017, 8, 21, 8)])
+
+    def test_icon_float_encoding_midnight_and_noon(self):
+        times = decode_time([20170821.0, 20170821.5, 20171231.75], ICON_TIME_UNITS)
+        self.assertEqual(
+            times,
+            [_utc(2017, 8, 21, 0), _utc(2017, 8, 21, 12), _utc(2017, 12, 31, 18)],
+        )
+
+    def test_icon_float_encoding_rounds_to_the_nearest_second(self):
+        # the fraction is a float, so an exact hour is not exactly representable
+        times = decode_time([20170821.25], ICON_TIME_UNITS)
+        self.assertEqual(times[0].second, 0)
+        self.assertEqual(times[0].microsecond, 0)
+        self.assertEqual(times[0], _utc(2017, 8, 21, 6))
+
+    def test_cf_encoding_is_also_accepted(self):
+        times = decode_time([0, 6, 24], b"hours since 2017-01-01 00:00:00")
+        self.assertEqual(times, [_utc(2017, 1, 1), _utc(2017, 1, 1, 6), _utc(2017, 1, 2)])
+
+    def test_cf_encoding_variants(self):
+        for units in [
+            "days since 2017-01-01",
+            "days since 2017-01-01 00:00:00",
+            "days since 2017-01-01T00:00:00Z",
+        ]:
+            with self.subTest(units=units):
+                self.assertEqual(decode_time([1.5], units), [_utc(2017, 1, 2, 12)])
+
+    def test_cf_seconds_and_minutes(self):
+        self.assertEqual(decode_time([90], "seconds since 2017-01-01"), [_utc(2017, 1, 1, 0, 1, 30)])
+        self.assertEqual(decode_time([90], "minutes since 2017-01-01"), [_utc(2017, 1, 1, 1, 30)])
+
+    def test_scalar_input_is_accepted(self):
+        self.assertEqual(decode_time(20170821.5, ICON_TIME_UNITS), [_utc(2017, 8, 21, 12)])
+
+    def test_unknown_encoding_raises(self):
+        with self.assertRaises(ValueError):
+            decode_time([0.0], "elapsed model seconds")
+
+    def test_invalid_date_raises(self):
+        # month 13 is not a date, and must not be silently accepted
+        with self.assertRaises(ValueError):
+            decode_time([20171321.0], ICON_TIME_UNITS)
+
+
+class TestDecodeValues(unittest.TestCase):
+    """
+    Reading netCDF through h5py bypasses the library's unpacking, so packing and
+    fill values have to be applied here or the fields come out as raw integers.
+    """
+
+    def test_unpacks_scale_and_offset(self):
+        raw = np.array([0, 100, 200], dtype=np.int16)
+        values = decode_values(raw, scale_factor=0.5, add_offset=250.0)
+
+        np.testing.assert_allclose(values, [250.0, 300.0, 350.0])
+        self.assertEqual(values.dtype, np.float32)
+
+    def test_passes_unpacked_data_through(self):
+        raw = np.array([1.5, 2.5], dtype=np.float64)
+        np.testing.assert_allclose(decode_values(raw), [1.5, 2.5])
+
+    def test_fill_values_become_nan(self):
+        raw = np.array([1, -9999, 3], dtype=np.int32)
+        values = decode_values(raw, fill_value=-9999)
+
+        self.assertTrue(np.isnan(values[1]))
+        np.testing.assert_allclose(values[[0, 2]], [1.0, 3.0])
+
+    def test_fill_value_is_matched_before_unpacking(self):
+        # CF matches the sentinel against the stored value; matching after
+        # scaling would either miss it or catch valid data instead
+        raw = np.array([0, -32767, 100], dtype=np.int16)
+        values = decode_values(raw, fill_value=-32767, scale_factor=0.1, add_offset=273.15)
+
+        self.assertTrue(np.isnan(values[1]))
+        np.testing.assert_allclose(values[[0, 2]], [273.15, 283.15], rtol=1e-6)
+
+    def test_integer_output_dtype_is_rejected(self):
+        # NaN cannot be represented, so missing data would turn into a number
+        with self.assertRaises(ValueError):
+            decode_values(np.array([1, 2]), fill_value=1, dtype=np.int32)
+
+
+class TestGridCoordinates(unittest.TestCase):
+    """ICON stores cell centers in radians with longitude in [-pi, pi]; makani
+    works in degrees with longitude in [0, 360)."""
+
+    def test_converts_radians_to_degrees(self):
+        lon, lat = grid_coordinates_in_degrees([0.0, np.pi / 2], [0.0, np.pi / 4])
+
+        np.testing.assert_allclose(lon, [0.0, 90.0])
+        np.testing.assert_allclose(lat, [0.0, 45.0])
+
+    def test_wraps_negative_longitudes(self):
+        lon, _ = grid_coordinates_in_degrees([-np.pi / 2, -np.pi], [0.0, 0.0])
+        np.testing.assert_allclose(lon, [270.0, 180.0])
+
+    def test_poles_are_accepted(self):
+        _, lat = grid_coordinates_in_degrees([0.0, 0.0], [np.pi / 2, -np.pi / 2])
+        np.testing.assert_allclose(lat, [90.0, -90.0])
+
+    def test_degrees_input_is_rejected(self):
+        # a file already in degrees would otherwise collapse into a few degrees
+        # around the prime meridian without any error
+        with self.assertRaises(ValueError):
+            grid_coordinates_in_degrees([0.0, 90.0], [0.0, 45.0])
+
+    def test_mismatched_shapes_are_rejected(self):
+        with self.assertRaises(ValueError):
+            grid_coordinates_in_degrees([0.0, 1.0], [0.0])
+
+
+class TestPressureLevels(unittest.TestCase):
+    """ICON writes levels in Pa, makani channel names carry hPa; selecting the
+    wrong one picks a completely different level without failing."""
+
+    def test_pascals_are_converted(self):
+        np.testing.assert_allclose(pressure_levels_in_hpa([100000.0, 50000.0, 5000.0]), [1000.0, 500.0, 50.0])
+
+    def test_hectopascals_are_left_alone(self):
+        np.testing.assert_allclose(pressure_levels_in_hpa([1000.0, 500.0, 50.0]), [1000.0, 500.0, 50.0])
+
+    def test_index_lookup_in_pascals(self):
+        levels = [100000.0, 85000.0, 50000.0, 25000.0]
+        self.assertEqual(pressure_level_index(levels, 500), 2)
+        self.assertEqual(pressure_level_index(levels, 1000), 0)
+
+    def test_index_lookup_in_hectopascals(self):
+        levels = [1000.0, 850.0, 500.0, 250.0]
+        self.assertEqual(pressure_level_index(levels, 850), 1)
+
+    def test_missing_level_raises(self):
+        with self.assertRaises(ValueError):
+            pressure_level_index([100000.0, 85000.0], 500)
+
+    def test_empty_level_coordinate_raises(self):
+        with self.assertRaises(ValueError):
+            pressure_levels_in_hpa([])
+
+
+class TestCheckGridUuid(unittest.TestCase):
+    """The data file names the grid it was run on; regridding against a
+    different grid file scrambles the field silently."""
+
+    def test_matching_uuids_pass(self):
+        check_grid_uuid("A1B2-C3D4", b"a1b2-c3d4")
+
+    def test_mismatched_uuids_raise(self):
+        with self.assertRaises(ValueError):
+            check_grid_uuid("a1b2-c3d4", "ffff-0000")
+
+    def test_absent_uuids_are_tolerated(self):
+        # not every setup writes the attribute, so this cannot be fatal
+        check_grid_uuid(None, "a1b2-c3d4")
+        check_grid_uuid("a1b2-c3d4", None)
+        check_grid_uuid("", "a1b2-c3d4")
+
+    def test_numpy_string_attributes_are_handled(self):
+        # h5py hands back bytes or 1-element arrays for netCDF string attributes
+        check_grid_uuid(np.array([b"a1b2-c3d4"]), "a1b2-c3d4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ncar_helpers.py
+++ b/tests/test_ncar_helpers.py
@@ -16,7 +16,8 @@
 """
 Unit tests for ``makani.utils.dataloaders.ncar_helpers``, the channel mapping,
 object key and accumulation window arithmetic behind the NSF NCAR ERA5 (RDA
-d633000) converter.
+d633000) converter. The channel name splitter it builds on is shared with the
+other readers and is covered in ``test_features.py``.
 
 Everything here is pure computation on names and datetimes, so no S3 access, no
 MPI and no data fixtures are involved. The reads themselves live in
@@ -41,36 +42,12 @@ from makani.utils.dataloaders.ncar_helpers import (
     build_ncar_channel_groups,
     latest_forecast_init,
     resolve_accumulation_segments,
-    split_channel_name,
     to_ncar_hours,
 )
 
 
 def _utc(year, month, day, hour=0):
     return dt.datetime(year, month, day, hour, tzinfo=dt.timezone.utc)
-
-
-class TestSplitChannelName(unittest.TestCase):
-    """
-    Channel names are classified by a trailing number: ``z500`` is the variable
-    ``z`` on 500 hPa, while ``u10m`` and ``t2m`` end in a letter and are surface
-    fields. ``d2`` is the one name that looks like a level but is not.
-    """
-
-    def test_pressure_level_channels(self):
-        self.assertEqual(split_channel_name("z500"), ("z", 500))
-        self.assertEqual(split_channel_name("t850"), ("t", 850))
-        self.assertEqual(split_channel_name("u1000"), ("u", 1000))
-        self.assertEqual(split_channel_name("q50"), ("q", 50))
-
-    def test_surface_channels_have_no_level(self):
-        for name in ["t2m", "u10m", "v10m", "u100m", "sp", "msl", "tcwv", "sst", "tp"]:
-            with self.subTest(channel=name):
-                self.assertEqual(split_channel_name(name), (name, None))
-
-    def test_d2_is_not_read_as_a_level(self):
-        # "d2" would otherwise parse as variable "d" on 2 hPa
-        self.assertEqual(split_channel_name("d2"), ("d2", None))
 
 
 class TestBuildNcarChannelGroups(unittest.TestCase):

--- a/tests/test_ncar_helpers.py
+++ b/tests/test_ncar_helpers.py
@@ -33,6 +33,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from makani.utils.dataloaders.ncar_helpers import (
     ACCUM_INIT_HOURS,
+    accumulated_variables,
     ACCUM_MAX_FORECAST_HOUR,
     NCAR_EPOCH,
     NcarVariable,
@@ -94,6 +95,20 @@ class TestBuildNcarChannelGroups(unittest.TestCase):
         # tp is not shipped directly, it is reconstructed as lsp + cp
         self.assertEqual(groups["tp"].kind, "accum")
         self.assertEqual([var.short_name for var in groups["tp"].variables], ["lsp", "cp"])
+
+    def test_precipitation_is_summed_not_alternatives(self):
+        """
+        The nesting of the tp entry carries meaning that is easy to lose.
+
+        d633000 has no total precipitation, so tp is lsp PLUS cp: one candidate
+        made of two components. Written one level flatter it would read as two
+        *alternatives*, the reader would take whichever it saw first, and the
+        dataset would silently carry roughly half its precipitation.
+        """
+        candidates = accumulated_variables["tp"]
+
+        self.assertEqual(len(candidates), 1, "tp must offer exactly one way to be built")
+        self.assertEqual([variable.short_name for variable in candidates[0]], ["lsp", "cp"])
 
     def test_unknown_channels_raise(self):
         with self.subTest(desc="unknown atmospheric prefix"):

--- a/tests/test_wb2_helpers.py
+++ b/tests/test_wb2_helpers.py
@@ -20,9 +20,54 @@ from makani.utils.dataloaders.wb2_helpers import (
     atmospheric_variables,
     surface_variables_inv,
     atmospheric_variables_inv,
+    surface_wb2_name,
+    atmospheric_wb2_name,
     split_convert_channel_names,
     build_wb2_channel_map,
 )
+
+
+class TestNameLookups(unittest.TestCase):
+    """
+    The two accessors are what the converters use, so that the mapping tables
+    stay an implementation detail of wb2_helpers. They also turn an unknown
+    name into a readable ValueError rather than a bare KeyError coming out of
+    the middle of a conversion run.
+    """
+
+    def test_surface_lookup(self):
+        self.assertEqual(surface_wb2_name("t2m"), "2m_temperature")
+        self.assertEqual(surface_wb2_name("msl"), "mean_sea_level_pressure")
+
+    def test_atmospheric_lookup(self):
+        self.assertEqual(atmospheric_wb2_name("z"), "geopotential")
+        self.assertEqual(atmospheric_wb2_name("q"), "specific_humidity")
+
+    def test_lookups_agree_with_the_tables(self):
+        for name in surface_variables:
+            with self.subTest(channel=name):
+                self.assertEqual(surface_wb2_name(name), surface_variables[name].name)
+        for prefix in atmospheric_variables:
+            with self.subTest(prefix=prefix):
+                self.assertEqual(atmospheric_wb2_name(prefix), atmospheric_variables[prefix].name)
+
+    def test_unknown_surface_name_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            surface_wb2_name("not_a_variable")
+        self.assertIn("not_a_variable", str(ctx.exception))
+        self.assertIn("Known names", str(ctx.exception))
+
+    def test_unknown_atmospheric_prefix_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            atmospheric_wb2_name("xyz")
+        self.assertIn("xyz", str(ctx.exception))
+        self.assertIn("Known prefixes", str(ctx.exception))
+
+    def test_atmospheric_prefix_is_not_a_full_channel_name(self):
+        # the accessor takes the prefix, not "z500"; passing the channel name is
+        # a mistake that has to fail rather than silently miss
+        with self.assertRaises(ValueError):
+            atmospheric_wb2_name("z500")
 
 
 # ===========================================================================
@@ -40,21 +85,21 @@ class TestMappingTables(unittest.TestCase):
 
     def test_inverse_surface_round_trips(self):
         for era5, wb2 in surface_variables.items():
-            self.assertEqual(surface_variables_inv[wb2], era5)
+            self.assertEqual(surface_variables_inv[wb2.name], era5)
 
     def test_inverse_atmospheric_round_trips(self):
         for era5, wb2 in atmospheric_variables.items():
-            self.assertEqual(atmospheric_variables_inv[wb2], era5)
+            self.assertEqual(atmospheric_variables_inv[wb2.name], era5)
 
     def test_known_surface_mappings(self):
-        self.assertEqual(surface_variables["u10m"], "10m_u_component_of_wind")
-        self.assertEqual(surface_variables["t2m"], "2m_temperature")
-        self.assertEqual(surface_variables["msl"], "mean_sea_level_pressure")
+        self.assertEqual(surface_variables["u10m"].name, "10m_u_component_of_wind")
+        self.assertEqual(surface_variables["t2m"].name, "2m_temperature")
+        self.assertEqual(surface_variables["msl"].name, "mean_sea_level_pressure")
 
     def test_known_atmospheric_mappings(self):
-        self.assertEqual(atmospheric_variables["z"], "geopotential")
-        self.assertEqual(atmospheric_variables["u"], "u_component_of_wind")
-        self.assertEqual(atmospheric_variables["t"], "temperature")
+        self.assertEqual(atmospheric_variables["z"].name, "geopotential")
+        self.assertEqual(atmospheric_variables["u"].name, "u_component_of_wind")
+        self.assertEqual(atmospheric_variables["t"].name, "temperature")
 
 
 # ===========================================================================

--- a/tests/test_wb2_helpers.py
+++ b/tests/test_wb2_helpers.py
@@ -16,6 +16,7 @@
 import unittest
 
 from makani.utils.dataloaders.wb2_helpers import (
+    Wb2Variable,
     surface_variables,
     atmospheric_variables,
     surface_variables_inv,
@@ -25,6 +26,44 @@ from makani.utils.dataloaders.wb2_helpers import (
     split_convert_channel_names,
     build_wb2_channel_map,
 )
+
+
+class TestVariableSemantics(unittest.TestCase):
+    """
+    The tables carry more than the WB2 name: the kind, the units and how the
+    variable relates to the channel in time. Those fields are what a converter
+    reasons about, and unlike the name they are never exercised by simply
+    reading a store, so they are pinned here.
+    """
+
+    def test_every_entry_is_a_descriptor(self):
+        for table in (surface_variables, atmospheric_variables):
+            for channel, variable in table.items():
+                with self.subTest(channel=channel):
+                    self.assertIsInstance(variable, Wb2Variable)
+                    self.assertTrue(variable.name)
+                    self.assertIn(variable.kind, ("pl", "sfc", "accum"))
+                    self.assertTrue(variable.units)
+
+    def test_atmospheric_entries_are_pressure_level(self):
+        for prefix, variable in atmospheric_variables.items():
+            with self.subTest(prefix=prefix):
+                self.assertEqual(variable.kind, "pl")
+
+    def test_instantaneous_surface_fields_do_not_accumulate(self):
+        for channel, variable in surface_variables.items():
+            if variable.kind == "sfc":
+                with self.subTest(channel=channel):
+                    self.assertEqual(variable.accumulation, "none")
+
+    def test_precipitation_carries_a_fixed_window(self):
+        # the window is baked into the WB2 name ("..._6hr"), so a store fixes it
+        # and the reader neither differences nor integrates anything
+        tp = surface_variables["tp"]
+
+        self.assertEqual(tp.name, "total_precipitation_6hr")
+        self.assertEqual(tp.kind, "accum")
+        self.assertEqual(tp.accumulation, "window")
 
 
 class TestNameLookups(unittest.TestCase):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -487,7 +487,7 @@ def init_wb2_zarr_dataset(
     Returns the same tuple as ``init_hdf5_dataset``/``init_zarr_dataset``
     (with ``concat_path=None``).
     """
-    from makani.utils.dataloaders.wb2_helpers import surface_variables, atmospheric_variables
+    from makani.utils.dataloaders.wb2_helpers import atmospheric_wb2_name, surface_wb2_name
 
     if channel_names is None:
         channel_names = list(CHANNEL_NAMES)
@@ -517,10 +517,10 @@ def init_wb2_zarr_dataset(
         if m is not None and ch_name != "d2":
             pressure = int(m.group())
             prefix = ch_name[: m.start()]
-            wb2_name = atmospheric_variables[prefix]
+            wb2_name = atmospheric_wb2_name(prefix)
             atm_vars.setdefault(wb2_name, set()).add(pressure)
         else:
-            surf_vars.add(surface_variables[ch_name])
+            surf_vars.add(surface_wb2_name(ch_name))
 
     # unified sorted level array covering all atmospheric variables in the fixture
     all_levels = sorted(set().union(*atm_vars.values())) if atm_vars else []


### PR DESCRIPTION
Groundwork for reading ICON model output. Adds the decoding and channel-mapping
  layer, and unifies the three data source readers onto one implementation of the
  channel grouping they had each grown their own copy of.
  
  ### Shared channel handling
     
  `makani/utils/features.py` now owns `split_channel_name`, the single definition
  of how a channel name splits into a variable prefix and a pressure level. It
  existed in three places before (`features`, `ncar_helpers`, `wb2_helpers`) and
  the copies had drifted: the wb2 one lacked the letter gate, so it classified 
  some names as atmospheric that the other two called surface.
  
  `makani/utils/dataloaders/channel_helpers.py` holds the grouping the readers
  share: `ChannelGroup`, `resolve_variable` and `build_channel_groups`. The NCAR
  and ICON readers now delegate to it, and `wb2_helpers` gains structured
  descriptors (`Wb2Variable`) carrying kind, units and accumulation semantics
  rather than bare strings.

A table entry distinguishes two cases that look identical in the data and mean
  the opposite: several **alternatives** (ICON reports precipitation as `tot_prec`
  *or* `pr`) versus several **components** that are summed (NCAR has no total
  precipitation, so `tp` is `lsp` *plus* `cp`). Getting that backwards is silent —
  half the precipitation, or a field no file can provide — so the nesting is
  explicit and both directions are tested.
  
  ### ICON helpers
     
  `icon_helpers.py` isolates what `h5py` does not do for a netCDF4 file:
  
  - **Time is not CF.** ICON writes `units = "day as %Y%m%d.%f"`, where
    `20170821.333333` is 2017-08-21 08:00. Read as a CF offset it yields dates 
    that are wrong but plausible.
  - **Values may be packed.** `scale_factor`/`add_offset` and `_FillValue` are
    applied by the netCDF library, not by HDF5. 
  - **Names are not standardized.** NWP setups write `temp`, `pres_msl`, `t_2m`;
    AES/CMIP setups write `ta`, `psl`, `tas`. Each channel maps to candidates,
    resolved against what a file actually contains.

Plus guards for the failures that are silent rather than loud: degrees mistaken
  for radians, Pa versus hPa level selection, and a mismatched grid UUID.
  
  The tables were checked against the EXCLAIM coupled DYAMOND run (R02B10, 83.9M
  cells): 37 ERA5 pressure levels, uncompressed float32, unstructured at cell
  centres. Hydrometeors map onto the ERA5 vocabulary (`clwc`, `ciwc`, `crwc`,
  `cswc`); `cswc` is built as `qs + qg`, since ERA5's snow content includes
  graupel and, at convection-resolving resolution, graupel dominates in deep
  convective cores.

### Also
    
  - `convert_makani_output_to_wb2.py` goes through accessors instead of indexing
    the wb2 tables, so their layout stays internal to `wb2_helpers`.
  - Smoke-import tests for the four `data_process` converters, which had no
    coverage at all and are not importable in CI (they import `mpi4py`).
  - `zarr>=3` and the other `pyproject` floors pinned in both Dockerfiles: makani
    is installed there with `--no-deps`, so `pyproject` constraints are never
    enforced and an unpinned `zarr` silently stayed at whatever the base image
    shipped — a v2 base breaks the zarr reader outright.
  
  ### Testing
  
  Full suite in the container: 2169 passed, 2 skipped, 3251 subtests. New
  coverage in `test_features.py`, `test_channel_helpers.py`, `test_icon_helpers.py`,
  and extensions to the ncar/wb2/data_process tests.
  
  ### Not included
  
  The ICON dataloader itself. It depends on a refactor of the dataloader stack
  into pluggable backends, which is in progress on a separate branch.