### PR TITLE
Tkurth/icon file survey

### DIFF
--- a/makani/utils/dataloaders/backends/icon.py
+++ b/makani/utils/dataloaders/backends/icon.py
@@ -54,10 +54,12 @@ to come from running several workers, which is what the DALI pipeline already
 does.
 """
 
+import datetime as dt
 import glob
 import logging
 import os
-from collections import OrderedDict
+import re
+from collections import Counter, OrderedDict
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import h5py
@@ -141,6 +143,30 @@ def variable_of_file(path: str, candidates: Sequence[str]) -> Optional[str]:
     stem = os.path.splitext(os.path.basename(path))[0]
     matches = [name for name in candidates if stem == name or stem.startswith(name + "_")]
     return max(matches, key=len) if matches else None
+
+
+#: how ICON stamps a file with the period it covers: a full timestamp for the
+#: daily files, a bare year and month for the aggregated ones
+_DATE_PATTERNS = (
+    (re.compile(r"(\d{8})T(\d{6})Z"), "%Y%m%d%H%M%S"),
+    (re.compile(r"_(\d{6})(?=[._]|$)"), "%Y%m"),
+)
+
+
+def date_of_file(path: str) -> Optional[dt.datetime]:
+    """When the period a file covers begins, from its name.
+
+    ``..._20210601T000000Z.nc`` starts at midnight on the first of June;
+    ``..._202106.nc`` is the monthly aggregate and starts at the same place.
+    Returns None when the name carries no date, which is a reason to open the
+    file rather than to guess.
+    """
+    stem = os.path.basename(path)
+    for pattern, fmt in _DATE_PATTERNS:
+        match = pattern.search(stem)
+        if match:
+            return dt.datetime.strptime("".join(match.groups()), fmt).replace(tzinfo=dt.timezone.utc)
+    return None
 
 
 def survey_files(paths: Sequence[str], candidates: Sequence[str]) -> Dict[Optional[str], List[str]]:
@@ -349,6 +375,83 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
                 }
         return found
 
+    def _file_groups(self, files: List[str]) -> List[List[str]]:
+        """Files grouped by the variable their name claims.
+
+        A group shares a level coordinate, a cadence and a file length, which is
+        what lets most of it be described from one member. Files whose name says
+        nothing are each their own group, so nothing is assumed about them.
+        """
+        keep = set(files)
+        groups = []
+        for name, paths in self.survey.items():
+            present = sorted(path for path in paths if path in keep)
+            if not present:
+                continue
+            if name is None:
+                groups.extend([path] for path in present)
+            else:
+                groups.append(present)
+        return groups
+
+    def _inspect_group(self, paths: List[str], grid_uuid: Optional[str]) -> Dict[str, Dict[str, dict]]:
+        """Describe every file of one variable, opening as few as possible.
+
+        The level coordinate, the cadence and the length are properties of the
+        variable rather than of the file, so one member describes them all. Only
+        the sample times differ, and a file stamped with the period it covers
+        says those too -- given that it is the same shape as its neighbours.
+
+        Three things keep that from being a guess:
+
+        * the first and last file are always read, because truncation happens at
+          the ends of a run;
+        * a file whose size differs from the rest of the group is read, since a
+          short file is exactly the one whose times cannot be derived;
+        * what is derived for the last file is checked against what was read
+          from it, and a mismatch abandons the shortcut for the whole group.
+
+        Getting this wrong would be silent -- plausible times attached to the
+        wrong samples -- so the fallback is to open everything, which is what
+        this did before.
+        """
+        opened = {path: self._inspect(path, grid_uuid) for path in {paths[0], paths[-1]}}
+        if len(paths) <= 2:
+            return {path: opened[path] for path in paths}
+
+        dates = {path: date_of_file(path) for path in paths}
+        sizes = {path: os.path.getsize(path) for path in paths}
+        usual_size = Counter(sizes.values()).most_common(1)[0][0]
+
+        first, last = paths[0], paths[-1]
+        reference = opened[first]
+
+        def derived(path) -> Optional[Dict[str, dict]]:
+            """The description a file's name implies, or None if it does not."""
+            if dates[path] is None or dates[first] is None or sizes[path] != usual_size:
+                return None
+            shift = dates[path] - dates[first]
+            return {name: dict(info, times=info["times"] + shift) for name, info in reference.items()}
+
+        # the check: the last file was read, so what its name implies can be
+        # compared against what it actually says
+        predicted = derived(last)
+        trustworthy = predicted is not None and all(
+            np.array_equal(predicted[name]["times"], opened[last][name]["times"]) for name in opened[last]
+        )
+        if not trustworthy:
+            logging.debug("ICON file names do not predict their contents for this group; reading every file")
+            return {path: self._inspect(path, grid_uuid) for path in paths}
+
+        described = {}
+        for path in paths:
+            if path in opened:
+                described[path] = opened[path]
+                continue
+            implied = derived(path)
+            described[path] = implied if implied is not None else self._inspect(path, grid_uuid)
+        return described
+
     def _build_sources(self, files: List[str], grid_uuid: Optional[str]) -> Dict[str, VariableSource]:
         """Collect every variable across every file, in time order.
 
@@ -358,8 +461,12 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
         """
         collected: Dict[Tuple[str, Optional[str]], dict] = {}
 
+        described = {}
+        for group in self._file_groups(files):
+            described.update(self._inspect_group(group, grid_uuid))
+
         for path in files:
-            for name, info in self._inspect(path, grid_uuid).items():
+            for name, info in described[path].items():
                 key = (name, info["level_name"])
                 entry = collected.setdefault(
                     key, {"paths": [], "times": [], "levels": info["levels"], "n_cells": info["n_cells"]}

--- a/makani/utils/dataloaders/backends/icon.py
+++ b/makani/utils/dataloaders/backends/icon.py
@@ -58,13 +58,17 @@ import glob
 import logging
 import os
 from collections import OrderedDict
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import h5py
 import numpy as np
 
+from ..channel_helpers import split_channel_name
 from ..icon_helpers import (
+    accumulated_variables,
+    atmospheric_variables,
     build_icon_channel_groups,
+    surface_variables,
     check_grid_uuid,
     decode_time,
     decode_values,
@@ -78,6 +82,73 @@ from .mesh import MeshChunkMixin
 #: level coordinates ICON writes, and what they mean for a makani channel
 PRESSURE_LEVEL_NAMES = ("plev", "pressure", "lev")
 SURFACE_LEVEL_NAMES = ("height", "height_2", "heightAboveGround", "alt", "altitude", "depth")
+
+
+def _candidate_names(candidates) -> List[str]:
+    """Every variable name in a table entry, flattening summed components."""
+    names = []
+    for candidate in candidates or ():
+        if hasattr(candidate, "name"):
+            names.append(candidate.name)
+        else:
+            # a tuple of components that are summed to form the channel
+            names.extend(component.name for component in candidate)
+    return names
+
+
+def candidate_variable_names(channel_names: Sequence[str]) -> List[str]:
+    """Every ICON variable that could serve one of these channels.
+
+    The alternatives, not the resolved choice: a run asking for ``u500`` may be
+    served by ``u`` or ``ua``, and which one is present is exactly what has not
+    been established yet.
+    """
+    names = set()
+    for channel in channel_names:
+        prefix, level = split_channel_name(channel)
+        if level is not None:
+            names.update(_candidate_names(atmospheric_variables.get(prefix)))
+        else:
+            names.update(_candidate_names(surface_variables.get(channel)))
+            names.update(_candidate_names(accumulated_variables.get(channel)))
+    return sorted(names)
+
+
+def known_variable_names() -> List[str]:
+    """Every ICON variable the channel tables know about.
+
+    Classification uses this rather than the wanted set, so that a file holding
+    a variable no channel asked for is recognised *and skipped*, while a file
+    whose name matches nothing stays a candidate for opening.
+    """
+    names = set()
+    for table in (atmospheric_variables, surface_variables, accumulated_variables):
+        for candidates in table.values():
+            names.update(_candidate_names(candidates))
+    return sorted(names)
+
+
+def variable_of_file(path: str, candidates: Sequence[str]) -> Optional[str]:
+    """Which variable a file holds, from its name, or None if it says nothing.
+
+    ICON names a file after the variable it carries and then decorates it, so
+    ``temp_EXCLAIM_..._20210601T000000Z.nc`` is ``temp``. The catch is that the
+    names nest: ``u_10m_dyamond_...`` starts with ``u_`` as well as ``u_10m_``,
+    and reading ten metre wind as upper air ``u`` would be silent. The longest
+    match is therefore the answer, and only names we are actually looking for
+    are candidates at all.
+    """
+    stem = os.path.splitext(os.path.basename(path))[0]
+    matches = [name for name in candidates if stem == name or stem.startswith(name + "_")]
+    return max(matches, key=len) if matches else None
+
+
+def survey_files(paths: Sequence[str], candidates: Sequence[str]) -> Dict[Optional[str], List[str]]:
+    """Group files by the variable their name claims, before opening any of them."""
+    survey: Dict[Optional[str], List[str]] = {}
+    for path in paths:
+        survey.setdefault(variable_of_file(path, candidates), []).append(path)
+    return survey
 
 
 class VariableSource(NamedTuple):
@@ -223,6 +294,38 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
                     return name, pressure_levels_in_hpa(handle[name])
                 return name, values
         return None, None
+
+    def _files_worth_opening(self, files: List[str], enable_logging: bool) -> List[str]:
+        """Drop the files whose name says they hold a variable nothing asked for.
+
+        A run reads a dozen variables out of a directory that may hold many
+        more, and every file it opens costs a round trip to the metadata server
+        before it says anything. Names are used only to *skip*: which variable a
+        file really holds, and whether it is on pressure levels, is still
+        decided by looking inside the ones that survive.
+
+        A file whose name matches nothing known is kept rather than dropped,
+        and if no wanted variable is named at all the survey is ignored
+        entirely -- so a dataset that does not follow the convention costs what
+        it always did rather than quietly losing data.
+        """
+        wanted = set(candidate_variable_names(self.channel_names))
+        self.survey = survey_files(files, known_variable_names())
+
+        named = {name for name in self.survey if name is not None}
+        if not named & wanted:
+            # the names say nothing we recognise, so they are no guide at all
+            return files
+
+        keep = [path for name in named & wanted for path in self.survey[name]]
+        # a name that matches nothing known could still hold a wanted variable
+        keep += self.survey.get(None, [])
+
+        skipped = len(files) - len(keep)
+        if skipped and enable_logging:
+            logging.info(f"Skipping {skipped} of {len(files)} ICON files: no channel asks for what they hold")
+
+        return sorted(keep)
 
     def _inspect(self, path: str, grid_uuid: Optional[str]) -> Dict[str, dict]:
         """What one file contributes: its variables, their times and levels."""
@@ -389,6 +492,7 @@ class IconBackend(MeshChunkMixin, DatasetBackend):
         if enable_logging:
             logging.info(f"Getting file stats from {len(files)} ICON files, grid {os.path.basename(self.grid_file)}")
 
+        files = self._files_worth_opening(files, enable_logging)
         sources = self._build_sources(files, getattr(self, "grid_uuid", None))
         self.channel_plan = self._resolve_channels(sources)
 

--- a/tests/test_data_backends.py
+++ b/tests/test_data_backends.py
@@ -71,6 +71,7 @@ from makani.utils.dataloaders.backends import (
 from makani.utils.dataloaders.backends.base import GridSpec
 from makani.utils.dataloaders.backends.factory import detect_backend
 from makani.utils.dataloaders.backends.makani_hdf5 import contiguous_slices
+from makani.utils.dataloaders.backends.icon import survey_files, variable_of_file
 from makani.utils.dataloaders.backends.mesh import block_of_rank, coalesce_runs
 
 from .testutils import (
@@ -1065,6 +1066,112 @@ class TestIconDiscovery(_IconFixture):
     def test_detected_from_the_extension(self):
         self.assertEqual(detect_backend(self.data_path), "icon")
         self.assertIsInstance(self._backend(), IconBackend)
+
+
+class TestVariableOfFile(unittest.TestCase):
+    """Reading a variable name off an ICON filename.
+
+    ICON names a file after the variable and then decorates it, which is enough
+    to tell -- before opening anything -- whether a run has any use for it. What
+    makes it delicate is that the names nest.
+    """
+
+    CANDIDATES = ["u", "v", "temp", "t_2m", "u_10m", "v_10m", "qv", "qg"]
+
+    def test_the_leading_name_is_the_variable(self):
+        self.assertEqual(variable_of_file("temp_EXCLAIM_atm_1_3_20210601T000000Z.nc", self.CANDIDATES), "temp")
+
+    def test_the_longest_match_wins(self):
+        """``u_10m`` is not ``u``.
+
+        Ten metre wind and upper air wind are both plausible fields of the same
+        name, so a prefix match that stops at the first candidate reads one as
+        the other and nothing downstream can tell.
+        """
+        self.assertEqual(variable_of_file("u_10m_dyamond_atm_7_202106.nc", self.CANDIDATES), "u_10m")
+        self.assertEqual(variable_of_file("u_EXCLAIM_atm_1_4_20210601T000000Z.nc", self.CANDIDATES), "u")
+
+    def test_a_name_with_underscores_is_matched_whole(self):
+        # splitting on the separator would give "t", which is a different table entry
+        self.assertEqual(variable_of_file("t_2m_dyamond_atm_3_202106.nc", self.CANDIDATES), "t_2m")
+
+    def test_a_prefix_has_to_end_at_a_separator(self):
+        # "temperature" is not "temp": matching mid-word would claim files that
+        # belong to a variable nobody asked about
+        self.assertIsNone(variable_of_file("temperature_of_something.nc", ["temp"]))
+
+    def test_an_unknown_name_says_nothing(self):
+        self.assertIsNone(variable_of_file("icon_grid_0056_R02B10_G.nc", self.CANDIDATES))
+
+    def test_the_survey_groups_by_variable(self):
+        survey = survey_files(["u_a_20210601.nc", "u_a_20210602.nc", "u_10m_b.nc", "mystery.nc"], self.CANDIDATES)
+
+        self.assertEqual(survey["u"], ["u_a_20210601.nc", "u_a_20210602.nc"])
+        self.assertEqual(survey["u_10m"], ["u_10m_b.nc"])
+        self.assertEqual(survey[None], ["mystery.nc"])
+
+
+class TestIconFileSurvey(_IconFixture):
+    """Which files discovery opens, and which it leaves alone.
+
+    A run reads a dozen variables from a directory that may hold far more, and
+    on a parallel filesystem every open is a round trip before the file says
+    anything. Names are used to skip work; what a file actually holds is still
+    read from inside it.
+    """
+
+    def _corrupt(self, name):
+        """A file that cannot be opened, so that opening it is detectable."""
+        path = os.path.join(self.data_path, name)
+        with open(path, "wb") as handle:
+            handle.write(b"not an hdf5 file at all")
+        self.addCleanup(os.remove, path)
+        return path
+
+    def test_a_file_for_an_unwanted_variable_is_never_opened(self):
+        """The assertion is the corruption: opening it would raise.
+
+        ``qg`` is a real ICON variable and no channel here asks for it, so
+        discovery should recognise the name and pass over the file without
+        looking inside.
+        """
+        self._corrupt("qg_EXCLAIM_coupled_dyamond_atm_1_3_20210601T000000Z.nc")
+
+        metadata = self._backend().discover()
+
+        self.assertEqual(len(metadata.timestamps), self.n_samples)
+
+    def test_a_file_with_an_unrecognised_name_is_still_opened(self):
+        """Skipping is a guess; reading is not.
+
+        A dataset whose naming does not follow the convention has to keep
+        working, so a name that matches nothing known is opened rather than
+        assumed to be irrelevant.
+        """
+        self._corrupt("mystery_file.nc")
+
+        with self.assertRaises(Exception):
+            self._backend().discover()
+
+    def test_the_survey_records_what_it_found(self):
+        backend = self._backend()
+        backend.discover()
+
+        self.assertIn("temp", backend.survey)
+        self.assertIn("u", backend.survey)
+        self.assertIn("t_2m", backend.survey)
+
+    def test_reading_is_unaffected_by_the_skipping(self):
+        # the same values as without the extra file present
+        self._corrupt("qs_EXCLAIM_coupled_dyamond_atm_1_3_20210601T000000Z.nc")
+        backend = self._backend()
+        backend.discover()
+
+        values = backend.read(0, slice(0, 1), np.array([0]))[0, 0]
+        expected = icon_expected_field("u", 0, ICON_PLEV_HPA.index(500))
+
+        finite = ~np.isnan(expected)
+        self.assertTrue(compare_arrays("u500 with a skipped file present", values[finite], expected[finite], atol=1e-5))
 
 
 class TestIconReading(_IconFixture):

--- a/tests/test_data_backends.py
+++ b/tests/test_data_backends.py
@@ -71,7 +71,7 @@ from makani.utils.dataloaders.backends import (
 from makani.utils.dataloaders.backends.base import GridSpec
 from makani.utils.dataloaders.backends.factory import detect_backend
 from makani.utils.dataloaders.backends.makani_hdf5 import contiguous_slices
-from makani.utils.dataloaders.backends.icon import survey_files, variable_of_file
+from makani.utils.dataloaders.backends.icon import date_of_file, survey_files, variable_of_file
 from makani.utils.dataloaders.backends.mesh import block_of_rank, coalesce_runs
 
 from .testutils import (
@@ -1109,6 +1109,128 @@ class TestVariableOfFile(unittest.TestCase):
         self.assertEqual(survey["u"], ["u_a_20210601.nc", "u_a_20210602.nc"])
         self.assertEqual(survey["u_10m"], ["u_10m_b.nc"])
         self.assertEqual(survey[None], ["mystery.nc"])
+
+
+class TestDateOfFile(unittest.TestCase):
+    """Reading the period a file covers off its name."""
+
+    def test_a_daily_file_carries_a_full_timestamp(self):
+        self.assertEqual(
+            date_of_file("temp_EXCLAIM_coupled_dyamond_atm_1_3_20210601T000000Z.nc"),
+            dt.datetime(2021, 6, 1, tzinfo=dt.timezone.utc),
+        )
+
+    def test_an_aggregated_file_carries_a_year_and_month(self):
+        self.assertEqual(date_of_file("t_2m_dyamond_atm_3_202106.nc"), dt.datetime(2021, 6, 1, tzinfo=dt.timezone.utc))
+
+    def test_the_date_is_utc(self):
+        # the times inside the files are UTC, so a naive date here would shift
+        # every derived axis by the reader's own timezone
+        self.assertEqual(date_of_file("u_atm_20210602T000000Z.nc").utcoffset(), dt.timedelta(0))
+
+    def test_a_name_without_a_date_says_nothing(self):
+        self.assertIsNone(date_of_file("mystery.nc"))
+        self.assertIsNone(date_of_file("icon_grid_0056_R02B10_G.nc"))
+
+
+class TestIconDerivedTimes(unittest.TestCase):
+    """Describing a variable's files without opening all of them.
+
+    The level coordinate, the cadence and the length belong to the variable
+    rather than to the file, so one member describes them all; only the sample
+    times differ, and the name says those. What makes it safe rather than a
+    guess is that the ends are always read, an odd sized file is always read,
+    and what the names predict for the last file is checked against what that
+    file actually says.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        # four days, so that two files are neither the first nor the last
+        cls.data_path, cls.grid_path, cls.n_samples, cls.channel_names = init_icon_dataset(cls.tmpdir.name, n_days=4)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    def _backend(self, **overrides):
+        kwargs = dict(grid_file=self.grid_path, channel_names=list(self.channel_names))
+        kwargs.update(overrides)
+        return get_backend(self.data_path, **kwargs)
+
+    def _scramble(self, name, keep_size=True):
+        """Make a file unreadable, optionally without changing its size."""
+        path = os.path.join(self.data_path, name)
+        with open(path, "rb") as handle:
+            original = handle.read()
+
+        def restore():
+            with open(path, "wb") as handle:
+                handle.write(original)
+
+        self.addCleanup(restore)
+
+        garbage = b"x" * (len(original) if keep_size else 128)
+        with open(path, "wb") as handle:
+            handle.write(garbage)
+        return path
+
+    def test_the_times_are_the_ones_the_files_hold(self):
+        # the shortcut has to produce exactly what reading every file would
+        metadata = self._backend().discover()
+
+        self.assertEqual(len(metadata.timestamps), self.n_samples)
+        self.assertEqual(metadata.timestamps[0], dt.datetime(2021, 6, 1, tzinfo=dt.timezone.utc))
+        self.assertEqual(metadata.timestamps[-1], dt.datetime(2021, 6, 4, 21, tzinfo=dt.timezone.utc))
+        steps = {
+            (metadata.timestamps[i + 1] - metadata.timestamps[i]).total_seconds() / 3600
+            for i in range(len(metadata.timestamps) - 1)
+        }
+        self.assertEqual(steps, {3.0})
+
+    def test_a_middle_file_is_not_opened(self):
+        """The assertion is that unreadable content goes unnoticed.
+
+        Day three is neither end and is the usual size, so its times come from
+        its name. Scrambling its contents while keeping its size is invisible to
+        a reader that never opens it -- and fatal to one that does.
+        """
+        self._scramble("temp_dyamond_atm_1_3_20210603T000000Z.nc")
+
+        metadata = self._backend().discover()
+
+        self.assertEqual(len(metadata.timestamps), self.n_samples)
+
+    def test_an_odd_sized_file_is_opened(self):
+        """Size is what says a file is the same shape as its neighbours.
+
+        A short file is exactly the one whose times cannot be derived, so it has
+        to be read -- and here reading it fails, which is the evidence.
+        """
+        self._scramble("temp_dyamond_atm_1_3_20210603T000000Z.nc", keep_size=False)
+
+        with self.assertRaises(Exception):
+            self._backend().discover()
+
+    def test_the_ends_are_always_read(self):
+        # truncation happens at the ends of a run, so they are never derived
+        self._scramble("temp_dyamond_atm_1_3_20210604T000000Z.nc")
+
+        with self.assertRaises(Exception):
+            self._backend().discover()
+
+    def test_reading_agrees_with_the_derived_axis(self):
+        # a sample whose times were derived still reads the right data
+        backend = self._backend()
+        backend.discover()
+
+        # sample 16 is the first of the third day, whose file was described by name
+        values = backend.read(2, slice(0, 1), np.array([2]))[0, 0]
+        expected = icon_expected_field("temp", 0, ICON_PLEV_HPA.index(500))
+
+        finite = ~np.isnan(expected)
+        self.assertTrue(compare_arrays("t500 on a derived day", values[finite], expected[finite], atol=1e-5))
 
 
 class TestIconFileSurvey(_IconFixture):


### PR DESCRIPTION
optimized file survey for ICON by incorporating file name metadata and doing spot checks, reduces the numbers of files need to be read by ~25x.