### PR TITLE
One shape descriptor for every dataloader

### DIFF
--- a/makani/utils/dataloader.py
+++ b/makani/utils/dataloader.py
@@ -138,14 +138,19 @@ def get_dataloader(params, files_pattern, device, mode="train", dali_device=None
                 pin_memory=torch.cuda.is_available(),
             )
         else:
-            # this will all be handled by the inferencer
+            # this will all be handled by the inferencer, which drives the dataset
+            # directly -- by index and by time -- so it has to stay reachable
             sampler = None
-            dataloader = types.SimpleNamespace()
+            dataloader = types.SimpleNamespace(dataset=dataset)
 
         # for compatibility with the DALI dataloader
         dataloader.lat_lon = dataset.lat_lon
         dataloader.get_output_normalization = dataset.get_output_normalization
         dataloader.get_input_normalization = dataset.get_input_normalization
+
+        # a torch DataLoader already carries its dataset, and refuses to have it
+        # reassigned; the stub above is given one explicitly
+        data_shapes = dataset.data_shapes
 
     elif params.enable_synthetic_data:
         from makani.utils.dataloaders.data_loader_dummy import DummyLoader
@@ -190,27 +195,7 @@ def get_dataloader(params, files_pattern, device, mode="train", dali_device=None
             io_rank=params.get("io_rank", [0, 0, 0]),
         )
 
-        dataset = types.SimpleNamespace(
-            in_channels=dataloader.in_channels,
-            out_channels=dataloader.out_channels,
-            grid_converter=dataloader.grid_converter,
-            img_shape_x=dataloader.img_shape[0],
-            img_shape_y=dataloader.img_shape[1],
-            img_crop_shape_x=dataloader.crop_shape[0],
-            img_crop_shape_y=dataloader.crop_shape[1],
-            img_crop_offset_x=dataloader.crop_anchor[0],
-            img_crop_offset_y=dataloader.crop_anchor[1],
-            img_local_shape_x=dataloader.read_shape[0],
-            img_local_shape_y=dataloader.read_shape[1],
-            img_local_offset_x=dataloader.read_anchor[0],
-            img_local_offset_y=dataloader.read_anchor[1],
-            img_local_shape_x_resampled=dataloader.return_shape[0],
-            img_local_shape_y_resampled=dataloader.return_shape[1],
-            img_shape_x_resampled=dataloader.img_shape_resampled[0],
-            img_shape_y_resampled=dataloader.img_shape_resampled[1],
-            subsampling_factor=dataloader.subsampling_factor,
-            lat_lon_local=dataloader.lat_lon_local,
-        )
+        data_shapes = dataloader.data_shapes
 
         # not needed for the no multifiles case
         sampler = None
@@ -223,29 +208,9 @@ def get_dataloader(params, files_pattern, device, mode="train", dali_device=None
             dali_device = "gpu" if torch.cuda.is_available() else "cpu"
         dataloader = DaliDataloader(params, files_pattern, (mode == "train"), dali_device=dali_device)
 
-        dataset = types.SimpleNamespace(
-            in_channels=dataloader.in_channels,
-            out_channels=dataloader.out_channels,
-            grid_converter=dataloader.grid_converter,
-            img_shape_x=dataloader.img_shape_x,
-            img_shape_y=dataloader.img_shape_y,
-            img_crop_shape_x=dataloader.img_crop_shape_x,
-            img_crop_shape_y=dataloader.img_crop_shape_y,
-            img_crop_offset_x=dataloader.img_crop_offset_x,
-            img_crop_offset_y=dataloader.img_crop_offset_y,
-            img_local_shape_x=dataloader.img_local_shape_x,
-            img_local_shape_y=dataloader.img_local_shape_y,
-            img_local_offset_x=dataloader.img_local_offset_x,
-            img_local_offset_y=dataloader.img_local_offset_y,
-            img_local_shape_x_resampled=dataloader.img_local_shape_x_resampled,
-            img_local_shape_y_resampled=dataloader.img_local_shape_y_resampled,
-            img_shape_x_resampled=dataloader.img_shape_x_resampled,
-            img_shape_y_resampled=dataloader.img_shape_y_resampled,
-            subsampling_factor=dataloader.subsampling_factor,
-            lat_lon_local=dataloader.lat_lon_local,
-        )
+        data_shapes = dataloader.data_shapes
 
         # not needed for the no multifiles case
         sampler = None
 
-    return dataloader, dataset, sampler
+    return dataloader, data_shapes, sampler

--- a/makani/utils/dataloaders/dali_dataloader.py
+++ b/makani/utils/dataloaders/dali_dataloader.py
@@ -45,6 +45,7 @@ from makani.utils import comm
 
 # es helper
 from makani.utils.dataloaders.data_helpers import get_data_normalization
+from makani.utils.dataloaders.data_shapes import DataShapes
 from makani.utils.dataloaders.sample_source import SampleSource
 from makani.utils.grids import GridConverter
 
@@ -79,8 +80,8 @@ class DaliDataloader(object):
             checkpoint=checkpoint,
         )
 
-        img_shape_x = self.img_shape_x
-        img_shape_y = self.img_shape_y
+        img_shape_x = self.data_shapes.img_shape_x
+        img_shape_y = self.data_shapes.img_shape_y
         in_channels = self.in_channels
         out_channels = self.out_channels
 
@@ -295,29 +296,10 @@ class DaliDataloader(object):
         )
 
         # some image properties
-        self.img_shape_x = self.extsource.img_shape[0]
-        self.img_shape_y = self.extsource.img_shape[1]
-
-        self.img_crop_shape_x = self.extsource.crop_size[0]
-        self.img_crop_shape_y = self.extsource.crop_size[1]
-        self.img_crop_offset_x = self.extsource.crop_anchor[0]
-        self.img_crop_offset_y = self.extsource.crop_anchor[1]
-
-        self.img_local_shape_x = self.extsource.read_shape[0]
-        self.img_local_shape_y = self.extsource.read_shape[1]
-        self.img_local_offset_x = self.extsource.read_anchor[0]
-        self.img_local_offset_y = self.extsource.read_anchor[1]
-
-        # resampled shape
-        self.img_shape_x_resampled = self.extsource.img_shape_resampled[0]
-        self.img_shape_y_resampled = self.extsource.img_shape_resampled[1]
-        self.img_local_shape_x_resampled = self.extsource.return_shape[0]
-        self.img_local_shape_y_resampled = self.extsource.return_shape[1]
-
-        # lat lon coords
+        # the geometry the run needs, in the one shape every loader reports it
+        self.data_shapes = DataShapes.from_loader(self.extsource, grid_converter=self.grid_converter)
         self.lat_lon_local = self.extsource.lat_lon_local
 
-        # num steps
         self.num_steps_per_epoch = self.extsource.num_steps_per_epoch
 
         # load stats

--- a/makani/utils/dataloaders/data_loader_dummy.py
+++ b/makani/utils/dataloaders/data_loader_dummy.py
@@ -28,6 +28,7 @@ from makani.utils import comm
 from torch_harmonics.distributed import compute_split_shapes
 
 # for grid conversion
+from makani.utils.dataloaders.data_shapes import DataShapes
 from makani.utils.grids import GridConverter
 
 # data helpers
@@ -104,15 +105,15 @@ class DummyLoader(object):
             self.lat_lon = None
 
         # get cropping:
-        self.crop_shape = crop_size
+        self.crop_size = crop_size
         self.crop_anchor = crop_anchor
 
         self._get_files_stats()
 
         # get local lat lon (overrides the read_anchor-based slice from _get_files_stats)
         self.lat_lon_local = (
-            self.lat_lon[0][self.crop_anchor[0] : self.crop_anchor[0] + self.crop_shape[0]],
-            self.lat_lon[1][self.crop_anchor[1] : self.crop_anchor[1] + self.crop_shape[1]],
+            self.lat_lon[0][self.crop_anchor[0] : self.crop_anchor[0] + self.crop_size[0]],
+            self.lat_lon[1][self.crop_anchor[1] : self.crop_anchor[1] + self.crop_size[1]],
         )
 
         # zenith angle yes or no?
@@ -131,6 +132,9 @@ class DummyLoader(object):
             torch.deg2rad(torch.as_tensor(self.lat_lon_local[0])).to(torch.float32),
             torch.deg2rad(torch.as_tensor(self.lat_lon_local[1])).to(torch.float32),
         )
+
+        # the geometry the run needs, in the one shape every loader reports it
+        self.data_shapes = DataShapes.from_loader(self)
 
     def _get_files_stats(self):
 
@@ -171,32 +175,32 @@ class DummyLoader(object):
 
         # determine local read size:
         # sanitize the crops first
-        if self.crop_shape[0] is None:
-            self.crop_shape_x = self.img_shape[0]
+        if self.crop_size[0] is None:
+            self.crop_size_x = self.img_shape[0]
         else:
-            self.crop_shape_x = self.crop_shape[0]
-        if self.crop_shape[1] is None:
-            self.crop_shape_y = self.img_shape[1]
+            self.crop_size_x = self.crop_size[0]
+        if self.crop_size[1] is None:
+            self.crop_size_y = self.img_shape[1]
         else:
-            self.crop_shape_y = self.crop_shape[1]
-        self.crop_shape = (self.crop_shape_x, self.crop_shape_y)
+            self.crop_size_y = self.crop_size[1]
+        self.crop_size = (self.crop_size_x, self.crop_size_y)
 
-        if self.crop_anchor[0] + self.crop_shape[0] > self.img_shape[0]:
+        if self.crop_anchor[0] + self.crop_size[0] > self.img_shape[0]:
             raise ValueError(
-                f"crop in dimension 0 (anchor {self.crop_anchor[0]} + shape {self.crop_shape[0]}) exceeds image shape {self.img_shape[0]}"
+                f"crop in dimension 0 (anchor {self.crop_anchor[0]} + shape {self.crop_size[0]}) exceeds image shape {self.img_shape[0]}"
             )
-        if self.crop_anchor[1] + self.crop_shape[1] > self.img_shape[1]:
+        if self.crop_anchor[1] + self.crop_size[1] > self.img_shape[1]:
             raise ValueError(
-                f"crop in dimension 1 (anchor {self.crop_anchor[1]} + shape {self.crop_shape[1]}) exceeds image shape {self.img_shape[1]}"
+                f"crop in dimension 1 (anchor {self.crop_anchor[1]} + shape {self.crop_size[1]}) exceeds image shape {self.img_shape[1]}"
             )
 
         # for x
-        split_shapes_x = compute_split_shapes(self.crop_shape[0], self.io_grid[0])
+        split_shapes_x = compute_split_shapes(self.crop_size[0], self.io_grid[0])
         read_shape_x = split_shapes_x[self.io_rank[0]]
         read_anchor_x = sum(split_shapes_x[: self.io_rank[0]])
 
         # for y
-        split_shapes_y = compute_split_shapes(self.crop_shape[1], self.io_grid[1])
+        split_shapes_y = compute_split_shapes(self.crop_size[1], self.io_grid[1])
         read_shape_y = split_shapes_y[self.io_rank[1]]
         read_anchor_y = sum(split_shapes_y[: self.io_rank[1]])
 
@@ -208,29 +212,10 @@ class DummyLoader(object):
             math.ceil(self.read_shape[1] / self.subsampling_factor),
         )
 
-        # set properties for compatibility
-        self.img_shape_x = self.img_shape[0]
-        self.img_shape_y = self.img_shape[1]
-
-        self.img_crop_shape_x = self.crop_shape[0]
-        self.img_crop_shape_y = self.crop_shape[1]
-        self.img_crop_offset_x = self.crop_anchor[0]
-        self.img_crop_offset_y = self.crop_anchor[1]
-
-        self.img_local_shape_x = self.read_shape[0]
-        self.img_local_shape_y = self.read_shape[1]
-        self.img_local_offset_x = self.read_anchor[0]
-        self.img_local_offset_y = self.read_anchor[1]
-
-        # resampling stuff
         self.img_shape_resampled = (
             math.ceil(self.img_shape[0] / self.subsampling_factor),
             math.ceil(self.img_shape[1] / self.subsampling_factor),
         )
-        self.img_local_shape_x_resampled = self.return_shape[0]
-        self.img_local_shape_y_resampled = self.return_shape[1]
-        self.img_shape_x_resampled = self.img_shape_resampled[0]
-        self.img_shape_y_resampled = self.img_shape_resampled[1]
 
         # auto-create lat/lon if the caller didn't supply them
         # (matches the pattern used by SampleSource)

--- a/makani/utils/dataloaders/data_loader_multifiles.py
+++ b/makani/utils/dataloaders/data_loader_multifiles.py
@@ -46,6 +46,7 @@ from makani.utils.dataloaders.data_helpers import (
 
 # storage backends
 from makani.utils.dataloaders.backends import get_backend
+from makani.utils.dataloaders.data_shapes import DataShapes
 
 # for grid conversion
 from makani.utils.grids import GridConverter
@@ -163,6 +164,9 @@ class MultifilesDataset(Dataset):
             torch.deg2rad(torch.tensor(self.lat_lon_local[0])).to(torch.float32),
             torch.deg2rad(torch.tensor(self.lat_lon_local[1])).to(torch.float32),
         )
+
+        # the geometry the run needs, in the one shape every loader reports it
+        self.data_shapes = DataShapes.from_loader(self)
 
     def _get_files_stats(self, enable_logging):
         """Ask the backend what is there, and settle what this rank reads."""

--- a/makani/utils/dataloaders/data_shapes.py
+++ b/makani/utils/dataloaders/data_shapes.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What a dataloader tells the rest of the run about the data it emits.
+
+Every loader answers the same questions -- how big is the field, which part of
+it does this run use, which part of *that* does this rank hold, how many
+channels come out -- and each used to answer them in its own spelling. The DALI
+loader carried ``img_local_shape_x``, the torch dataset carried ``read_shape``
+*and* a block of ``img_*`` aliases written "for compatibility", the synthetic
+loader carried ``read_shape`` alone, and ``get_dataloader`` reconciled them by
+hand into a ``types.SimpleNamespace`` per branch. Three copies of one mapping,
+and nothing anywhere stating what the mapping was.
+
+:class:`DataShapes` is that statement. A loader reports one, ``get_dataloader``
+returns it, and :meth:`makani.utils.driver.Driver._set_data_shapes` reads it.
+
+Shape of the type
+-----------------
+The split is the one ``torch_harmonics`` uses for its grid descriptors: a global
+grid, and a :class:`Shard` describing one rank's piece of it. When
+``GridS2``/``GridShardS2`` reach a tagged release, ``grid_shape`` and ``shard``
+can become those types without anything else moving, and makani inherits their
+quadrature weights and spectral bounds. Until then this stays dependency free
+and deliberately small.
+
+The ``img_shape_x`` style names survive as properties. They are what ``params``
+carries, what configs and checkpoints are written in, and what ``loss.py``,
+``metric.py`` and the preprocessor read. They are a compatibility surface over a
+structured core, not the core itself.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class Shard:
+    """One rank's piece of a decomposed field.
+
+    Named after ``torch_harmonics.GridShardS2``, whose ``shape``, ``lat_offset``
+    and ``lon_offset`` mean the same things, so that adopting it later is a
+    rename rather than a redesign.
+
+    Attributes
+    ----------
+    shape : tuple of int
+        Rows and columns this rank holds.
+    lat_offset, lon_offset : int
+        Where they start in the full field.
+    lats, lons : list of float
+        Coordinates of this rank's points, in degrees.
+    """
+
+    shape: Tuple[int, int]
+    lat_offset: int
+    lon_offset: int
+    lats: List[float] = field(default_factory=list)
+    lons: List[float] = field(default_factory=list)
+
+    @property
+    def nlat(self) -> int:
+        return self.shape[0]
+
+    @property
+    def nlon(self) -> int:
+        return self.shape[1]
+
+
+@dataclass(frozen=True)
+class DataShapes:
+    """The geometry and channel counts of what a loader emits.
+
+    Attributes
+    ----------
+    in_channels, out_channels : sequence of int
+        Channel indices the loader was asked for, in the order it emits them.
+    grid_shape : tuple of int
+        The dataset's own field, before cropping or decomposition.
+    crop_shape, crop_offset : tuple of int
+        The region of it this run uses.
+    shard : Shard
+        The part of that region this rank holds.
+    shard_shape_resampled : tuple of int
+        What the rank emits after subsampling. Reported rather than recomputed:
+        the loader takes a strided slice of a region that may itself start at an
+        offset, which is not always ``ceil(shard.shape / subsampling_factor)``.
+    subsampling_factor : int
+        Decimation applied during the read. When the downsampling layer replaces
+        it this becomes 1 and the ``_resampled`` names go with it.
+    grid_converter : optional
+        Converts the data grid to the model grid. Carried here because the
+        trainers need it and it is settled at the same time as the rest.
+    grid : optional
+        The backend's ``GridSpec``, where the loader has one. An unstructured
+        dataset has no rows and columns, so the flattened accessors raise for it
+        rather than inventing a shape.
+    """
+
+    in_channels: Sequence[int]
+    out_channels: Sequence[int]
+
+    grid_shape: Tuple[int, int]
+    crop_shape: Tuple[int, int]
+    crop_offset: Tuple[int, int]
+    shard: Shard
+    shard_shape_resampled: Tuple[int, int]
+
+    subsampling_factor: int = 1
+    grid_converter: Any = None
+    grid: Any = None
+
+    # ---- derived -----------------------------------------------------------
+
+    @property
+    def is_structured(self) -> bool:
+        """Whether this describes a raster rather than a mesh."""
+        return self.grid is None or getattr(self.grid, "is_structured", True)
+
+    @property
+    def grid_shape_resampled(self) -> Tuple[int, int]:
+        """The full field after subsampling."""
+        return (
+            math.ceil(self.grid_shape[0] / self.subsampling_factor),
+            math.ceil(self.grid_shape[1] / self.subsampling_factor),
+        )
+
+    @property
+    def lat_lon_local(self) -> Tuple[List[float], List[float]]:
+        """This rank's coordinates, under the name the trainers use."""
+        return (self.shard.lats, self.shard.lons)
+
+    # ---- the flattened names params is written in --------------------------
+
+    def _row_column(self, name: str, values, index: int):
+        """One component of a raster quantity, or a refusal for a mesh."""
+        if not self.is_structured:
+            raise AttributeError(
+                f"'{name}' is a row or column of a raster, which this dataset does not have: it is stored on "
+                f"a {getattr(self.grid, 'kind', 'non raster')} grid. Use grid_shape, shard, or the grid itself."
+            )
+        return values[index]
+
+    @property
+    def img_shape_x(self) -> int:
+        return self._row_column("img_shape_x", self.grid_shape, 0)
+
+    @property
+    def img_shape_y(self) -> int:
+        return self._row_column("img_shape_y", self.grid_shape, 1)
+
+    @property
+    def img_crop_shape_x(self) -> int:
+        return self._row_column("img_crop_shape_x", self.crop_shape, 0)
+
+    @property
+    def img_crop_shape_y(self) -> int:
+        return self._row_column("img_crop_shape_y", self.crop_shape, 1)
+
+    @property
+    def img_crop_offset_x(self) -> int:
+        return self._row_column("img_crop_offset_x", self.crop_offset, 0)
+
+    @property
+    def img_crop_offset_y(self) -> int:
+        return self._row_column("img_crop_offset_y", self.crop_offset, 1)
+
+    @property
+    def img_local_shape_x(self) -> int:
+        return self._row_column("img_local_shape_x", self.shard.shape, 0)
+
+    @property
+    def img_local_shape_y(self) -> int:
+        return self._row_column("img_local_shape_y", self.shard.shape, 1)
+
+    @property
+    def img_local_offset_x(self) -> int:
+        return self._row_column("img_local_offset_x", (self.shard.lat_offset, self.shard.lon_offset), 0)
+
+    @property
+    def img_local_offset_y(self) -> int:
+        return self._row_column("img_local_offset_y", (self.shard.lat_offset, self.shard.lon_offset), 1)
+
+    @property
+    def img_local_shape_x_resampled(self) -> int:
+        return self._row_column("img_local_shape_x_resampled", self.shard_shape_resampled, 0)
+
+    @property
+    def img_local_shape_y_resampled(self) -> int:
+        return self._row_column("img_local_shape_y_resampled", self.shard_shape_resampled, 1)
+
+    @property
+    def img_shape_x_resampled(self) -> int:
+        return self._row_column("img_shape_x_resampled", self.grid_shape_resampled, 0)
+
+    @property
+    def img_shape_y_resampled(self) -> int:
+        return self._row_column("img_shape_y_resampled", self.grid_shape_resampled, 1)
+
+    # ---- construction ------------------------------------------------------
+
+    @classmethod
+    def from_loader(cls, loader, grid: Optional[Any] = None, grid_converter: Optional[Any] = None) -> "DataShapes":
+        """Read the geometry off a loader that reports it in tuples.
+
+        The loaders settle the same quantities and used to name them
+        differently; they all carry the tuple form now, so one reader serves
+        every one of them and the spellings have nowhere to diverge again.
+
+        The loader side says ``crop_size``/``crop_anchor``, which is what the
+        backends and both sample sources call them; this type says
+        ``crop_shape``/``crop_offset``, to pair with the shard. That one
+        translation lives here rather than in each loader.
+        """
+        if grid is None:
+            grid = getattr(getattr(loader, "backend", None), "chunk", None)
+        if grid_converter is None:
+            grid_converter = getattr(loader, "grid_converter", None)
+
+        return cls(
+            in_channels=loader.in_channels,
+            out_channels=loader.out_channels,
+            grid_shape=tuple(loader.img_shape),
+            crop_shape=tuple(loader.crop_size),
+            crop_offset=tuple(loader.crop_anchor),
+            shard=Shard(
+                shape=tuple(loader.read_shape),
+                lat_offset=loader.read_anchor[0],
+                lon_offset=loader.read_anchor[1],
+                lats=loader.lat_lon_local[0],
+                lons=loader.lat_lon_local[1],
+            ),
+            shard_shape_resampled=tuple(loader.return_shape),
+            subsampling_factor=loader.subsampling_factor,
+            grid_converter=grid_converter,
+            grid=grid,
+        )

--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -183,32 +183,36 @@ class Driver(metaclass=abc.ABCMeta):
 
         return params
 
-    def _set_data_shapes(self, params, dataset):
+    def _set_data_shapes(self, params, data_shapes):
+        """Copy the loader's geometry into ``params``.
+
+        The rest of the run reads its shapes from ``params`` rather than from the
+        loader, so this is where the two meet. ``data_shapes`` is a
+        :class:`~makani.utils.dataloaders.data_shapes.DataShapes`, which every
+        loader reports in the same form.
         """
-        Routine for setting the shapes correctly
-        """
 
-        params.N_in_channels = len(dataset.in_channels)
-        params.N_out_channels = len(dataset.out_channels)
+        params.N_in_channels = len(data_shapes.in_channels)
+        params.N_out_channels = len(data_shapes.out_channels)
 
-        params.img_shape_x = dataset.img_shape_x
-        params.img_shape_y = dataset.img_shape_y
+        params.img_shape_x = data_shapes.img_shape_x
+        params.img_shape_y = data_shapes.img_shape_y
 
-        params.img_crop_shape_x = dataset.img_crop_shape_x
-        params.img_crop_shape_y = dataset.img_crop_shape_y
-        params.img_crop_offset_x = dataset.img_crop_offset_x
-        params.img_crop_offset_y = dataset.img_crop_offset_y
+        params.img_crop_shape_x = data_shapes.img_crop_shape_x
+        params.img_crop_shape_y = data_shapes.img_crop_shape_y
+        params.img_crop_offset_x = data_shapes.img_crop_offset_x
+        params.img_crop_offset_y = data_shapes.img_crop_offset_y
 
-        params.img_local_shape_x = dataset.img_local_shape_x
-        params.img_local_shape_y = dataset.img_local_shape_y
-        params.img_local_offset_x = dataset.img_local_offset_x
-        params.img_local_offset_y = dataset.img_local_offset_y
+        params.img_local_shape_x = data_shapes.img_local_shape_x
+        params.img_local_shape_y = data_shapes.img_local_shape_y
+        params.img_local_offset_x = data_shapes.img_local_offset_x
+        params.img_local_offset_y = data_shapes.img_local_offset_y
 
-        params.img_local_shape_x_resampled = dataset.img_local_shape_x_resampled
-        params.img_local_shape_y_resampled = dataset.img_local_shape_y_resampled
-        params.img_shape_x_resampled = dataset.img_shape_x_resampled
-        params.img_shape_y_resampled = dataset.img_shape_y_resampled
-        params.subsampling_factor = dataset.subsampling_factor
+        params.img_local_shape_x_resampled = data_shapes.img_local_shape_x_resampled
+        params.img_local_shape_y_resampled = data_shapes.img_local_shape_y_resampled
+        params.img_shape_x_resampled = data_shapes.img_shape_x_resampled
+        params.img_shape_y_resampled = data_shapes.img_shape_y_resampled
+        params.subsampling_factor = data_shapes.subsampling_factor
 
         if (params.subsampling_factor > 1) and (
             (params.img_crop_shape_x != params.img_shape_x) or (params.img_crop_shape_y != params.img_shape_y)

--- a/makani/utils/inference/inferencer.py
+++ b/makani/utils/inference/inferencer.py
@@ -103,10 +103,14 @@ class Inferencer(Driver):
             self.params["enable_synthetic_data"] = False
 
         # the file path is taken from inf_data_path to perform inference on the out of sample dataset
-        self.valid_dataloader, self.valid_dataset, _ = get_dataloader(
+        self.valid_dataloader, self.valid_data_shapes, _ = get_dataloader(
             self.params, self.params.inf_data_path, mode="inference", device=self.device
         )
-        self._set_data_shapes(self.params, self.valid_dataset)
+        self._set_data_shapes(self.params, self.valid_data_shapes)
+
+        # inference addresses samples by index and by time, which is the dataset's
+        # own business rather than anything the shapes describe
+        self.valid_dataset = self.valid_dataloader.dataset
 
         if self.log_to_screen:
             self.logger.info("data loader initialized")

--- a/makani/utils/training/autoencoder_trainer.py
+++ b/makani/utils/training/autoencoder_trainer.py
@@ -87,16 +87,16 @@ class AutoencoderTrainer(Driver):
         if self.log_to_screen:
             self.logger.info(f"Using channel names: {self.params.channel_names}")
             self.logger.info("initializing data loader")
-        self.train_dataloader, self.train_dataset, self.train_sampler = get_dataloader(
+        self.train_dataloader, self.train_data_shapes, self.train_sampler = get_dataloader(
             self.params, self.params.train_data_path, mode="train", device=self.device
         )
-        self.valid_dataloader, self.valid_dataset, self.valid_sampler = get_dataloader(
+        self.valid_dataloader, self.valid_data_shapes, self.valid_sampler = get_dataloader(
             self.params, self.params.valid_data_path, mode="eval", device=self.device
         )
-        self._set_data_shapes(self.params, self.valid_dataset)
+        self._set_data_shapes(self.params, self.valid_data_shapes)
         # obtain the true lon lat grid after cropping and resampling
-        self.lat_global = torch.as_tensor(self.valid_dataset.lat_lon_local[0]).to(self.device)
-        self.lon_global = torch.as_tensor(self.valid_dataset.lat_lon_local[1]).to(self.device)
+        self.lat_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[0]).to(self.device)
+        self.lon_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[1]).to(self.device)
         if comm.get_size("h") > 1:
             self.lat_global = gather_uneven(self.lat_global, 0, "h")
         if comm.get_size("w") > 1:

--- a/makani/utils/training/deterministic_trainer.py
+++ b/makani/utils/training/deterministic_trainer.py
@@ -96,16 +96,16 @@ class Trainer(Driver):
             if self.log_to_screen:
                 self.logger.info(f"Using channel names: {self.params.channel_names}")
                 self.logger.info("initializing data loader")
-            self.train_dataloader, self.train_dataset, self.train_sampler = get_dataloader(
+            self.train_dataloader, self.train_data_shapes, self.train_sampler = get_dataloader(
                 self.params, self.params.train_data_path, mode="train", device=self.device
             )
-            self.valid_dataloader, self.valid_dataset, self.valid_sampler = get_dataloader(
+            self.valid_dataloader, self.valid_data_shapes, self.valid_sampler = get_dataloader(
                 self.params, self.params.valid_data_path, mode="eval", device=self.device
             )
-            self._set_data_shapes(self.params, self.valid_dataset)
+            self._set_data_shapes(self.params, self.valid_data_shapes)
             # obtain the true lon lat grid after cropping and resampling
-            self.lat_global = torch.as_tensor(self.valid_dataset.lat_lon_local[0]).to(self.device)
-            self.lon_global = torch.as_tensor(self.valid_dataset.lat_lon_local[1]).to(self.device)
+            self.lat_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[0]).to(self.device)
+            self.lon_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[1]).to(self.device)
             if comm.get_size("h") > 1:
                 self.lat_global = gather_uneven(self.lat_global, 0, "h")
             if comm.get_size("w") > 1:

--- a/makani/utils/training/ensemble_trainer.py
+++ b/makani/utils/training/ensemble_trainer.py
@@ -98,16 +98,16 @@ class EnsembleTrainer(Trainer):
             if self.log_to_screen:
                 self.logger.info(f"Using channel names: {self.params.channel_names}")
                 self.logger.info("initializing data loader")
-            self.train_dataloader, self.train_dataset, self.train_sampler = get_dataloader(
+            self.train_dataloader, self.train_data_shapes, self.train_sampler = get_dataloader(
                 self.params, self.params.train_data_path, mode="train", device=self.device
             )
-            self.valid_dataloader, self.valid_dataset, self.valid_sampler = get_dataloader(
+            self.valid_dataloader, self.valid_data_shapes, self.valid_sampler = get_dataloader(
                 self.params, self.params.valid_data_path, mode="eval", device=self.device
             )
-            self._set_data_shapes(self.params, self.valid_dataset)
+            self._set_data_shapes(self.params, self.valid_data_shapes)
             # obtain the true lon lat grid after cropping and resampling
-            self.lat_global = torch.as_tensor(self.valid_dataset.lat_lon_local[0]).to(self.device)
-            self.lon_global = torch.as_tensor(self.valid_dataset.lat_lon_local[1]).to(self.device)
+            self.lat_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[0]).to(self.device)
+            self.lon_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[1]).to(self.device)
             if comm.get_size("h") > 1:
                 self.lat_global = gather_uneven(self.lat_global, 0, "h")
             if comm.get_size("w") > 1:

--- a/makani/utils/training/stochastic_trainer.py
+++ b/makani/utils/training/stochastic_trainer.py
@@ -93,16 +93,16 @@ class StochasticTrainer(Driver):
         if self.log_to_screen:
             self.logger.info(f"Using channel names: {self.params.channel_names}")
             self.logger.info("initializing data loader")
-        self.train_dataloader, self.train_dataset, self.train_sampler = get_dataloader(
+        self.train_dataloader, self.train_data_shapes, self.train_sampler = get_dataloader(
             self.params, self.params.train_data_path, mode="train", device=self.device
         )
-        self.valid_dataloader, self.valid_dataset, self.valid_sampler = get_dataloader(
+        self.valid_dataloader, self.valid_data_shapes, self.valid_sampler = get_dataloader(
             self.params, self.params.valid_data_path, mode="eval", device=self.device
         )
-        self._set_data_shapes(self.params, self.valid_dataset)
+        self._set_data_shapes(self.params, self.valid_data_shapes)
         # obtain the true lon lat grid after cropping and resampling
-        self.lat_global = torch.as_tensor(self.valid_dataset.lat_lon_local[0]).to(self.device)
-        self.lon_global = torch.as_tensor(self.valid_dataset.lat_lon_local[1]).to(self.device)
+        self.lat_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[0]).to(self.device)
+        self.lon_global = torch.as_tensor(self.valid_data_shapes.lat_lon_local[1]).to(self.device)
         if comm.get_size("h") > 1:
             self.lat_global = gather_uneven(self.lat_global, 0, "h")
         if comm.get_size("w") > 1:

--- a/tests/test_data_shapes.py
+++ b/tests/test_data_shapes.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the shape descriptor the loaders report.
+
+What used to be three hand-built ``types.SimpleNamespace`` blocks is one type,
+so the mapping from a loader's geometry to the names ``params`` carries is now
+somewhere it can be checked. The failure this guards against is quiet: a field
+crossed with its neighbour -- a crop offset read as a shape, a local extent read
+as a global one -- leaves every shape plausible and the run subtly wrong.
+
+Needs no DALI, no GPU and no dataset.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from makani.utils.dataloaders.data_shapes import DataShapes, Shard
+
+
+def make_loader(**overrides):
+    """A stand-in reporting the tuples every real loader reports."""
+    loader = types.SimpleNamespace(
+        in_channels=[0, 1, 2],
+        out_channels=[0, 1],
+        img_shape=(64, 128),
+        crop_size=(32, 96),
+        crop_anchor=(4, 8),
+        read_shape=(16, 96),
+        read_anchor=(20, 8),
+        return_shape=(8, 48),
+        subsampling_factor=2,
+        lat_lon_local=([1.0, 2.0], [3.0, 4.0]),
+        grid_converter="converter",
+    )
+    for name, value in overrides.items():
+        setattr(loader, name, value)
+    return loader
+
+
+class TestFromLoader(unittest.TestCase):
+    """Reading a loader's geometry into the descriptor."""
+
+    def setUp(self):
+        self.shapes = DataShapes.from_loader(make_loader())
+
+    def test_every_field_comes_from_the_right_place(self):
+        """The whole mapping, asserted field by field.
+
+        Each of these was a line in a namespace literal, and a namespace literal
+        is exactly where a crossed pair hides -- the shapes stay plausible and
+        nothing downstream can tell.
+        """
+        self.assertEqual(self.shapes.grid_shape, (64, 128))
+        self.assertEqual(self.shapes.crop_shape, (32, 96))
+        self.assertEqual(self.shapes.crop_offset, (4, 8))
+        self.assertEqual(self.shapes.shard.shape, (16, 96))
+        self.assertEqual(self.shapes.shard.lat_offset, 20)
+        self.assertEqual(self.shapes.shard.lon_offset, 8)
+        self.assertEqual(self.shapes.shard_shape_resampled, (8, 48))
+        self.assertEqual(self.shapes.subsampling_factor, 2)
+
+    def test_channels_are_carried_in_order(self):
+        self.assertEqual(list(self.shapes.in_channels), [0, 1, 2])
+        self.assertEqual(list(self.shapes.out_channels), [0, 1])
+
+    def test_the_grid_converter_is_carried(self):
+        self.assertEqual(self.shapes.grid_converter, "converter")
+
+    def test_an_override_wins_over_the_loader(self):
+        # the DALI loader holds the converter while its sample source holds the
+        # geometry, so the two come from different objects
+        shapes = DataShapes.from_loader(make_loader(), grid_converter="other")
+        self.assertEqual(shapes.grid_converter, "other")
+
+    def test_the_backend_grid_is_picked_up(self):
+        grid = types.SimpleNamespace(is_structured=True, kind="equiangular")
+        loader = make_loader(backend=types.SimpleNamespace(chunk=grid))
+
+        self.assertIs(DataShapes.from_loader(loader).grid, grid)
+
+    def test_a_loader_without_a_backend_has_no_grid(self):
+        # the synthetic loader has none, and reports a raster all the same
+        shapes = DataShapes.from_loader(make_loader())
+
+        self.assertIsNone(shapes.grid)
+        self.assertTrue(shapes.is_structured)
+
+
+class TestFlattenedNames(unittest.TestCase):
+    """The ``img_shape_x`` surface ``params`` is written in.
+
+    These names are the ones configs and checkpoints carry, so each has to keep
+    meaning what it meant. Asserted individually rather than in a loop, since
+    what is being checked is precisely which component each one names.
+    """
+
+    def setUp(self):
+        self.shapes = DataShapes.from_loader(make_loader())
+
+    def test_global_shape(self):
+        self.assertEqual(self.shapes.img_shape_x, 64)
+        self.assertEqual(self.shapes.img_shape_y, 128)
+
+    def test_crop(self):
+        self.assertEqual(self.shapes.img_crop_shape_x, 32)
+        self.assertEqual(self.shapes.img_crop_shape_y, 96)
+        self.assertEqual(self.shapes.img_crop_offset_x, 4)
+        self.assertEqual(self.shapes.img_crop_offset_y, 8)
+
+    def test_this_rank(self):
+        self.assertEqual(self.shapes.img_local_shape_x, 16)
+        self.assertEqual(self.shapes.img_local_shape_y, 96)
+        self.assertEqual(self.shapes.img_local_offset_x, 20)
+        self.assertEqual(self.shapes.img_local_offset_y, 8)
+
+    def test_resampled(self):
+        self.assertEqual(self.shapes.img_local_shape_x_resampled, 8)
+        self.assertEqual(self.shapes.img_local_shape_y_resampled, 48)
+        self.assertEqual(self.shapes.img_shape_x_resampled, 32)
+        self.assertEqual(self.shapes.img_shape_y_resampled, 64)
+
+    def test_the_global_resampled_shape_rounds_up(self):
+        # a field that does not divide evenly still emits the partial row
+        shapes = DataShapes.from_loader(make_loader(img_shape=(65, 128), subsampling_factor=2))
+        self.assertEqual(shapes.grid_shape_resampled, (33, 64))
+
+    def test_the_local_resampled_shape_is_reported_not_derived(self):
+        """A strided read of an offset region is not ceil(shape / factor).
+
+        Where the rank's block starts decides whether it catches the first
+        sample of the stride, so the loader reports what it will emit rather
+        than having it recomputed from a rule that is right only sometimes.
+        """
+        shapes = DataShapes.from_loader(make_loader(read_shape=(17, 96), return_shape=(8, 48)))
+        self.assertEqual(shapes.img_local_shape_x_resampled, 8)
+
+    def test_lat_lon_local_is_the_shard_coordinates(self):
+        self.assertEqual(self.shapes.lat_lon_local, ([1.0, 2.0], [3.0, 4.0]))
+
+
+class TestUnstructured(unittest.TestCase):
+    """A mesh has no rows and columns, and says so.
+
+    ICON emits an unstructured grid, where ``img_shape_x`` has no meaning. The
+    accessors refuse rather than return the first element of something, because
+    a plausible number here becomes a silently wrong model input.
+    """
+
+    def setUp(self):
+        grid = types.SimpleNamespace(is_structured=False, kind="unstructured")
+        self.shapes = DataShapes.from_loader(make_loader(backend=types.SimpleNamespace(chunk=grid)))
+
+    def test_it_is_not_structured(self):
+        self.assertFalse(self.shapes.is_structured)
+
+    def test_the_flattened_accessors_refuse(self):
+        for name in (
+            "img_shape_x",
+            "img_shape_y",
+            "img_crop_shape_x",
+            "img_local_shape_x",
+            "img_local_offset_y",
+            "img_shape_x_resampled",
+            "img_local_shape_y_resampled",
+        ):
+            with self.subTest(name=name):
+                with self.assertRaises(AttributeError) as ctx:
+                    getattr(self.shapes, name)
+                self.assertIn("unstructured", str(ctx.exception))
+
+    def test_the_structured_free_parts_still_work(self):
+        # what a mesh can answer, it still answers
+        self.assertEqual(list(self.shapes.in_channels), [0, 1, 2])
+        self.assertEqual(self.shapes.lat_lon_local, ([1.0, 2.0], [3.0, 4.0]))
+
+
+class TestShard(unittest.TestCase):
+    """Named after ``torch_harmonics.GridShardS2``, and meaning the same."""
+
+    def test_nlat_and_nlon_are_the_shape(self):
+        shard = Shard(shape=(12, 34), lat_offset=1, lon_offset=2)
+
+        self.assertEqual(shard.nlat, 12)
+        self.assertEqual(shard.nlon, 34)
+
+    def test_coordinates_default_to_empty(self):
+        shard = Shard(shape=(2, 2), lat_offset=0, lon_offset=0)
+
+        self.assertEqual(shard.lats, [])
+        self.assertEqual(shard.lons, [])
+
+
+class TestImmutability(unittest.TestCase):
+
+    def test_the_descriptor_cannot_be_edited_in_place(self):
+        """Settled once, at construction.
+
+        The namespace it replaces was writable, so anything holding it could
+        change what a later reader saw. Freezing it means the shapes a run is
+        configured with are the shapes the loader reported.
+        """
+        shapes = DataShapes.from_loader(make_loader())
+
+        with self.assertRaises(Exception):
+            shapes.grid_shape = (1, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 What this changes
  
  get_dataloader returned three different things depending on the branch it took. For DALI and the synthetic loader it built a types.SimpleNamespace of 17 shape fields by hand; for the
  multifiles path it returned the actual dataset. The trainers and the inferencer both received it as valid_dataset and used it for different purposes — the trainers for shapes, the
  inferencer for shapes and for by-index and by-time lookups.
  
  Underneath, the same geometry was spelled three ways. The DALI loader carried img_local_shape_x; MultifilesDataset carried read_shape and a block of img_* aliases commented "for
  compatibility"; DummyLoader carried read_shape alone. Three copies of one mapping, and nothing anywhere stating what the mapping was.
  
  DataShapes is that statement. A loader reports one, get_dataloader returns it, Driver._set_data_shapes reads it.
  
  Shape of the type
  
  The split is deliberately the one torch_harmonics uses for its grid descriptors: a global grid, and a Shard for one rank's piece of it, with shape, lat_offset and lon_offset named to
  match. When GridS2/GridShardS2 reach a tagged release, grid_shape and shard can become those types without anything else moving — and makani inherits their quadrature weights and
  spectral bounds. Until then this stays dependency free and small.
  
  The img_shape_x names survive as properties. They're what params carries, what configs and checkpoints are written in, and what loss.py, metric.py and preprocessor_helpers.py read;
  turning that into a second API break would buy nothing. They're a compatibility surface over a structured core, not the core itself.
  
  For an unstructured grid — which ICON emits — those accessors raise rather than return the first element of something. A plausible number there becomes a silently wrong model input.

The dual role is gone
  
  get_dataloader now always returns the descriptor. The inferencer takes the real dataset from dataloader.dataset, so its seven by-index and by-time uses are unchanged and now genuinely
  refer to a dataset. The trainers' valid_dataset becomes valid_data_shapes, which is what it always was.
  
  One wrinkle worth knowing for review: torch.utils.data.DataLoader.__setattr__ guards six attributes, dataset among them, and refuses assignment after construction. So the DataLoader
  keeps its own, and only the inference-mode stub is given one explicitly.
  
  Tests
  
  tests/test_data_shapes.py, 20 tests, no DALI or GPU. The whole mapping is asserted field by field, because a namespace literal is exactly where a crossed pair hides — a crop offset
  read as a shape leaves every number plausible and the run subtly wrong. Plus the unstructured refusals, the frozen dataclass, and the case where the local resampled shape genuinely
  isn't ceil(shape / factor).
  
  Not in here
  
  params still carries 17 flattened keys, because configs and checkpoints are written in them. Moving those to tuples is a separate change touching driver.py, loss.py, metric.py,
  preprocessor_helpers.py, stochastic_interpolant.py and the inferencer — worth doing once nothing else is in flight, and cheap now that there's one place the names are produced.
  
  subsampling_factor and the _resampled fields stay until the downsampling layer replaces them, at which point the factor becomes 1 and those names go with it.