### PR TITLE
An ICON storage backend, reading the native icosahedral mesh

### DIFF
--- a/makani/utils/dataloader.py
+++ b/makani/utils/dataloader.py
@@ -118,6 +118,7 @@ def get_dataloader(params, files_pattern, device, mode="train", dali_device=None
             odirect_alignment=params.get("odirect_alignment", 0),
             io_grid=params.get("io_grid", [1, 1, 1]),
             io_rank=params.get("io_rank", [0, 0, 0]),
+            backend=params.get("dataset_backend", None),
         )
 
         if mode in ["train", "eval"]:

--- a/makani/utils/dataloaders/backends/__init__.py
+++ b/makani/utils/dataloaders/backends/__init__.py
@@ -15,10 +15,17 @@
 
 """Storage backends for the sample sources.
 
-Each backend knows how to find, open and read one dataset layout. They are
-consumed by :class:`makani.utils.dataloaders.sample_source.SampleSource`, which
-owns everything the layouts have in common: index arithmetic, shuffling, epoch
-cycling, window assembly and spatial sharding.
+Each backend knows how to find, open and read one dataset layout, and emits data
+on the grid that layout stores -- a lat/lon raster for the makani and
+WeatherBench2 formats, an icosahedral mesh for ICON. None of them resample.
+
+They are consumed by
+:class:`makani.utils.dataloaders.sample_source.SampleSource`, which feeds the
+DALI pipeline, and by
+:class:`makani.utils.dataloaders.data_loader_multifiles.MultifilesDataset`,
+which is the map style dataset inference uses. Both own what the layouts have in
+common: index arithmetic, window assembly, normalization and, for the training
+source, shuffling and epoch cycling.
 """
 
 from .base import DatasetBackend, BackendMetadata
@@ -26,6 +33,7 @@ from .makani_hdf5 import MakaniHDF5Backend
 from .makani_zarr import MakaniZarrBackend
 from .arco_wb2 import ArcoWB2Backend
 from .makani_concat import MakaniConcatBackend
+from .icon import IconBackend
 from .factory import get_backend
 
 __all__ = [
@@ -35,5 +43,6 @@ __all__ = [
     "MakaniZarrBackend",
     "ArcoWB2Backend",
     "MakaniConcatBackend",
+    "IconBackend",
     "get_backend",
 ]

--- a/makani/utils/dataloaders/backends/base.py
+++ b/makani/utils/dataloaders/backends/base.py
@@ -158,12 +158,16 @@ class BackendMetadata(NamedTuple):
     Attributes
     ----------
     files : list of str
-        Paths, in the order the sample index runs through them.
+        One entry per unit the sample index runs through, in order. For most
+        layouts a unit is a file. It need not be: a dataset that splits its
+        variables across files has a sample spanning several of them, and the
+        entry is then one representative path, with the backend holding the rest
+        internally. Nothing outside the backend opens these.
     labels : list of int
         A label per file, used for reporting and for deriving timestamps when a
         file carries none. For the makani layouts this is the year.
     samples_per_file : list of int
-        Number of samples in each file. The caller turns this into global
+        Number of samples in each unit. The caller turns this into global
         offsets; a backend never sees a global sample index.
     timestamps : numpy.ndarray
         One timezone aware datetime per sample, concatenated across files.
@@ -198,10 +202,13 @@ class DatasetBackend(abc.ABC):
         carries them, so that a dataset on a grid other than the assumed
         equiangular one is described by its own coordinates rather than by
         fabricated ones.
-    file_pattern : str
-        Glob for the file names, without the extension. The default ``"????"``
-        is the makani convention of a file per year; a dataset of arbitrarily
-        named files passes ``"*"`` and is ordered by time instead of by name.
+    file_pattern : str, optional
+        Glob for the file names, without the extension. Defaults to
+        :attr:`default_file_pattern`, which is whatever the layout names its
+        files: the makani layouts use ``"????"``, a file per year, while ICON
+        names its files after the variable and the date. A dataset of
+        arbitrarily named files in a makani layout passes ``"*"`` and is ordered
+        by time instead of by name.
     relative_timestamp : bool
         Whether the stored times are offsets rather than dates, as in a
         climatology indexed by time of year.
@@ -245,6 +252,11 @@ class DatasetBackend(abc.ABC):
         do about it: resampling still happens downstream.
     """
 
+    #: how this layout names its files, without the extension. Permissive here
+    #: because a layout that has no convention should not impose one; the makani
+    #: layouts override it with the year they are named after.
+    default_file_pattern: str = "*"
+
     #: attributes holding open file handles, dropped when pickled
     _handle_attributes: Tuple[str, ...] = ()
 
@@ -260,7 +272,7 @@ class DatasetBackend(abc.ABC):
         timestamp_name: str = "timestamp",
         latitude_name: str = "lat",
         longitude_name: str = "lon",
-        file_pattern: str = "????",
+        file_pattern: Optional[str] = None,
         relative_timestamp: bool = False,
         dhours: int = 6,
         channel_names: Optional[Sequence[str]] = None,
@@ -277,7 +289,7 @@ class DatasetBackend(abc.ABC):
         self.timestamp_name = timestamp_name
         self.latitude_name = latitude_name
         self.longitude_name = longitude_name
-        self.file_pattern = file_pattern
+        self.file_pattern = file_pattern if file_pattern is not None else self.default_file_pattern
         self.relative_timestamp = relative_timestamp
         self.dhours = dhours
         self.channel_names = channel_names

--- a/makani/utils/dataloaders/backends/factory.py
+++ b/makani/utils/dataloaders/backends/factory.py
@@ -19,11 +19,11 @@ Detection is by inspection, the way the loaders have always done it: a path
 that is a file is a concatenated dataset, a directory holding ``????.h5`` is the
 per-year HDF5 layout, one holding ``????.zarr`` is zarr -- and a zarr store that
 has no ``fields`` array is a WeatherBench2 store, whose variables are named
-individually.
+individually. A directory of netCDF files is ICON output on its native mesh.
 
-``file_pattern`` is the name to glob for, without the extension. It defaults to
-the makani convention of a file per year; a dataset of arbitrarily named files
-passes ``"*"``.
+``file_pattern`` is the name to glob for, without the extension. Left unset,
+each candidate layout is asked what it names its files, so a directory of
+``2017.h5`` and one of ``temp_..._20210601T000000Z.nc`` are both found.
 
 A run that knows what it has can name it outright and skip the guessing.
 """
@@ -34,6 +34,7 @@ from typing import Optional
 
 from .arco_wb2 import ArcoWB2Backend
 from .base import DatasetBackend
+from .icon import IconBackend
 from .makani_concat import MakaniConcatBackend
 from .makani_hdf5 import MakaniHDF5Backend
 from .makani_zarr import MakaniZarrBackend, zarr_open
@@ -43,10 +44,21 @@ BACKENDS = {
     "makani_zarr": MakaniZarrBackend,
     "makani_concat": MakaniConcatBackend,
     "arco_wb2": ArcoWB2Backend,
+    "icon": IconBackend,
+}
+
+#: options only some layouts understand, dropped for the others so that a run
+#: can carry them all in its config without every backend having to accept them
+LAYOUT_OPTIONS = {
+    MakaniHDF5Backend: ("enable_odirect", "odirect_alignment", "enable_s3"),
+    MakaniConcatBackend: ("enable_odirect", "odirect_alignment", "enable_s3"),
+    IconBackend: ("grid_file", "halo_degrees", "max_open_files"),
 }
 
 
-def detect_backend(location, dataset_name: str = "fields", enable_s3: bool = False, file_pattern: str = "????") -> str:
+def detect_backend(
+    location, dataset_name: str = "fields", enable_s3: bool = False, file_pattern: Optional[str] = None
+) -> str:
     """Name the backend that fits what is at ``location``."""
     locations = location if isinstance(location, list) else [location]
 
@@ -61,11 +73,17 @@ def detect_backend(location, dataset_name: str = "fields", enable_s3: bool = Fal
         return "makani_hdf5"
 
     for path in locations:
-        if glob.glob(os.path.join(path, f"{file_pattern}.h5")):
+        if glob.glob(os.path.join(path, f"{file_pattern or IconBackend.default_file_pattern}.nc")):
+            # netCDF is only used by the ICON layout here, so the extension is
+            # enough; nothing has to be opened to decide
+            return "icon"
+
+    for path in locations:
+        if glob.glob(os.path.join(path, f"{file_pattern or MakaniHDF5Backend.default_file_pattern}.h5")):
             return "makani_hdf5"
 
     for path in locations:
-        stores = sorted(glob.glob(os.path.join(path, f"{file_pattern}.zarr")))
+        stores = sorted(glob.glob(os.path.join(path, f"{file_pattern or MakaniZarrBackend.default_file_pattern}.zarr")))
         if stores:
             # the layouts share a container, so the store itself has to be asked
             return "makani_zarr" if dataset_name in zarr_open(stores[0]) else "arco_wb2"
@@ -91,7 +109,7 @@ def get_backend(location, backend: Optional[str] = None, **kwargs) -> DatasetBac
             location,
             dataset_name=kwargs.get("dataset_name", "fields"),
             enable_s3=kwargs.get("enable_s3", False),
-            file_pattern=kwargs.get("file_pattern", "????"),
+            file_pattern=kwargs.get("file_pattern"),
         )
 
     if backend not in BACKENDS:
@@ -99,9 +117,11 @@ def get_backend(location, backend: Optional[str] = None, **kwargs) -> DatasetBac
 
     backend_type = BACKENDS[backend]
 
-    # only the HDF5 layouts know what to do with these
-    if backend_type not in (MakaniHDF5Backend, MakaniConcatBackend):
-        for name in ("enable_odirect", "odirect_alignment", "enable_s3"):
-            kwargs.pop(name, None)
+    # a config may carry options for layouts other than the one in use
+    keep = LAYOUT_OPTIONS.get(backend_type, ())
+    for options in LAYOUT_OPTIONS.values():
+        for name in options:
+            if name not in keep:
+                kwargs.pop(name, None)
 
     return backend_type(location, **kwargs)

--- a/makani/utils/dataloaders/backends/factory.py
+++ b/makani/utils/dataloaders/backends/factory.py
@@ -52,7 +52,7 @@ BACKENDS = {
 LAYOUT_OPTIONS = {
     MakaniHDF5Backend: ("enable_odirect", "odirect_alignment", "enable_s3"),
     MakaniConcatBackend: ("enable_odirect", "odirect_alignment", "enable_s3"),
-    IconBackend: ("grid_file", "halo_degrees", "max_open_files"),
+    IconBackend: ("grid_file", "halo_degrees", "max_open_files", "enable_odirect", "odirect_alignment"),
 }
 
 

--- a/makani/utils/dataloaders/backends/icon.py
+++ b/makani/utils/dataloaders/backends/icon.py
@@ -1,0 +1,473 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ICON output, read on its native icosahedral mesh.
+
+Netcdf4 files of ``(time, level, ncells)``, one variable per file, on a grid
+whose coordinates live in a separate grid file. The mesh is emitted as it is
+stored: this backend does not resample, and the cells it hands out are labelled
+with their own latitude and longitude so that a layer downstream can put them
+wherever the model wants them.
+
+Three things make this layout different from the makani ones, and between them
+they account for most of what is here.
+
+**A sample spans several files.** Each variable is its own file, so the 72
+channels of a run come from a dozen of them. What the sample index runs through
+is therefore a *unit* rather than a file, and a unit is a stretch of the common
+time axis over which no variable changes file. The rest is bookkeeping: for
+every sample and every variable, which file and which index within it.
+
+**The variables do not share a time axis.** In the EXCLAIM DYAMOND output
+``temp`` is three hourly in daily files, ``u`` on altitude levels is hourly in
+daily files, and ``t_2m`` is hourly in monthly ones. The dataset's samples are
+the times that *all* the required variables have, which is their intersection.
+
+**Names alone do not identify a variable.** The same run writes two variables
+called ``u``, one on pressure levels and one on altitude levels. A makani
+channel like ``u500`` means the pressure level one, so candidates are resolved
+by the level coordinate they carry rather than by name.
+
+Reading
+-------
+Cells are selected geometrically -- see :mod:`.mesh` -- and read as slices. The
+files carry no compression filter, so a contiguous range costs about what its
+length suggests, while a strided or element-wise selection falls back to a
+gather that measures an order of magnitude slower. Everything here is therefore
+built to issue few, long, contiguous reads.
+
+Reads are issued one variable after another. Nothing is gained by threading
+them: h5py serializes calls into HDF5 behind a global lock, so concurrency has
+to come from running several workers, which is what the DALI pipeline already
+does.
+"""
+
+import glob
+import logging
+import os
+from collections import OrderedDict
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+import h5py
+import numpy as np
+
+from ..icon_helpers import (
+    build_icon_channel_groups,
+    check_grid_uuid,
+    decode_time,
+    decode_values,
+    grid_coordinates_in_degrees,
+    pressure_level_index,
+    pressure_levels_in_hpa,
+)
+from .base import BackendMetadata, DatasetBackend, GridSpec
+from .mesh import MeshChunkMixin
+
+#: level coordinates ICON writes, and what they mean for a makani channel
+PRESSURE_LEVEL_NAMES = ("plev", "pressure", "lev")
+SURFACE_LEVEL_NAMES = ("height", "height_2", "heightAboveGround", "alt", "altitude", "depth")
+
+
+class VariableSource(NamedTuple):
+    """Where one ICON variable's samples live, and on what levels.
+
+    Attributes
+    ----------
+    name : str
+        Variable name inside the files.
+    paths : list of str
+        Files carrying it, in time order.
+    times : numpy.ndarray
+        Every sample time it has, concatenated across those files.
+    path_of_sample, index_of_sample : numpy.ndarray
+        For each entry of ``times``, which file it is in and where in that file.
+    levels_hpa : numpy.ndarray, optional
+        Pressure levels in hPa, for a variable that has them.
+    level_name : str, optional
+        Name of the level coordinate, which is what tells a pressure level
+        variable from an altitude one of the same name.
+    """
+
+    name: str
+    paths: List[str]
+    times: np.ndarray
+    path_of_sample: np.ndarray
+    index_of_sample: np.ndarray
+    levels_hpa: Optional[np.ndarray]
+    level_name: Optional[str]
+
+    @property
+    def is_pressure(self) -> bool:
+        return self.level_name in PRESSURE_LEVEL_NAMES
+
+
+class Unit(NamedTuple):
+    """A stretch of the sample axis over which no variable changes file."""
+
+    start: int
+    n_samples: int
+    paths: Dict[str, str]
+
+
+class ChannelSource(NamedTuple):
+    """What one makani channel is read from."""
+
+    variable: str
+    level_index: int
+
+
+class IconBackend(MeshChunkMixin, DatasetBackend):
+    """Reads ICON output on its native mesh.
+
+    Parameters
+    ----------
+    grid_file : str
+        The ICON grid, which carries ``clon``/``clat``. Output files reference a
+        grid rather than containing one, so this cannot be inferred.
+    halo_degrees : float, optional
+        Margin around this rank's block, in degrees. Defaults to about three
+        cells, from the mesh's own spacing -- enough for an interpolation
+        stencil to reach past the block edge without a neighbour exchange.
+    max_open_files : int, optional
+        Handles to keep. A long run touches one file per variable per day, which
+        would otherwise accumulate.
+    """
+
+    #: named after the variable and the date, never after the year
+    default_file_pattern = "*"
+
+    _handle_attributes = ("files",)
+    _transient_attributes = MeshChunkMixin._transient_attributes
+
+    def __init__(
+        self,
+        *args,
+        grid_file: Optional[str] = None,
+        halo_degrees: Optional[float] = None,
+        max_open_files: int = 64,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        if grid_file is None:
+            raise ValueError(
+                "ICON output references its grid rather than carrying it, so grid_file is required: it is "
+                "the file holding clon/clat, named by the grid_file_uri attribute of the data."
+            )
+        if self.channel_names is None:
+            raise ValueError("ICON addresses variables by name, so channel_names is required.")
+
+        self.grid_file = grid_file
+        self.halo_degrees = halo_degrees
+        self.max_open_files = max_open_files
+
+        self.files: List = []
+        self.source_paths: List[str] = []
+        self.sources: Dict[str, VariableSource] = {}
+        self.units: List[Unit] = []
+        self.channel_plan: Dict[int, ChannelSource] = {}
+        self._open_order: "OrderedDict[str, int]" = OrderedDict()
+
+    # ---- discovery ---------------------------------------------------------
+
+    def _find_files(self) -> List[str]:
+        paths = []
+        for location in self.location:
+            paths += glob.glob(os.path.join(location, f"{self.file_pattern}.nc"))
+        return sorted(paths)
+
+    @staticmethod
+    def _data_variables(handle) -> List[str]:
+        """Variables that hold fields, as opposed to coordinates."""
+        return [
+            name
+            for name, obj in handle.items()
+            if isinstance(obj, h5py.Dataset) and obj.ndim == 3 and "coordinates" not in name
+        ]
+
+    def _level_coordinate(self, handle, dset) -> Tuple[Optional[str], Optional[np.ndarray]]:
+        """Name and values of the level axis, or None where there is none."""
+        for name in PRESSURE_LEVEL_NAMES + SURFACE_LEVEL_NAMES:
+            if name in handle and handle[name].shape == (dset.shape[1],):
+                values = np.asarray(handle[name])
+                if name in PRESSURE_LEVEL_NAMES:
+                    return name, pressure_levels_in_hpa(handle[name])
+                return name, values
+        return None, None
+
+    def _inspect(self, path: str, grid_uuid: Optional[str]) -> Dict[str, dict]:
+        """What one file contributes: its variables, their times and levels."""
+        found = {}
+        with h5py.File(path, "r") as handle:
+            check_grid_uuid(handle.attrs.get("uuidOfHGrid"), grid_uuid)
+
+            if self.timestamp_name not in handle and "time" not in handle:
+                raise ValueError(f"{path} carries no time coordinate, so its samples cannot be placed.")
+            time_key = self.timestamp_name if self.timestamp_name in handle else "time"
+            times = np.asarray(decode_time(handle[time_key][...], handle[time_key].attrs.get("units")))
+
+            for name in self._data_variables(handle):
+                dset = handle[name]
+                level_name, levels = self._level_coordinate(handle, dset)
+                found[name] = {
+                    "times": times,
+                    "n_cells": int(dset.shape[-1]),
+                    "level_name": level_name,
+                    "levels": levels,
+                }
+        return found
+
+    def _build_sources(self, files: List[str], grid_uuid: Optional[str]) -> Dict[str, VariableSource]:
+        """Collect every variable across every file, in time order.
+
+        A variable name can appear with two different level coordinates -- the
+        pressure level ``u`` and the altitude level one -- so sources are keyed
+        by name *and* level coordinate, and resolved to a channel later.
+        """
+        collected: Dict[Tuple[str, Optional[str]], dict] = {}
+
+        for path in files:
+            for name, info in self._inspect(path, grid_uuid).items():
+                key = (name, info["level_name"])
+                entry = collected.setdefault(
+                    key, {"paths": [], "times": [], "levels": info["levels"], "n_cells": info["n_cells"]}
+                )
+                entry["paths"].append(path)
+                entry["times"].append(info["times"])
+
+        sources = {}
+        for (name, level_name), entry in collected.items():
+            order = np.argsort([times[0] for times in entry["times"]])
+            paths = [entry["paths"][idx] for idx in order]
+            per_file = [entry["times"][idx] for idx in order]
+
+            times = np.concatenate(per_file)
+            path_of_sample = np.concatenate([np.full(len(part), idx) for idx, part in enumerate(per_file)])
+            index_of_sample = np.concatenate([np.arange(len(part)) for part in per_file])
+
+            sources[(name, level_name)] = VariableSource(
+                name=name,
+                paths=paths,
+                times=times,
+                path_of_sample=path_of_sample,
+                index_of_sample=index_of_sample,
+                levels_hpa=entry["levels"] if level_name in PRESSURE_LEVEL_NAMES else None,
+                level_name=level_name,
+            )
+        return sources
+
+    def _resolve_channels(self, sources: Dict[Tuple[str, Optional[str]], VariableSource]) -> Dict[int, ChannelSource]:
+        """Decide which variable and level each makani channel is read from."""
+        available = sorted({name for name, _ in sources})
+        groups = build_icon_channel_groups(list(self.channel_names), available=available)
+
+        plan: Dict[int, ChannelSource] = {}
+        for group in groups:
+            if group.kind == "accum":
+                raise NotImplementedError(
+                    f"Channel group '{group.name}' is accumulated, which needs differencing between "
+                    "consecutive outputs. That is a converter's job, not a reader's."
+                )
+            if len(group.variables) > 1:
+                raise NotImplementedError(
+                    f"Channel group '{group.name}' is the sum of several ICON variables, which this "
+                    "backend does not assemble."
+                )
+
+            wanted = group.variables[0].name
+            candidates = [source for (name, _), source in sources.items() if name == wanted]
+            if not candidates:
+                raise ValueError(f"Variable '{wanted}' is named by the channel table but not in the files.")
+
+            if group.kind == "pl":
+                # the disambiguation: two variables may share a name, and only
+                # the one on pressure levels can serve a pressure level channel
+                pressure = [source for source in candidates if source.is_pressure]
+                if not pressure:
+                    raise ValueError(
+                        f"Channel group '{group.name}' needs '{wanted}' on pressure levels, but the files "
+                        f"carry it on {[source.level_name for source in candidates]} only."
+                    )
+                source = pressure[0]
+                for channel_index, level in zip(group.channel_indices, group.levels):
+                    plan[channel_index] = ChannelSource(wanted, pressure_level_index(source.levels_hpa, level))
+            else:
+                source = next((c for c in candidates if not c.is_pressure), candidates[0])
+                plan[group.channel_indices[0]] = ChannelSource(wanted, 0)
+
+            self.sources[wanted] = source
+
+        missing = set(range(len(self.channel_names))) - set(plan)
+        if missing:
+            names = [self.channel_names[idx] for idx in sorted(missing)]
+            raise ValueError(f"No ICON variable resolved for channels {names}.")
+        return plan
+
+    def _common_times(self) -> np.ndarray:
+        """The times every required variable has."""
+        times = None
+        for source in self.sources.values():
+            available = set(source.times.tolist())
+            times = available if times is None else (times & available)
+        if not times:
+            raise ValueError(
+                "The required variables share no sample times. They are written at different cadences, "
+                "so the dataset is their intersection -- and here that is empty."
+            )
+        return np.array(sorted(times))
+
+    def _build_units(self, times: np.ndarray) -> List[Unit]:
+        """Split the sample axis wherever any variable changes file."""
+        locate = {}
+        for name, source in self.sources.items():
+            positions = np.searchsorted(source.times, times)
+            locate[name] = (source.path_of_sample[positions], source.index_of_sample[positions])
+
+        boundaries = np.zeros(len(times), dtype=bool)
+        boundaries[0] = True
+        for path_of_sample, _ in locate.values():
+            boundaries[1:] |= path_of_sample[1:] != path_of_sample[:-1]
+
+        starts = np.flatnonzero(boundaries)
+        stops = np.append(starts[1:], len(times))
+
+        units = []
+        for start, stop in zip(starts, stops):
+            paths = {name: self.sources[name].paths[locate[name][0][start]] for name in self.sources}
+            units.append(Unit(int(start), int(stop - start), paths))
+
+        self._sample_position = {name: locate[name][1] for name in self.sources}
+        return units
+
+    def _read_grid(self) -> GridSpec:
+        with h5py.File(self.grid_file, "r") as handle:
+            if "clon" not in handle or "clat" not in handle:
+                raise ValueError(f"{self.grid_file} has no clon/clat, so it is not an ICON grid file.")
+            lon, lat = grid_coordinates_in_degrees(handle["clon"][...], handle["clat"][...])
+            self.grid_uuid = handle.attrs.get("uuidOfHGrid")
+        return GridSpec("unstructured", (len(lat),), lat, lon)
+
+    def discover(self, enable_logging: bool = False) -> BackendMetadata:
+        files = self._find_files()
+        if not files:
+            locations = ", ".join(self.location)
+            raise IOError(f"Error, the specified file path(s) {locations} contain no netCDF files.")
+
+        grid = self._read_grid()
+        if self.halo_degrees is None:
+            self.halo_degrees = self.default_halo_degrees(grid.lat)
+
+        if enable_logging:
+            logging.info(f"Getting file stats from {len(files)} ICON files, grid {os.path.basename(self.grid_file)}")
+
+        sources = self._build_sources(files, getattr(self, "grid_uuid", None))
+        self.channel_plan = self._resolve_channels(sources)
+
+        times = self._common_times()
+        self.units = self._build_units(times)
+
+        self.source_paths = sorted({path for source in self.sources.values() for path in source.paths})
+        self.path_index = {path: idx for idx, path in enumerate(self.source_paths)}
+        self.files = [None] * len(self.source_paths)
+
+        self.chunk = self._resolve_chunk(grid)
+        self.metadata = BackendMetadata(
+            files=[unit.paths[next(iter(unit.paths))] for unit in self.units],
+            labels=[time.year for time in times[[unit.start for unit in self.units]]],
+            samples_per_file=[unit.n_samples for unit in self.units],
+            timestamps=times,
+            grid=grid,
+            total_channels=len(self.channel_names),
+        )
+        return self.metadata
+
+    # ---- handles -----------------------------------------------------------
+
+    def open(self, file_idx: int) -> None:
+        """Open every file the unit needs, dropping the least recently used."""
+        for path in self.units[file_idx].paths.values():
+            self._handle(path)
+
+    def _handle(self, path: str):
+        index = self.path_index[path]
+        if self.files[index] is None:
+            self.files[index] = h5py.File(path, "r")
+        self._open_order[path] = index
+        self._open_order.move_to_end(path)
+
+        while len(self._open_order) > self.max_open_files:
+            stale, stale_index = self._open_order.popitem(last=False)
+            handle, self.files[stale_index] = self.files[stale_index], None
+            if handle is not None:
+                handle.close()
+
+        return self.files[index]
+
+    def _restore(self) -> None:
+        # handles and the read buffer are both rebuilt lazily in the worker
+        self._open_order = OrderedDict()
+        self._buffer = None
+
+    # ---- reading -----------------------------------------------------------
+
+    @staticmethod
+    def _packing(attributes) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+        """Fill value and packing parameters of one variable."""
+        fill = attributes.get("_FillValue", attributes.get("missing_value"))
+        return fill, attributes.get("scale_factor"), attributes.get("add_offset")
+
+    def _decode_into(self, values, destination, fill, scale_factor, add_offset) -> None:
+        """Write decoded values into ``destination``, without a copy where possible.
+
+        The general path goes through :func:`~..icon_helpers.decode_values`,
+        which matches fill values against the *raw* data before unpacking, as CF
+        requires. That matters when a variable is packed, because the sentinel
+        is an integer and comparing it after conversion to float is not the same
+        test. Unpacked data -- which is what ICON writes here -- has no such
+        ordering constraint, so the values can be copied straight in and the
+        fills replaced in place.
+        """
+        if scale_factor is None and add_offset is None:
+            np.copyto(destination, values, casting="same_kind")
+            if fill is not None:
+                destination[destination == np.asarray(fill).reshape(()).astype(destination.dtype)] = np.nan
+            return
+
+        destination[...] = decode_values(values, fill_value=fill, scale_factor=scale_factor, add_offset=add_offset)
+
+    def read(self, file_idx, time_slice, channels, out=None):
+        unit = self.units[file_idx]
+        local_indices = list(range(*time_slice.indices(unit.n_samples)))
+
+        if out is None:
+            out = np.empty((len(local_indices), len(channels), *self.chunk.shape), dtype=np.float32)
+
+        for position, channel in enumerate(channels):
+            plan = self.channel_plan[int(channel)]
+            dset = self._handle(unit.paths[plan.variable])[plan.variable]
+            fill, scale_factor, add_offset = self._packing(dset.attrs)
+
+            for step, local_idx in enumerate(local_indices):
+                time_idx = int(self._sample_position[plan.variable][unit.start + local_idx])
+
+                # bound explicitly: the reader is called once per run, and reading
+                # a loop variable through a closure is how that goes subtly wrong
+                def read_run(run, destination, dset=dset, time_idx=time_idx, level=plan.level_index):
+                    dset.read_direct(destination, np.s_[time_idx, level, run], np.s_[:])
+
+                values = self._gather_runs(read_run, dset.dtype)
+                self._decode_into(values, out[step, position, :], fill, scale_factor, add_offset)
+
+        return out

--- a/makani/utils/dataloaders/backends/icon.py
+++ b/makani/utils/dataloaders/backends/icon.py
@@ -143,6 +143,16 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
     max_open_files : int, optional
         Handles to keep. A long run touches one file per variable per day, which
         would otherwise accumulate.
+    enable_odirect : bool
+        Read through the O_DIRECT driver, bypassing the page cache. Worth more
+        here than for the makani layouts: a training run reads tens of gigabytes
+        per sample and never reads any of it twice, so everything it pulls
+        through the cache is eviction pressure on something else. The cost is
+        that a read shorter than the alignment is rounded up, which is why the
+        selection is coalesced into long runs first.
+    odirect_alignment : int
+        Alignment and block size for O_DIRECT, when the default does not suit
+        the filesystem.
     """
 
     #: named after the variable and the date, never after the year
@@ -157,6 +167,8 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
         grid_file: Optional[str] = None,
         halo_degrees: Optional[float] = None,
         max_open_files: int = 64,
+        enable_odirect: bool = False,
+        odirect_alignment: int = 0,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -172,6 +184,11 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
         self.grid_file = grid_file
         self.halo_degrees = halo_degrees
         self.max_open_files = max_open_files
+
+        self.file_driver = "direct" if enable_odirect else None
+        self.file_driver_kwargs = {}
+        if enable_odirect and odirect_alignment > 0:
+            self.file_driver_kwargs = dict(alignment=odirect_alignment, block_size=odirect_alignment)
 
         self.files: List = []
         self.source_paths: List[str] = []
@@ -403,7 +420,7 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
     def _handle(self, path: str):
         index = self.path_index[path]
         if self.files[index] is None:
-            self.files[index] = h5py.File(path, "r")
+            self.files[index] = h5py.File(path, "r", driver=self.file_driver, **self.file_driver_kwargs)
         self._open_order[path] = index
         self._open_order.move_to_end(path)
 

--- a/makani/utils/dataloaders/backends/makani_hdf5.py
+++ b/makani/utils/dataloaders/backends/makani_hdf5.py
@@ -37,7 +37,13 @@ from torch_harmonics.distributed import compute_split_shapes
 
 from ..aws_connector import get_default_aws_connector
 from ..data_helpers import get_lat_lon_grid, get_timestamp
-from .base import BackendMetadata, DatasetBackend, GridSpec, order_files_by_time, timestamp_converter
+from .base import (
+    BackendMetadata,
+    DatasetBackend,
+    GridSpec,
+    order_files_by_time,
+    timestamp_converter,
+)
 
 
 def contiguous_slices(indices: Sequence[int]):
@@ -114,6 +120,9 @@ class MakaniHDF5Backend(StructuredChunkMixin, DatasetBackend):
         exclusive with O_DIRECT, and disables ``read_direct``, which the ROS3
         driver does not support.
     """
+
+    #: one file per year, named after it
+    default_file_pattern = "????"
 
     _handle_attributes = ("files", "dsets")
     # the S3 connector holds a session that does not survive pickling

--- a/makani/utils/dataloaders/backends/makani_zarr.py
+++ b/makani/utils/dataloaders/backends/makani_zarr.py
@@ -36,7 +36,13 @@ import zarr
 from zarr.core.buffer.cpu import NDBuffer as _ZarrNDBuffer
 
 from ..data_helpers import get_lat_lon_grid, get_timestamp
-from .base import BackendMetadata, DatasetBackend, GridSpec, order_files_by_time, timestamp_converter
+from .base import (
+    BackendMetadata,
+    DatasetBackend,
+    GridSpec,
+    order_files_by_time,
+    timestamp_converter,
+)
 from .makani_hdf5 import StructuredChunkMixin, contiguous_slices
 
 
@@ -64,6 +70,9 @@ def zarr_open(path, mode="r"):
 
 class MakaniZarrBackend(StructuredChunkMixin, DatasetBackend):
     """Reads the makani layout from zarr, one store per year."""
+
+    #: one store per year, named after it
+    default_file_pattern = "????"
 
     _handle_attributes = ("files", "dsets")
 

--- a/makani/utils/dataloaders/backends/mesh.py
+++ b/makani/utils/dataloaders/backends/mesh.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deciding which cells of a mesh a rank reads.
+
+The counterpart of :class:`~.makani_hdf5.StructuredChunkMixin` for data that has
+no raster structure. A raster chunk is a rectangle, and saying which one takes
+four numbers. A mesh has a flat list of cells in whatever order the model wrote
+them, so the question "which cells belong to this rank" has to be answered
+geometrically, against the grid the run will *use* rather than the one the data
+is stored on.
+
+That is what ``target_grid`` is for. The rank's share of the target raster is a
+lat/lon block; the cells it needs are the ones inside that block, plus a margin,
+because interpolating onto a point near the edge reaches for cells beyond it.
+
+Reading the selection
+---------------------
+Cells that are wanted are not contiguous in storage, and how badly they are
+scattered is a property of the mesh ordering. ICON's is good: it follows the
+icosahedral root triangles, so a compact region on the sphere lands in a handful
+of long runs rather than millions of isolated cells. That matters more than it
+sounds, because a strided or element-wise selection through HDF5 falls back to a
+gather and measures about ten times slower than reading the same bytes in one
+piece.
+
+So the selection is turned into slices, and short gaps between them are bridged
+rather than split: a read costs a fixed amount before it moves a byte, so
+reading *through* a gap is cheaper than paying for another read. ``merge_gap``
+is where that trade sits, in cells.
+"""
+
+from typing import List, Sequence, Tuple
+
+import numpy as np
+from torch_harmonics.distributed import compute_split_shapes
+
+from .base import GridSpec
+
+
+def coalesce_runs(indices: np.ndarray, merge_gap: int = 0) -> List[slice]:
+    """Turn sorted cell indices into slices, bridging gaps up to ``merge_gap``.
+
+    A gap shorter than ``merge_gap`` is read through rather than skipped, since
+    one larger read beats two smaller ones once the fixed cost of a read exceeds
+    the cost of the bytes bridged.
+    """
+    if len(indices) == 0:
+        return []
+
+    indices = np.asarray(indices)
+    # a new run starts wherever the step from the previous index is bigger than
+    # the gap we are willing to read through
+    breaks = np.flatnonzero(np.diff(indices) > merge_gap + 1) + 1
+    starts = np.concatenate(([0], breaks))
+    stops = np.concatenate((breaks, [len(indices)]))
+
+    return [slice(int(indices[start]), int(indices[stop - 1]) + 1) for start, stop in zip(starts, stops)]
+
+
+def block_of_rank(axis: np.ndarray, io_grid: Sequence[int], io_rank: Sequence[int], dim: int) -> Tuple[float, float]:
+    """The span of a target axis this rank is responsible for."""
+    splits = compute_split_shapes(len(axis), io_grid[dim])
+    start = sum(splits[: io_rank[dim]])
+    stop = start + splits[io_rank[dim]]
+    return float(axis[start]), float(axis[stop - 1])
+
+
+def within_longitudes(lon: np.ndarray, low: float, high: float) -> np.ndarray:
+    """Mask of longitudes inside ``[low, high]``, the short way round the sphere.
+
+    Longitude wraps, so a block running from 350 to 10 degrees is two intervals
+    in the coordinate but one region on the sphere. Comparing against a shifted
+    origin keeps it one test either way.
+    """
+    if high - low >= 360.0:
+        return np.ones_like(lon, dtype=bool)
+    return np.mod(lon - low, 360.0) <= np.mod(high - low, 360.0)
+
+
+class MeshChunkMixin:
+    """Selects this rank's cells from an unstructured grid.
+
+    Expects the backend to carry ``target_grid``, ``io_grid``, ``io_rank`` and
+    ``halo_degrees``, and sets ``cell_index`` (the selected cells, ascending),
+    ``cell_runs`` (how they will be read) and ``read_shape``.
+    """
+
+    #: cells to read through rather than break a read for; see the module note
+    merge_gap: int = 1 << 20
+
+    #: the read buffer is scratch space, rebuilt on demand rather than shipped
+    #: to a worker process
+    _transient_attributes = ("_buffer",)
+
+    def _reject_raster_options(self) -> None:
+        """Refuse the options that only mean something on a raster."""
+        if self.subsampling_factor != 1:
+            raise ValueError(
+                "subsampling_factor has no meaning on an unstructured grid, where index order is not a "
+                "spatial pattern. Choose a coarser target_grid instead."
+            )
+        if any(size is not None for size in self.crop_size) or any(anchor != 0 for anchor in self.crop_anchor):
+            raise ValueError(
+                "crop_size and crop_anchor describe a rectangle of a raster, which an unstructured grid "
+                "does not have. Restrict the target_grid instead."
+            )
+
+    def _resolve_chunk(self, grid: GridSpec) -> GridSpec:
+        self._reject_raster_options()
+
+        decomposed = any(size > 1 for size in self.io_grid)
+        if decomposed and self.target_grid is None:
+            raise ValueError(
+                "An unstructured dataset needs target_grid to decompose: which cells a rank reads is "
+                "decided by the region of the target grid it is responsible for, and a mesh has no rows "
+                "and columns to split instead."
+            )
+
+        if not decomposed:
+            # one rank, so the chunk is the whole mesh and nothing has to be selected
+            self.cell_index = np.arange(grid.shape[0])
+            self.cell_runs = [slice(0, grid.shape[0])]
+            self._plan_compaction()
+            self.read_anchor = [0]
+            self.read_shape = [int(grid.shape[0])]
+            return grid
+
+        halo = self.halo_degrees
+        lat_low, lat_high = block_of_rank(self.target_grid.lat, self.io_grid, self.io_rank, 0)
+        lon_low, lon_high = block_of_rank(self.target_grid.lon, self.io_grid, self.io_rank, 1)
+
+        # latitudes may run either way; the block is the interval between them
+        lat_low, lat_high = min(lat_low, lat_high), max(lat_low, lat_high)
+
+        inside = (grid.lat >= lat_low - halo) & (grid.lat <= lat_high + halo)
+        if self.io_grid[1] > 1:
+            inside &= within_longitudes(grid.lon, lon_low - halo, lon_high + halo)
+
+        self.cell_index = np.flatnonzero(inside)
+        if len(self.cell_index) == 0:
+            raise ValueError(
+                f"No cells fall in this rank's block (lat {lat_low:.2f} to {lat_high:.2f}, "
+                f"lon {lon_low:.2f} to {lon_high:.2f}, halo {halo:.3f} degrees). The target grid and the "
+                "mesh may not describe the same sphere."
+            )
+
+        self.cell_runs = coalesce_runs(self.cell_index, self.merge_gap)
+        self._plan_compaction()
+        self.read_anchor = [int(self.cell_index[0])]
+        self.read_shape = [int(self.cell_index[-1] - self.cell_index[0] + 1)]
+
+        return GridSpec(
+            kind=grid.kind,
+            shape=(len(self.cell_index),),
+            lat=grid.lat[self.cell_index],
+            lon=grid.lon[self.cell_index],
+        )
+
+    def _plan_compaction(self) -> None:
+        """Work out once how the runs map onto the cells that are kept.
+
+        The runs are read whole because that is what storage is fast at, so the
+        cells bridged by ``merge_gap`` come along and have to be dropped. Where
+        they land in the concatenated runs depends only on the selection, so it
+        is settled here rather than recomputed on every read.
+        """
+        self.run_offsets = np.cumsum([0] + [run.stop - run.start for run in self.cell_runs])
+        self.run_span = int(self.run_offsets[-1])
+        # nothing was bridged, so the runs already are the cells, in order
+        self.runs_are_exact = self.run_span == len(self.cell_index)
+
+        if self.runs_are_exact:
+            self.compact_index = None
+            return
+
+        offsets = []
+        for position, run in zip(self.run_offsets[:-1], self.cell_runs):
+            take = self.cell_index[(self.cell_index >= run.start) & (self.cell_index < run.stop)]
+            offsets.append(position + (take - run.start))
+        self.compact_index = np.concatenate(offsets)
+
+    def _run_buffer(self, dtype) -> np.ndarray:
+        """A buffer holding one field over the runs, reused across reads.
+
+        Its size is fixed by the selection, and a read fills it completely, so
+        there is nothing to gain from allocating it again per channel and per
+        timestep -- which at a few tens of megabytes a time is worth avoiding.
+        """
+        buffer = getattr(self, "_buffer", None)
+        if buffer is None or buffer.dtype != dtype or buffer.shape[0] != self.run_span:
+            buffer = np.empty(self.run_span, dtype=dtype)
+            self._buffer = buffer
+        return buffer
+
+    def _gather_runs(self, read_run, dtype) -> np.ndarray:
+        """Read every run into the shared buffer and return the cells kept.
+
+        The result aliases the buffer when nothing was bridged, so a caller that
+        keeps it has to copy; every caller here writes it straight into an
+        output array.
+        """
+        buffer = self._run_buffer(dtype)
+        for start, stop, run in zip(self.run_offsets[:-1], self.run_offsets[1:], self.cell_runs):
+            read_run(run, buffer[start:stop])
+
+        return buffer if self.runs_are_exact else buffer[self.compact_index]
+
+    @staticmethod
+    def default_halo_degrees(lat: np.ndarray, factor: float = 3.0) -> float:
+        """A margin a few cells wide, from the mesh's own spacing.
+
+        The spacing is estimated from the cell count rather than from the
+        neighbour tables, which a data file does not carry: a mesh of ``n`` cells
+        covering the sphere has cells of about ``sqrt(4 pi / n)`` radians across.
+        """
+        spacing = np.degrees(np.sqrt(4.0 * np.pi / max(len(lat), 1)))
+        return float(factor * spacing)

--- a/makani/utils/dataloaders/data_loader_multifiles.py
+++ b/makani/utils/dataloaders/data_loader_multifiles.py
@@ -82,6 +82,7 @@ class MultifilesDataset(Dataset):
         io_grid: Optional[List[int]] = [1, 1, 1],
         io_rank: Optional[List[int]] = [0, 0, 0],
         enable_logging: Optional[bool] = True,
+        backend: Optional[str] = None,
         **kwargs,
     ):
 
@@ -105,6 +106,7 @@ class MultifilesDataset(Dataset):
         self.enable_s3 = enable_s3
         self.enable_odirect = enable_odirect
         self.odirect_alignment = odirect_alignment
+        self.backend_name = backend
 
         # channels are read in ascending order because that is the only order
         # storage can serve efficiently, then permuted back into the requested one
@@ -171,6 +173,7 @@ class MultifilesDataset(Dataset):
         # dataset is not necessarily a file per year
         self.backend = get_backend(
             self.location,
+            backend=self.backend_name,
             dataset_name=self.dataset_name,
             timestamp_name=self.timestamp_name,
             channel_names=self.channel_names,

--- a/tests/test_data_backends.py
+++ b/tests/test_data_backends.py
@@ -16,10 +16,11 @@
 """
 Unit tests for the storage backends.
 
-``test_sample_source.py`` drives all four backends end to end through
+``test_sample_source.py`` drives the raster backends end to end through
 ``SampleSource``, which covers the read path thoroughly. What it cannot see are
 the properties that hold *between* the pieces, and those are what this file
-pins:
+pins -- along with the whole of the ICON backend, which no end to end suite
+reaches yet because nothing downstream consumes an unstructured grid:
 
 * **coordinates match the data.** A backend promises that ``chunk.lat`` and
   ``chunk.lon`` give the position of every value it emits. Nothing downstream
@@ -34,6 +35,13 @@ pins:
 * **pickling.** ``test_pickle_roundtrip`` covers handles, but only for local
   files; the connection a remote backend holds is dropped by different
   machinery.
+* **times are absolute.** Ordering and a non-null timezone are cheap to satisfy
+  while still being wrong by an epoch, an offset or a unit, so the first sample
+  of every layout is checked against the time it was written at.
+* **which cells a rank reads,** for the mesh: that the runs cover the selection,
+  that a target point's neighbours are on the same rank, and that the values and
+  the coordinates emitted describe the same cells. All three are silent when
+  wrong -- the arrays stay self consistent and the field is scrambled.
 
 These need neither DALI nor a GPU, so unlike the end to end suite they run in
 CI.
@@ -53,6 +61,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from makani.utils.dataloaders.backends import (
     ArcoWB2Backend,
+    IconBackend,
     BackendMetadata,
     MakaniConcatBackend,
     MakaniHDF5Backend,
@@ -62,9 +71,17 @@ from makani.utils.dataloaders.backends import (
 from makani.utils.dataloaders.backends.base import GridSpec
 from makani.utils.dataloaders.backends.factory import detect_backend
 from makani.utils.dataloaders.backends.makani_hdf5 import contiguous_slices
+from makani.utils.dataloaders.backends.mesh import block_of_rank, coalesce_runs
 
 from .testutils import (
     CHANNEL_NAMES,
+    ICON_FILL,
+    ICON_FILL_CELLS,
+    ICON_N_CELLS,
+    ICON_PLEV_HPA,
+    compare_arrays,
+    icon_expected_field,
+    init_icon_dataset,
     DHOURS,
     NUM_SAMPLES_PER_YEAR,
     TRAIN_YEARS,
@@ -104,6 +121,67 @@ class TestContiguousSlices(unittest.TestCase):
         indices = [1, 2, 3, 9, 10, 40]
         covered = [i for s in contiguous_slices(indices) for i in range(s.start, s.stop)]
         self.assertEqual(covered, indices)
+
+
+class TestCoalesceRuns(unittest.TestCase):
+    """Turning selected cells into the reads that fetch them.
+
+    Like ``contiguous_slices``, a broken version still returns the right data:
+    the cells are all there, just fetched in more reads, or in one read far
+    larger than it needed to be. Only the slices themselves show it, so they are
+    asserted directly.
+    """
+
+    def test_adjacent_cells_are_one_run(self):
+        self.assertEqual(coalesce_runs(np.array([4, 5, 6])), [slice(4, 7)])
+
+    def test_a_gap_splits_the_run(self):
+        self.assertEqual(coalesce_runs(np.array([0, 1, 2, 7, 8])), [slice(0, 3), slice(7, 9)])
+
+    def test_a_short_gap_is_read_through(self):
+        # one read of nine cells beats two reads of three and two, once the
+        # fixed cost of a read exceeds the four cells bridged
+        self.assertEqual(coalesce_runs(np.array([0, 1, 2, 7, 8]), merge_gap=4), [slice(0, 9)])
+
+    def test_the_gap_is_a_limit_not_a_hint(self):
+        # the gap here is five cells, one more than allowed, so it still splits
+        self.assertEqual(coalesce_runs(np.array([0, 1, 2, 8, 9]), merge_gap=4), [slice(0, 3), slice(8, 10)])
+
+    def test_empty(self):
+        self.assertEqual(coalesce_runs(np.array([], dtype=int)), [])
+
+    def test_single_cell(self):
+        self.assertEqual(coalesce_runs(np.array([5])), [slice(5, 6)])
+
+    def test_runs_cover_every_selected_cell(self):
+        """The property that makes bridging safe: nothing is dropped.
+
+        A cell that falls outside every run is read as whatever the buffer held,
+        which is silent and looks like data.
+        """
+        selection = np.sort(np.random.default_rng(0).choice(10_000, 500, replace=False))
+        for merge_gap in (0, 8, 64, 1024):
+            with self.subTest(merge_gap=merge_gap):
+                covered = np.concatenate(
+                    [np.arange(run.start, run.stop) for run in coalesce_runs(selection, merge_gap)]
+                )
+                self.assertTrue(np.all(np.isin(selection, covered)))
+
+    def test_bridging_trades_reads_for_bytes(self):
+        """Fewer reads with a larger gap, and every surviving gap is a real one."""
+        selection = np.sort(np.random.default_rng(0).choice(10_000, 500, replace=False))
+
+        tight = coalesce_runs(selection, 0)
+        loose = coalesce_runs(selection, 1024)
+
+        self.assertLess(len(loose), len(tight))
+
+        # whatever the setting, a gap that was left unbridged has to be wider
+        # than the one we were willing to read through
+        for merge_gap, runs in ((0, tight), (1024, loose)):
+            with self.subTest(merge_gap=merge_gap):
+                gaps = [later.start - earlier.stop for earlier, later in zip(runs, runs[1:])]
+                self.assertTrue(all(gap > merge_gap for gap in gaps))
 
 
 class TestGridSpec(unittest.TestCase):
@@ -252,6 +330,19 @@ class TestDiscovery(_BackendFixture):
         self.assertIsNotNone(metadata.timestamps[0].tzinfo)
         self.assertTrue(all(a < b for a, b in zip(metadata.timestamps, metadata.timestamps[1:])))
 
+    def test_annotated_timestamps_are_the_times_the_file_carries(self):
+        """The times a file was annotated with, read back as they were written.
+
+        Ordering and a non-null timezone are cheap to satisfy while still being
+        wrong by an epoch, an offset or a unit. The fixture writes the first
+        sample at midnight UTC on new year, so that is what has to come back.
+        """
+        metadata = get_backend(self.train_path).discover()
+
+        self.assertEqual(metadata.timestamps[0], dt.datetime(TRAIN_YEARS[0], 1, 1, tzinfo=dt.timezone.utc))
+        self.assertEqual(metadata.timestamps[1] - metadata.timestamps[0], dt.timedelta(hours=DHOURS))
+        self.assertEqual(metadata.timestamps[0].utcoffset(), dt.timedelta(0))
+
     def test_labels_are_the_years(self):
         metadata = get_backend(self.train_path).discover()
 
@@ -290,8 +381,8 @@ class TestChunkCoordinates(_BackendFixture):
         backend = self._backend()
 
         self.assertEqual(backend.chunk.shape, (IMG_SIZE_H, IMG_SIZE_W))
-        np.testing.assert_allclose(backend.chunk.lat, backend.metadata.grid.lat)
-        np.testing.assert_allclose(backend.chunk.lon, backend.metadata.grid.lon)
+        self.assertTrue(compare_arrays("backend.chunk.lat", backend.chunk.lat, backend.metadata.grid.lat))
+        self.assertTrue(compare_arrays("backend.chunk.lon", backend.chunk.lon, backend.metadata.grid.lon))
 
     def test_coordinate_lengths_match_the_chunk_shape(self):
         for io_grid, io_rank in [([1, 1], [0, 0]), ([2, 1], [1, 0]), ([2, 2], [1, 1]), ([3, 1], [2, 0])]:
@@ -309,8 +400,16 @@ class TestChunkCoordinates(_BackendFixture):
 
         lat_start = backend.read_anchor[0]
         lon_start = backend.read_anchor[1]
-        np.testing.assert_allclose(backend.chunk.lat, grid.lat[lat_start : lat_start + backend.read_shape[0]])
-        np.testing.assert_allclose(backend.chunk.lon, grid.lon[lon_start : lon_start + backend.read_shape[1]])
+        self.assertTrue(
+            compare_arrays(
+                "backend.chunk.lat", backend.chunk.lat, grid.lat[lat_start : lat_start + backend.read_shape[0]]
+            )
+        )
+        self.assertTrue(
+            compare_arrays(
+                "backend.chunk.lon", backend.chunk.lon, grid.lon[lon_start : lon_start + backend.read_shape[1]]
+            )
+        )
 
     def test_chunks_tile_the_grid_without_gaps_or_overlap(self):
         # every latitude of the global grid is claimed by exactly one rank
@@ -319,7 +418,7 @@ class TestChunkCoordinates(_BackendFixture):
             backend = self._backend(io_grid=[3, 1], io_rank=[rank, 0])
             claimed.append(backend.chunk.lat)
 
-        np.testing.assert_allclose(np.concatenate(claimed), backend.metadata.grid.lat)
+        self.assertTrue(compare_arrays("np.concatenate(claimed)", np.concatenate(claimed), backend.metadata.grid.lat))
 
     def test_data_at_a_coordinate_is_the_data_at_that_coordinate(self):
         """Read a decomposed chunk and check it against the same region read whole.
@@ -345,13 +444,13 @@ class TestChunkCoordinates(_BackendFixture):
             lon_offset : lon_offset + part.chunk.shape[1],
         ]
 
-        np.testing.assert_allclose(chunk, expected)
+        self.assertTrue(compare_arrays("chunk", chunk, expected))
 
     def test_subsampling_takes_every_nth_coordinate(self):
         backend = self._backend(subsampling_factor=2)
 
-        np.testing.assert_allclose(backend.chunk.lat, backend.metadata.grid.lat[::2])
-        np.testing.assert_allclose(backend.chunk.lon, backend.metadata.grid.lon[::2])
+        self.assertTrue(compare_arrays("backend.chunk.lat", backend.chunk.lat, backend.metadata.grid.lat[::2]))
+        self.assertTrue(compare_arrays("backend.chunk.lon", backend.chunk.lon, backend.metadata.grid.lon[::2]))
 
     def test_crop_decomposition_and_subsampling_compose(self):
         """All three narrow the chunk, and they are applied in one place.
@@ -376,8 +475,8 @@ class TestChunkCoordinates(_BackendFixture):
         expected_lat = grid.lat[expected_start : crop_anchor[0] + crop_size[0] : 2]
         expected_lon = grid.lon[crop_anchor[1] : crop_anchor[1] + crop_size[1] : 2]
 
-        np.testing.assert_allclose(backend.chunk.lat, expected_lat)
-        np.testing.assert_allclose(backend.chunk.lon, expected_lon)
+        self.assertTrue(compare_arrays("backend.chunk.lat", backend.chunk.lat, expected_lat))
+        self.assertTrue(compare_arrays("backend.chunk.lon", backend.chunk.lon, expected_lon))
         self.assertEqual(backend.chunk.shape, (len(expected_lat), len(expected_lon)))
 
     def test_crop_beyond_the_grid_raises(self):
@@ -428,7 +527,7 @@ class TestLifecycle(_BackendFixture):
         backend.close()
         after = backend.read(0, slice(0, 1), channels)
 
-        np.testing.assert_allclose(before, after)
+        self.assertTrue(compare_arrays("before", before, after))
 
 
 class TestConcatBackend(_BackendFixture):
@@ -486,7 +585,7 @@ class TestPickling(_BackendFixture):
         restored = pickle.loads(pickle.dumps(backend))
         after = restored.read(0, slice(0, 2), channels)
 
-        np.testing.assert_allclose(before, after)
+        self.assertTrue(compare_arrays("before", before, after))
 
     def test_roundtrip_preserves_the_chunk(self):
         backend = get_backend(self.train_path, io_grid=[2, 2], io_rank=[0, 1])
@@ -495,8 +594,8 @@ class TestPickling(_BackendFixture):
         restored = pickle.loads(pickle.dumps(backend))
 
         self.assertEqual(restored.chunk.shape, backend.chunk.shape)
-        np.testing.assert_allclose(restored.chunk.lat, backend.chunk.lat)
-        np.testing.assert_allclose(restored.chunk.lon, backend.chunk.lon)
+        self.assertTrue(compare_arrays("restored.chunk.lat", restored.chunk.lat, backend.chunk.lat))
+        self.assertTrue(compare_arrays("restored.chunk.lon", restored.chunk.lon, backend.chunk.lon))
 
 
 class TestReading(_BackendFixture):
@@ -521,7 +620,7 @@ class TestReading(_BackendFixture):
         out = np.zeros_like(allocated)
         backend.read(0, slice(0, 2), channels, out=out)
 
-        np.testing.assert_allclose(allocated, out)
+        self.assertTrue(compare_arrays("allocated", allocated, out))
 
     def test_channel_subset_is_read_in_order(self):
         backend = get_backend(self.train_path)
@@ -530,8 +629,8 @@ class TestReading(_BackendFixture):
         every = backend.read(0, slice(0, 1), np.arange(NUM_CHANNELS))
         subset = backend.read(0, slice(0, 1), np.array([0, 2]))
 
-        np.testing.assert_allclose(subset[:, 0], every[:, 0])
-        np.testing.assert_allclose(subset[:, 1], every[:, 2])
+        self.assertTrue(compare_arrays("subset[:, 0]", subset[:, 0], every[:, 0]))
+        self.assertTrue(compare_arrays("subset[:, 1]", subset[:, 1], every[:, 2]))
 
     def test_strided_time_slice(self):
         backend = get_backend(self.train_path)
@@ -543,8 +642,8 @@ class TestReading(_BackendFixture):
         third = backend.read(0, slice(2, 3), channels)
 
         self.assertEqual(strided.shape[0], 2)
-        np.testing.assert_allclose(strided[0], first[0])
-        np.testing.assert_allclose(strided[1], third[0])
+        self.assertTrue(compare_arrays("strided[0]", strided[0], first[0]))
+        self.assertTrue(compare_arrays("strided[1]", strided[1], third[0]))
 
 
 class TestTimestampSynthesis(unittest.TestCase):
@@ -667,7 +766,13 @@ class TestUnconsolidatedZarr(unittest.TestCase):
         backend = get_backend(self.plain)
         backend.discover()
 
-        np.testing.assert_allclose(backend.read(0, slice(0, 3), channels), reference.read(0, slice(0, 3), channels))
+        self.assertTrue(
+            compare_arrays(
+                "backend.read(0, slice(0, 3), channels)",
+                backend.read(0, slice(0, 3), channels),
+                reference.read(0, slice(0, 3), channels),
+            )
+        )
 
 
 def _write_h5(path, data, timestamps, latitude=None, longitude=None):
@@ -804,15 +909,19 @@ class TestFileCoordinates(unittest.TestCase):
         self._write()
         metadata = get_backend(self.tmpdir.name).discover()
 
-        np.testing.assert_allclose(metadata.grid.lat, self.latitude, rtol=1e-6)
-        np.testing.assert_allclose(metadata.grid.lon, self.longitude, rtol=1e-6)
+        self.assertTrue(compare_arrays("metadata.grid.lat", metadata.grid.lat, self.latitude, rtol=1e-6))
+        self.assertTrue(compare_arrays("metadata.grid.lon", metadata.grid.lon, self.longitude, rtol=1e-6))
 
     def test_a_file_without_coordinates_falls_back(self):
         self._write(with_coordinates=False)
         metadata = get_backend(self.tmpdir.name).discover()
 
-        np.testing.assert_allclose(metadata.grid.lat, np.linspace(90, -90, self.shape[0], endpoint=True))
-        np.testing.assert_allclose(metadata.grid.lon, np.linspace(0, 360, self.shape[1], endpoint=False))
+        self.assertTrue(
+            compare_arrays("metadata.grid.lat", metadata.grid.lat, np.linspace(90, -90, self.shape[0], endpoint=True))
+        )
+        self.assertTrue(
+            compare_arrays("metadata.grid.lon", metadata.grid.lon, np.linspace(0, 360, self.shape[1], endpoint=False))
+        )
 
     def test_an_explicit_grid_wins_over_the_file(self):
         # the caller knows something the file does not, e.g. a dataset written
@@ -821,7 +930,7 @@ class TestFileCoordinates(unittest.TestCase):
         override = (np.linspace(1, 8, self.shape[0]), np.linspace(1, 16, self.shape[1]))
         metadata = get_backend(self.tmpdir.name, lat_lon=override).discover()
 
-        np.testing.assert_allclose(metadata.grid.lat, override[0])
+        self.assertTrue(compare_arrays("metadata.grid.lat", metadata.grid.lat, override[0]))
 
     def test_the_chunk_carries_the_file_coordinates(self):
         # the chunk is what a consumer actually reads coordinates from, so the
@@ -830,10 +939,471 @@ class TestFileCoordinates(unittest.TestCase):
         backend = get_backend(self.tmpdir.name, io_grid=[2, 1], io_rank=[1, 0])
         backend.discover()
 
-        np.testing.assert_allclose(backend.chunk.lat, self.latitude[self.shape[0] // 2 :], rtol=1e-6)
+        self.assertTrue(
+            compare_arrays("backend.chunk.lat", backend.chunk.lat, self.latitude[self.shape[0] // 2 :], rtol=1e-6)
+        )
+
+
+class _IconFixture(unittest.TestCase):
+    """A scaled down ICON dataset, shared by the tests below."""
+
+    def assertFieldEqual(self, got, want, msg="field"):
+        """Compare fields that carry NaN where the fixture wrote a fill.
+
+        Where the NaNs sit is asserted separately, and deliberately: NaN never
+        compares equal, so folding it into the value check would either hide a
+        misplaced fill or fail for the wrong reason.
+        """
+        got, want = np.asarray(got), np.asarray(want)
+        self.assertTrue(np.array_equal(np.isnan(got), np.isnan(want)), f"{msg}: fills are in different places")
+
+        finite = ~np.isnan(want)
+        self.assertTrue(compare_arrays(msg, got[finite], want[finite], atol=1e-5, rtol=1e-5, verbose=True))
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.data_path, cls.grid_path, cls.n_samples, cls.channel_names = init_icon_dataset(cls.tmpdir.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    def _backend(self, **overrides):
+        kwargs = dict(grid_file=self.grid_path, channel_names=list(self.channel_names))
+        kwargs.update(overrides)
+        return get_backend(self.data_path, **kwargs)
+
+
+class TestIconDiscovery(_IconFixture):
+    """What the backend makes of a directory of ICON output.
+
+    The layout differs from every other one here in three ways at once -- a
+    sample spans files, the variables disagree about what times exist, and a
+    variable name does not identify a variable -- so what discovery settles is
+    worth stating rather than inferring from a read.
+    """
+
+    def test_the_mesh_is_reported_as_unstructured(self):
+        metadata = self._backend().discover()
+
+        self.assertEqual(metadata.grid.kind, "unstructured")
+        self.assertEqual(metadata.grid.shape, (ICON_N_CELLS,))
+        self.assertFalse(metadata.grid.is_structured)
+
+    def test_coordinates_are_degrees_with_longitude_in_zero_to_360(self):
+        # the files store radians with longitude in [-pi, pi]; makani works in
+        # degrees with longitude in [0, 360)
+        grid = self._backend().discover().grid
+
+        self.assertGreaterEqual(grid.lon.min(), 0.0)
+        self.assertLess(grid.lon.max(), 360.0)
+        self.assertGreaterEqual(grid.lat.min(), -90.0)
+        self.assertLessEqual(grid.lat.max(), 90.0)
+        self.assertEqual(len(grid.lat), ICON_N_CELLS)
+
+    def test_samples_are_the_times_every_variable_has(self):
+        """The sample axis is an intersection, not a union.
+
+        Pressure level variables are three hourly and the surface one is
+        hourly, so an hourly sample would have no temperature to go with it.
+        Taking the union instead would produce samples that cannot be read.
+        """
+        metadata = self._backend().discover()
+
+        self.assertEqual(len(metadata.timestamps), self.n_samples)
+        steps = {
+            (metadata.timestamps[idx + 1] - metadata.timestamps[idx]).total_seconds() / 3600
+            for idx in range(len(metadata.timestamps) - 1)
+        }
+        self.assertEqual(steps, {3.0})
+
+    def test_units_break_where_a_file_changes(self):
+        # the level variables are daily and the surface variable spans both
+        # days, so the units are the days: within one, no variable changes file
+        metadata = self._backend().discover()
+
+        self.assertEqual(metadata.samples_per_file, [8, 8])
+        self.assertEqual(sum(metadata.samples_per_file), len(metadata.timestamps))
+
+    def test_timestamps_are_absolute_utc_times(self):
+        """The sample times, not merely their spacing.
+
+        The files say ``minutes since 2020-1-1 00:00:00`` and start on the
+        first of June 2021. A misparsed epoch, a wrong unit or a naive local
+        time would all still produce an evenly spaced, ordered axis.
+        """
+        metadata = self._backend().discover()
+
+        self.assertEqual(metadata.timestamps[0], dt.datetime(2021, 6, 1, tzinfo=dt.timezone.utc))
+        self.assertEqual(metadata.timestamps[1], dt.datetime(2021, 6, 1, 3, tzinfo=dt.timezone.utc))
+        self.assertEqual(metadata.timestamps[0].utcoffset(), dt.timedelta(0))
+
+    def test_coordinates_keep_the_order_the_grid_file_has(self):
+        """Cell n of the grid describes cell n of the data.
+
+        The only thing tying a value to a place on the sphere is that both are
+        indexed by the same cell number. Sorting or otherwise reordering the
+        coordinates on the way in would leave every array self consistent, every
+        test of shapes and ranges passing, and every field scrambled -- so the
+        coordinates are checked against the grid file itself rather than against
+        anything else the backend produced.
+        """
+        metadata = self._backend().discover()
+
+        with h5.File(self.grid_path, "r") as handle:
+            clon, clat = handle["clon"][...], handle["clat"][...]
+
+        self.assertTrue(compare_arrays("latitudes", metadata.grid.lat, np.degrees(clat), atol=1e-6))
+        self.assertTrue(compare_arrays("longitudes", metadata.grid.lon, np.mod(np.degrees(clon), 360.0), atol=1e-6))
+
+    def test_total_channels_is_what_was_asked_for(self):
+        # ICON has no channel axis to count, so the number is the request
+        metadata = self._backend().discover()
+        self.assertEqual(metadata.total_channels, len(self.channel_names))
+
+    def test_detected_from_the_extension(self):
+        self.assertEqual(detect_backend(self.data_path), "icon")
+        self.assertIsInstance(self._backend(), IconBackend)
+
+
+class TestIconReading(_IconFixture):
+
+    def _read(self, backend, sample, channel):
+        """One channel at one sample, through the unit it falls in."""
+        offset = 0
+        for unit_idx, count in enumerate(backend.metadata.samples_per_file):
+            if sample < offset + count:
+                return backend.read(unit_idx, slice(sample - offset, sample - offset + 1), np.array([channel]))
+            offset += count
+        raise AssertionError("sample out of range")
+
+    def setUp(self):
+        self.backend = self._backend()
+        self.backend.discover()
+
+    def test_a_pressure_level_channel_reads_the_pressure_level_variable(self):
+        """Two variables are called ``u``; only one can serve ``u500``.
+
+        The files carry ``u`` on pressure levels and ``u`` on altitude levels.
+        Resolving by name alone picks whichever was seen first, which is wrong
+        half the time and silently so -- both are plausible wind fields.
+        """
+        values = self._read(self.backend, sample=0, channel=0)  # u500
+
+        expected = icon_expected_field("u", 0, ICON_PLEV_HPA.index(500))
+        self.assertFieldEqual(values[0, 0], expected, "u500")
+
+    def test_levels_are_addressed_by_pressure_not_by_position(self):
+        u500 = self._read(self.backend, sample=0, channel=0)
+        u850 = self._read(self.backend, sample=0, channel=1)
+
+        for name, values, hpa in (("u500", u500, 500), ("u850", u850, 850)):
+            with self.subTest(channel=name):
+                self.assertFieldEqual(values[0, 0], icon_expected_field("u", 0, ICON_PLEV_HPA.index(hpa)), name)
+
+    def test_a_surface_channel_follows_its_own_cadence(self):
+        """The hourly variable has to be indexed by time, not by sample number.
+
+        Sample 1 is three hours after sample 0, which is index 1 in a three
+        hourly file and index 3 in an hourly one. Reusing the sample index for
+        both is the obvious mistake and it misdates the surface field.
+        """
+        values = self._read(self.backend, sample=1, channel=4)  # t2m
+
+        self.assertFieldEqual(values[0, 0], icon_expected_field("t_2m", 3, 0), "t2m at sample 1")
+
+    def test_reading_crosses_a_unit_boundary_correctly(self):
+        # sample 8 is the first of the second day, so a different file for the
+        # level variables and a later index in the same file for the surface one
+        values = self._read(self.backend, sample=8, channel=2)  # t500
+
+        expected = icon_expected_field("temp", 0, ICON_PLEV_HPA.index(500))
+        self.assertFieldEqual(values[0, 0], expected, "t500 on the second day")
+
+    def test_fill_values_become_nan(self):
+        # cell 7 is written as _FillValue throughout
+        values = self._read(self.backend, sample=0, channel=0)
+
+        self.assertTrue(np.isnan(values[0, 0, list(ICON_FILL_CELLS)]).all())
+        self.assertFalse(np.isnan(np.delete(values[0, 0], list(ICON_FILL_CELLS))).any())
+
+    def test_the_raw_fill_sentinel_does_not_survive(self):
+        values = self._read(self.backend, sample=0, channel=0)
+        self.assertFalse(np.any(values == ICON_FILL))
+
+    def test_several_channels_at_once_match_one_at_a_time(self):
+        together = self.backend.read(0, slice(0, 2), np.array([0, 2, 4]))
+
+        for position, channel in enumerate([0, 2, 4]):
+            with self.subTest(channel=self.channel_names[channel]):
+                alone = self.backend.read(0, slice(0, 2), np.array([channel]))
+                self.assertFieldEqual(together[:, position], alone[:, 0], "batched vs single channel")
+
+    def test_reads_are_repeatable(self):
+        # the run buffer is reused between reads, so a second read has to
+        # overwrite it rather than return what the first one left behind
+        first = self.backend.read(0, slice(0, 1), np.array([0])).copy()
+        self.backend.read(0, slice(1, 2), np.array([2]))
+        again = self.backend.read(0, slice(0, 1), np.array([0]))
+
+        self.assertFieldEqual(again, first, "repeated read")
+
+
+class TestIconDecomposition(_IconFixture):
+    """Which cells a rank reads, and the guarantee that makes it safe."""
+
+    def _target_grid(self, nlat=32, nlon=64):
+        return GridSpec(
+            "equiangular",
+            (nlat, nlon),
+            np.linspace(90, -90, nlat),
+            np.linspace(0, 360, nlon, endpoint=False),
+        )
+
+    def test_one_rank_gets_the_whole_mesh(self):
+        backend = self._backend()
+        backend.discover()
+        self.assertEqual(backend.chunk.shape, (ICON_N_CELLS,))
+
+    def test_ranks_cover_the_mesh_between_them(self):
+        """Every cell reaches some rank, and the overlap is only the halo.
+
+        A cell that no rank reads is a hole in the field that nothing else
+        would notice, since each rank's own chunk looks self consistent.
+        """
+        target = self._target_grid()
+        seen = []
+        for rank in range(2):
+            backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[rank, 0])
+            backend.discover()
+            seen.append(set(backend.cell_index.tolist()))
+
+        self.assertEqual(set().union(*seen), set(range(ICON_N_CELLS)))
+        self.assertTrue(seen[0] & seen[1], "the halo should make the blocks overlap")
+
+    def test_a_rank_reads_its_own_latitudes(self):
+        target = self._target_grid()
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[0, 0])
+        backend.discover()
+
+        # the northern half, give or take the halo
+        self.assertGreater(backend.chunk.lat.min(), -backend.halo_degrees - 1e-6)
+
+    def test_the_chunk_coordinates_are_the_cells_selected(self):
+        target = self._target_grid()
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[1, 0])
+        backend.discover()
+
+        self.assertTrue(compare_arrays("chunk lat", backend.chunk.lat, backend.metadata.grid.lat[backend.cell_index]))
+        self.assertTrue(compare_arrays("chunk lon", backend.chunk.lon, backend.metadata.grid.lon[backend.cell_index]))
+
+    def test_a_decomposed_read_matches_the_whole_mesh(self):
+        """A rank's values are the global field restricted to its cells.
+
+        This is what ties the selection to the read: the runs are read whole and
+        the bridged cells dropped, so an off by one in the compaction shows up
+        here as a shifted field and nowhere else.
+        """
+        target = self._target_grid()
+        whole = self._backend()
+        whole.discover()
+        reference = whole.read(0, slice(0, 1), np.array([0]))
+
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[1, 0])
+        backend.discover()
+        local = backend.read(0, slice(0, 1), np.array([0]))
+
+        self.assertFieldEqual(local[0, 0], reference[0, 0][backend.cell_index], "decomposed read")
+
+    def test_values_and_coordinates_describe_the_same_cells(self):
+        """What a rank emits, and where it says those values are, agree.
+
+        Checked against the fixture's formula rather than against another read,
+        so it does not rely on the selection being right on both sides: the
+        value at position k identifies the cell it came from, and the coordinate
+        at position k has to be that cell's.
+        """
+        target = self._target_grid()
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[1, 0])
+        backend.discover()
+
+        values = backend.read(0, slice(0, 1), np.array([0]))[0, 0]
+        expected = icon_expected_field("u", 0, ICON_PLEV_HPA.index(500))[backend.cell_index]
+
+        finite = ~np.isnan(expected)
+        self.assertTrue(compare_arrays("decomposed u500", values[finite], expected[finite], atol=1e-5, rtol=1e-5))
+
+        grid = backend.metadata.grid
+        self.assertTrue(compare_arrays("chunk latitudes", backend.chunk.lat, grid.lat[backend.cell_index]))
+        self.assertTrue(compare_arrays("chunk longitudes", backend.chunk.lon, grid.lon[backend.cell_index]))
+
+    def test_every_target_point_has_its_neighbours_locally(self):
+        """The guarantee the halo exists for.
+
+        Resampling onto a target point reads the cells around it, so those cells
+        have to be on the same rank -- otherwise the regrid needs a neighbour
+        exchange, which is exactly what selecting a margin avoids. Asserted as
+        the property rather than as a cell count, so it stays meaningful if the
+        default margin changes.
+        """
+        target = self._target_grid()
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[0, 0])
+        backend.discover()
+
+        grid = backend.metadata.grid
+        lat_low, lat_high = block_of_rank(target.lat, [2, 1], [0, 0], 0)
+        lat_low, lat_high = min(lat_low, lat_high), max(lat_low, lat_high)
+        rows = target.lat[(target.lat >= lat_low) & (target.lat <= lat_high)]
+
+        local = set(backend.cell_index.tolist())
+        points = [(lat, lon) for lat in rows[::4] for lon in target.lon[::8]]
+
+        for lat, lon in points:
+            # great circle distance from this target point to every cell
+            cosine = np.sin(np.radians(lat)) * np.sin(np.radians(grid.lat)) + np.cos(np.radians(lat)) * np.cos(
+                np.radians(grid.lat)
+            ) * np.cos(np.radians(lon - grid.lon))
+            nearest = np.argsort(-cosine)[:3]
+            with self.subTest(lat=round(float(lat), 1), lon=round(float(lon), 1)):
+                self.assertTrue(set(nearest.tolist()) <= local, "a neighbour of this point is on another rank")
+
+    def test_the_halo_widens_the_selection(self):
+        # without it a rank holds only its own block, and the points at the edge
+        # have nothing beyond them to interpolate from
+        target = self._target_grid()
+
+        bare = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[0, 0], halo_degrees=0.0)
+        bare.discover()
+        padded = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[0, 0])
+        padded.discover()
+
+        self.assertLess(len(bare.cell_index), len(padded.cell_index))
+        self.assertTrue(set(bare.cell_index.tolist()) <= set(padded.cell_index.tolist()))
+
+    def test_a_fragmented_selection_still_reads_correctly(self):
+        """Several runs rather than one, which the default gap hides.
+
+        With the default ``merge_gap`` a selection this small collapses into a
+        single run, so the compaction is never asked to interleave pieces. A gap
+        of zero forces one run per stretch, which is what a rank of a real mesh
+        would see.
+        """
+        target = self._target_grid()
+        backend = self._backend(target_grid=target, io_grid=[2, 1], io_rank=[1, 0])
+        backend.merge_gap = 0
+        backend.discover()
+
+        self.assertGreater(len(backend.cell_runs), 1, "the selection should not be one contiguous stretch")
+
+        values = backend.read(0, slice(0, 1), np.array([0]))[0, 0]
+        expected = icon_expected_field("u", 0, ICON_PLEV_HPA.index(500))[backend.cell_index]
+
+        finite = ~np.isnan(expected)
+        self.assertTrue(compare_arrays("fragmented read", values[finite], expected[finite], atol=1e-5, rtol=1e-5))
+
+    def test_decomposition_without_a_target_grid_is_refused(self):
+        # a mesh has no rows and columns to split, so there is nothing to
+        # decompose against unless the run says what grid it is heading for
+        with self.assertRaises(ValueError) as ctx:
+            self._backend(io_grid=[2, 1], io_rank=[0, 0]).discover()
+        self.assertIn("target_grid", str(ctx.exception))
+
+
+class TestIconRejections(_IconFixture):
+    """Options and datasets the backend refuses, and how it says so."""
+
+    def test_subsampling_is_refused(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._backend(subsampling_factor=2).discover()
+        self.assertIn("target_grid", str(ctx.exception))
+
+    def test_cropping_is_refused(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._backend(crop_size=[10, 10]).discover()
+        self.assertIn("target_grid", str(ctx.exception))
+
+    def test_channel_names_are_required(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_backend(self.data_path, grid_file=self.grid_path)
+        self.assertIn("channel_names", str(ctx.exception))
+
+    def test_the_grid_file_is_required(self):
+        # the output references a grid rather than carrying one, so there is
+        # nothing to fall back on
+        with self.assertRaises(ValueError) as ctx:
+            get_backend(self.data_path, channel_names=list(self.channel_names))
+        self.assertIn("grid_file", str(ctx.exception))
+
+    def test_a_grid_from_another_run_is_refused(self):
+        """A mismatched grid produces a plausible but scrambled field.
+
+        Nothing downstream can detect it: the values are real and the
+        coordinates are real, they simply do not belong together. So the UUIDs
+        ICON stamps on both sides are compared.
+        """
+        wrong = os.path.join(self.tmpdir.name, "wrong_grid.nc")
+        with h5.File(self.grid_path, "r") as source, h5.File(wrong, "w") as handle:
+            for name in ("clon", "clat"):
+                handle.create_dataset(name, data=source[name][...])
+            handle.attrs["uuidOfHGrid"] = np.bytes_("00000000-0000-0000-0000-000000000000")
+
+        with self.assertRaises(ValueError) as ctx:
+            self._backend(grid_file=wrong).discover()
+        # the message has to name the grid that was found, since the usual cause
+        # is pointing at a grid from a different run
+        self.assertIn("00000000-0000-0000-0000-000000000000", str(ctx.exception))
+
+    def test_a_file_that_is_not_a_grid_is_refused(self):
+        not_a_grid = os.path.join(self.tmpdir.name, "not_a_grid.nc")
+        with h5.File(not_a_grid, "w") as handle:
+            handle.create_dataset("something", data=np.zeros(4))
+
+        with self.assertRaises(ValueError) as ctx:
+            self._backend(grid_file=not_a_grid).discover()
+        self.assertIn("clon", str(ctx.exception))
+
+
+class TestIconPickling(_IconFixture):
+
+    def test_handles_and_buffers_do_not_travel(self):
+        # a worker process gets the plan, not the open files or the scratch
+        # space, both of which it rebuilds for itself
+        backend = self._backend()
+        backend.discover()
+        backend.read(0, slice(0, 1), np.array([0]))
+
+        state = pickle.loads(pickle.dumps(backend)).__getstate__()
+
+        self.assertTrue(all(handle is None for handle in state["files"]))
+        self.assertIsNone(state["_buffer"])
+
+    def test_reads_survive_a_round_trip(self):
+        backend = self._backend()
+        backend.discover()
+        before = backend.read(0, slice(0, 2), np.array([0, 4]))
+
+        revived = pickle.loads(pickle.dumps(backend))
+        after = revived.read(0, slice(0, 2), np.array([0, 4]))
+
+        self.assertFieldEqual(after, before, "read after unpickling")
 
 
 class TestWb2Backend(unittest.TestCase):
+
+    def test_datetime64_times_survive_the_conversion(self):
+        """WB2 stores times as datetime64[ns], not as seconds.
+
+        They go through a nanosecond to second conversion that no other layout
+        needs, and getting that wrong by a factor of 1e9 lands the dataset in
+        1970 -- ordered, timezone aware and completely wrong.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            train_path = init_wb2_zarr_dataset(tmpdir)[0]
+            metadata = get_backend(train_path, channel_names=list(CHANNEL_NAMES)).discover()
+
+            self.assertEqual(metadata.timestamps[0], dt.datetime(TRAIN_YEARS[0], 1, 1, tzinfo=dt.timezone.utc))
+            self.assertEqual(metadata.timestamps[1] - metadata.timestamps[0], dt.timedelta(hours=DHOURS))
 
     def test_channel_names_are_required(self):
         # the layout addresses variables by name, so there is nothing to read

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1227,10 +1227,15 @@ class TestMultifilesDataset(unittest.TestCase):
         inp, tar = dataset[0]
 
         # channel c holds c + 1
-        np.testing.assert_allclose(inp[:, 0].numpy(), 1.0)
-        np.testing.assert_allclose(inp[:, 1].numpy(), 2.0)
-        np.testing.assert_allclose(tar[:, 0].numpy(), 4.0)
-        np.testing.assert_allclose(tar[:, 1].numpy(), 5.0)
+        for name, values, constant in (
+            ("inp c0", inp[:, 0], 1.0),
+            ("inp c1", inp[:, 1], 2.0),
+            ("tar c0", tar[:, 0], 4.0),
+            ("tar c1", tar[:, 1], 5.0),
+        ):
+            with self.subTest(field=name):
+                got = values.numpy()
+                self.assertTrue(compare_arrays(name, got, np.full_like(got, constant)))
 
     def test_target_channels_are_reordered_like_the_inputs(self):
         # an unsorted request has to come back in the order it was asked for,
@@ -1239,10 +1244,15 @@ class TestMultifilesDataset(unittest.TestCase):
 
         inp, tar = dataset[0]
 
-        np.testing.assert_allclose(inp[:, 0].numpy(), 2.0)
-        np.testing.assert_allclose(inp[:, 1].numpy(), 1.0)
-        np.testing.assert_allclose(tar[:, 0].numpy(), 5.0)
-        np.testing.assert_allclose(tar[:, 1].numpy(), 3.0)
+        for name, values, constant in (
+            ("inp c0", inp[:, 0], 2.0),
+            ("inp c1", inp[:, 1], 1.0),
+            ("tar c0", tar[:, 0], 5.0),
+            ("tar c1", tar[:, 1], 3.0),
+        ):
+            with self.subTest(field=name):
+                got = values.numpy()
+                self.assertTrue(compare_arrays(name, got, np.full_like(got, constant)))
 
     def test_timestamps_stride_by_dt(self):
         """The times returned belong to the samples returned.
@@ -1265,8 +1275,8 @@ class TestMultifilesDataset(unittest.TestCase):
 
         _, _, inp_time, _ = dataset[5]
 
-        expected = [dataset.timestamps[5], dataset.timestamps[5 + 3]]
-        np.testing.assert_allclose(inp_time.numpy(), expected)
+        expected = np.asarray([dataset.timestamps[5], dataset.timestamps[5 + 3]])
+        self.assertTrue(compare_arrays("input timestamps", inp_time.numpy(), expected))
 
     def test_target_times_stride_by_dt(self):
         dataset = self._make(dt=2, n_future=1, return_timestamp=True, add_zenith=False)
@@ -1297,7 +1307,7 @@ class TestMultifilesDataset(unittest.TestCase):
         with h5.File(sorted(glob.glob(os.path.join(self.train_path, "*.h5")))[0], "r") as handle:
             latitude = handle["lat"][...]
 
-        np.testing.assert_allclose(dataset.lat_lon[0], latitude, rtol=1e-6)
+        self.assertTrue(compare_arrays("latitudes", np.asarray(dataset.lat_lon[0]), latitude, rtol=1e-6))
 
     def test_lookup_by_time_round_trips(self):
         # inference addresses samples by timestamp, so the two directions have

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -19,7 +19,7 @@ import re
 import json
 import datetime as dt
 import random
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import numpy as np
 import h5py as h5
@@ -670,3 +670,207 @@ def compare_arrays(msg, array1, array2, atol=1e-8, rtol=1e-5, verbose=False):
             )
 
     return allclose
+
+
+# ---------------------------------------------------------------------------
+# ICON fixture
+#
+# Scaled down from the EXCLAIM R02B10 DYAMOND output, keeping the properties the
+# backend has to cope with and shrinking only the ones it does not care about:
+#
+#   * one variable per file, so a sample spans several of them
+#   * cadences that differ per variable -- three hourly on pressure levels,
+#     hourly at the surface -- so the sample axis is an intersection
+#   * file spans that differ -- daily for the level variables, one file covering
+#     the whole period for the surface one -- so unit boundaries do not line up
+#   * two variables called ``u``, one on pressure levels and one on altitude
+#     levels, which is what forces resolution by level coordinate
+#   * the cell axis chunked into 21 pieces, as the real files are
+#
+# What is smaller: 320 cells rather than 83,886,080 (both are 20 * 4 * 4**b, the
+# icosahedral count, here with b=1 instead of b=10), four pressure levels rather
+# than 37, and two days rather than a simulation.
+# ---------------------------------------------------------------------------
+
+ICON_N_CELLS = 320
+ICON_PLEV_HPA = (1000, 850, 500, 250)
+ICON_UUID = "e6f7602e-2027-11ef-ab56-6d1c8c7a4d8d"
+ICON_EPOCH = "minutes since 2020-1-1 00:00:00"
+ICON_FILL = np.float32(-9.99e-08)
+ICON_CHANNEL_NAMES = ["u500", "u850", "t500", "t850", "t2m"]
+#: cells written as _FillValue, which a reader has to turn into NaN
+ICON_FILL_CELLS = (7,)
+
+
+def _icosahedral_ordering(lon_rad, lat_rad):
+    """Order cells the way ICON does: by which root region they fall in.
+
+    ICON's cell index follows the icosahedron, so cells that are close on the
+    sphere are close in the file -- coarsely, and with boundaries at the vertex
+    latitudes of +-arctan(1/2) = +-26.57 degrees. Reproducing that is what makes
+    the run coalescing in the backend meaningful to test: a lat/lon block should
+    land in a handful of long index ranges rather than scattered singletons.
+    """
+    # the twelve icosahedron vertices, ordered as a sweep from one pole to the
+    # other rather than by construction: regions next to each other in the index
+    # then lie next to each other on the sphere, which is the property being
+    # imitated. Listing the poles first would make cell 0 and cell n/12
+    # antipodal, and destroy exactly the locality this exists to provide.
+    ring = np.arctan(0.5)
+    vertex_lat = [np.pi / 2] + [ring] * 5 + [-ring] * 5 + [-np.pi / 2]
+    vertex_lon = (
+        [0.0]
+        + [index * 2 * np.pi / 5 for index in range(5)]
+        + [(index + 0.5) * 2 * np.pi / 5 for index in range(5)]
+        + [0.0]
+    )
+
+    vertex_lat = np.asarray(vertex_lat)
+    vertex_lon = np.asarray(vertex_lon)
+
+    # nearest vertex by great circle distance
+    cosine = np.sin(lat_rad[:, None]) * np.sin(vertex_lat[None, :]) + np.cos(lat_rad[:, None]) * np.cos(
+        vertex_lat[None, :]
+    ) * np.cos(lon_rad[:, None] - vertex_lon[None, :])
+    region = np.argmax(cosine, axis=1)
+
+    return np.lexsort((lon_rad, lat_rad, region))
+
+
+def icon_grid_coordinates(n_cells: int = ICON_N_CELLS):
+    """Cell centres for the fixture, in radians, ordered like ICON's."""
+    # a Fibonacci sphere: near uniform, and deterministic
+    indices = np.arange(n_cells, dtype=np.float64)
+    lat = np.arcsin(1.0 - 2.0 * (indices + 0.5) / n_cells)
+    lon = np.mod(indices * np.pi * (3.0 - np.sqrt(5.0)), 2.0 * np.pi) - np.pi
+
+    order = _icosahedral_ordering(lon, lat)
+    return lon[order], lat[order]
+
+
+def icon_expected_value(variable: str, time_index: int, level_index: int, cell: np.ndarray):
+    """The value the fixture stores, so a test can assert an exact read."""
+    base = float(sum(ord(character) for character in variable))
+    return np.float32(base + 1000.0 * time_index + 10.0 * level_index) + np.asarray(cell, dtype=np.float32) / 1000.0
+
+
+def icon_expected_field(variable: str, time_index: int, level_index: int, n_cells: int = ICON_N_CELLS):
+    """The whole field a reader should return, fills included as NaN."""
+    field = icon_expected_value(variable, time_index, level_index, np.arange(n_cells))
+    field[list(ICON_FILL_CELLS)] = np.nan
+    return field
+
+
+def _write_icon_file(path, variable, units, times, level_name, level_values, level_units, n_cells, fill_cells=()):
+    """One ICON style netCDF4 file: a single variable of (time, level, ncells)."""
+    n_chunks = 21  # as in the real files, so the cell axis is chunked the same way
+    chunk = int(np.ceil(n_cells / n_chunks))
+
+    with h5.File(path, "w") as handle:
+        handle.attrs["Conventions"] = np.bytes_("CF-1.6")
+        handle.attrs["uuidOfHGrid"] = np.bytes_(ICON_UUID)
+        handle.attrs["grid_file_uri"] = np.bytes_("http://example.invalid/icon_grid_test.nc")
+
+        time_dset = handle.create_dataset("time", data=np.asarray(times, dtype=np.float64))
+        time_dset.attrs["units"] = np.bytes_(ICON_EPOCH)
+
+        level_dset = handle.create_dataset(level_name, data=np.asarray(level_values, dtype=np.float64))
+        level_dset.attrs["units"] = np.bytes_(level_units)
+
+        cells = np.arange(n_cells)
+        data = np.empty((len(times), len(level_values), n_cells), dtype=np.float32)
+        for time_index in range(len(times)):
+            for level_index in range(len(level_values)):
+                data[time_index, level_index] = icon_expected_value(variable, time_index, level_index, cells)
+        for cell in fill_cells:
+            data[:, :, cell] = ICON_FILL
+
+        field = handle.create_dataset(variable, data=data, chunks=(1, 1, chunk))
+        field.attrs["units"] = np.bytes_(units)
+        field.attrs["_FillValue"] = ICON_FILL
+        field.attrs["missing_value"] = ICON_FILL
+        field.attrs["CDI_grid_type"] = np.bytes_("unstructured")
+        field.attrs["number_of_grid_in_reference"] = np.int32(1)
+
+
+def init_icon_dataset(
+    path: str,
+    n_cells: Optional[int] = ICON_N_CELLS,
+    n_days: Optional[int] = 2,
+    fill_cells: Optional[Sequence[int]] = ICON_FILL_CELLS,
+):
+    """Create a scaled down ICON dataset and its grid file.
+
+    Returns ``(data_path, grid_path, n_samples, channel_names)``, where
+    ``n_samples`` counts the times every required variable has -- the three
+    hourly axis, since that is the coarsest.
+    """
+    data_path = os.path.join(path, "icon")
+    grid_path = os.path.join(path, "icon_grid_test.nc")
+    os.makedirs(data_path, exist_ok=True)
+
+    lon_rad, lat_rad = icon_grid_coordinates(n_cells)
+    with h5.File(grid_path, "w") as handle:
+        handle.attrs["uuidOfHGrid"] = np.bytes_(ICON_UUID)
+        handle.attrs["grid_root"] = np.int32(2)
+        handle.attrs["grid_level"] = np.int32(1)
+        for name, values in (("clon", lon_rad), ("clat", lat_rad)):
+            dset = handle.create_dataset(name, data=values)
+            dset.attrs["units"] = np.bytes_("radian")
+
+    day_zero = dt.datetime(2021, 6, 1, tzinfo=dt.timezone.utc)
+    epoch = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    minutes = lambda when: (when - epoch).total_seconds() / 60.0  # noqa: E731
+
+    pressures = np.asarray(ICON_PLEV_HPA, dtype=np.float64) * 100.0  # the files store Pa
+
+    for day in range(n_days):
+        start = day_zero + dt.timedelta(days=day)
+        stamp = start.strftime("%Y%m%dT%H%M%SZ")
+
+        # three hourly on pressure levels, one file per day
+        three_hourly = [minutes(start + dt.timedelta(hours=3 * step)) for step in range(8)]
+        for variable, units in (("temp", "K"), ("u", "m s-1")):
+            _write_icon_file(
+                os.path.join(data_path, f"{variable}_dyamond_atm_1_3_{stamp}.nc"),
+                variable,
+                units,
+                three_hourly,
+                "plev",
+                pressures,
+                "Pa",
+                n_cells,
+                fill_cells,
+            )
+
+        # the same name on altitude levels, hourly: what forces resolution by
+        # level coordinate rather than by name
+        hourly = [minutes(start + dt.timedelta(hours=step)) for step in range(24)]
+        _write_icon_file(
+            os.path.join(data_path, f"u_dyamond_atm_4_{stamp}.nc"),
+            "u",
+            "m s-1",
+            hourly,
+            "alt",
+            np.asarray([10.0, 100.0]),
+            "m",
+            n_cells,
+            fill_cells,
+        )
+
+    # hourly at the surface, and one file for the whole period rather than one
+    # per day, so its unit boundaries do not line up with the others
+    all_hours = [minutes(day_zero + dt.timedelta(hours=step)) for step in range(24 * n_days)]
+    _write_icon_file(
+        os.path.join(data_path, "t_2m_dyamond_atm_3_202106.nc"),
+        "t_2m",
+        "K",
+        all_hours,
+        "height_2",
+        np.asarray([2.0]),
+        "m",
+        n_cells,
+        fill_cells,
+    )
+
+    return data_path, grid_path, 8 * n_days, list(ICON_CHANNEL_NAMES)


### PR DESCRIPTION
What this adds
  
  The first backend whose data isn't a lat/lon raster, and therefore the first exercise of the unstructured half of the contract that #172 (../merge_requests/172) wrote but nothing used:
  GridSpec(kind="unstructured"), target_grid, and a chunk that is a set of cells rather than a rectangle.
  
  Scope is deliberately the backend only. Nothing downstream consumes a mesh yet, so there's no trainer, preprocessor or resampling change — tests/test_data_backends.py is the entire
  surface, and it runs in CI without DALI or a GPU.
  
  Three properties of ICON output, all found by probing rather than assumed
  
  I probed the EXCLAIM R02B10 DYAMOND files before writing anything, and two of the three findings changed the design:
  
  - A sample spans several files. Each variable is written to its own file, so the 72 channels of a FourCastNet3 run come from a dozen of them. What the sample index runs through is
    therefore a unit — a stretch of the time axis over which no variable changes file. BackendMetadata.files is now documented as the unit rather than the file; that's the only change
    visible outside icon.py.
  - The variables don't share a time axis. temp is 3-hourly in daily files, u on altitude levels is hourly in daily files, t_2m is hourly in monthly ones. The dataset's samples are the
    times every required variable has, and each variable keeps its own map from sample → (file, index).
  - A name doesn't identify a variable. The same run writes two variables called u, one on pressure levels and one on altitude levels. Only the first can serve u500, so candidates
    resolve by the level coordinate they carry. Resolving by name picks whichever was seen first — wrong half the time, and silently, since both are plausible wind fields.

Reads are shaped by measurement
  
  scripts/benchmark_icon_read.py (untracked scratch, happy to include it) measured the real files on Lustre:
  
  - a contiguous cell range costs about what its length suggests — reads are not inflated to whole chunks, so there's no ~21-rank ceiling on spatial parallelism
  - a strided selection is ~10× slower, because HDF5 falls back to an element-wise gather
  - fragmentation is cheap once reads pipeline
  
  So mesh.py coalesces a rank's cells into slices and reads through short gaps rather than splitting, plans the compaction once instead of per read, and reuses a single buffer across
  channels and timesteps. A corollary worth stating: subsetting to a coarser target grid saves nothing on I/O — the cells wanted are scattered ~1-in-10 through the index space, so every
  page is touched either way.
  
  mesh.py
  
  The counterpart to StructuredChunkMixin. Splits target_grid by io_grid/io_rank into this rank's lat/lon block, selects the cells inside it plus halo_degrees (defaulting to ~3 cells
  from the mesh's own spacing), and handles the longitude seam. crop and subsampling_factor are rejected with messages pointing at target_grid — index order isn't a spatial pattern on a
  mesh, so decimation is meaningless.
    
  One thing moved out of the base
    
  The default file pattern was "????" in DatasetBackend — the makani convention of a file per year, which no ICON file matches. It's now a default_file_pattern class attribute: the base
  is permissive ("*"), each layout declares its own, and detect_backend asks the classes rather than keeping a second copy. Same class of bug as the one the multifiles port hit: a
  default that was really one layout's property sitting in the shared contract.

Tests
  
  39 new. The fixture is your dataset scaled down — same file splits, same cadence ratios, same 21-way chunking, 320 cells instead of 83,886,080 (both are 20·4·4ᵇ). Cells are ordered by
  icosahedral region, so a 40° latitude band lands in 6 index runs, as it does in the real grid; an earlier ordering made cell 0 and cell n/12 antipodal and destroyed exactly the
  locality the run-coalescing needs.
  
  Values encode variable, time, level and cell, which is what lets the tests pin behaviour by value rather than by shape: 
  
  - u500 reading the altitude-level u — both are plausible fields, so only the value shows it
  - the hourly surface variable indexed by sample number instead of time (sample 1 is index 1 in a 3-hourly file, index 3 in an hourly one)
  - an off-by-one in the run compaction, visible only as a spatially shifted field
  - coordinates checked against the grid file itself, not against anything else the backend produced — otherwise a reordering moves both sides of the comparison together
  - the halo guarantee stated as a property: every target point's three nearest cells are on the same rank
  
  Also in here
  
  Two gaps the ICON work made obvious in the existing backends: neither the annotated HDF5 timestamps nor the WeatherBench2 datetime64 ones were ever checked against an absolute time —
  only for ordering and a non-null timezone, both of which are satisfiable while being wrong by an epoch, an offset, or a factor of 1e9. And test_data_backends.py's pre-existing
  np.testing.assert_allclose calls are converted to compare_arrays, matching the rest of the suite.
  
  Not in here
  
  No training path. That needs the resampling layer and the shape-descriptor cleanup (get_dataloader still returns a hand-built SimpleNamespace whose every field assumes a raster — an
  ICON run has no img_shape_x to report). Accumulated channels and multi-variable sums raise rather than return something plausible-but-wrong; differencing is a converter's job.