### PR TITLE
Install libssl-dev in the AWS image

### DIFF
--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -20,7 +20,7 @@ ARG DLFW_VERSION=25.12
 FROM nvcr.io/nvidia/pytorch:${DLFW_VERSION}-py3
 
 # update repo info
-RUN apt update -y && apt install -y libibmad5
+RUN apt update -y && apt install -y libibmad5 libssl-dev
 
 # upgrade cmake
 RUN apt remove cmake -y && \


### PR DESCRIPTION
s2n-tls and aws-c-cal both link against OpenSSL's libcrypto, and the image never installed its headers. The build worked anyway for as long as the base image happened to ship them; on nvcr.io/nvidia/pytorch 26.06 it does not, and s2n-tls fails at configure time with

    Could NOT find crypto (missing: crypto_LIBRARY crypto_INCLUDE_DIR)

aws-c-cal, two steps later, needs the same headers and would have failed next. Declaring the dependency in the first apt install covers both and makes the image independent of what the next base bump happens to include.

Only the AWS image needs this: the plain Dockerfile builds nothing that links against libcrypto.