### PR TITLE
Replace eval-based plot functors with an op registry

### DIFF
--- a/makani/utils/driver.py
+++ b/makani/utils/driver.py
@@ -980,10 +980,10 @@ class Driver(metaclass=abc.ABCMeta):
         """
         from makani.utils import visualize
 
-        # Functors reference channels symbolically via {name} placeholders. The
-        # visualizer resolves them against channel_names, ships only the
-        # referenced channels to the renderer subprocesses, and rewrites each
-        # functor to index into the stripped tensor.
+        # Plot entries name an op from visualize.PLOT_OPS and reference channels
+        # symbolically. The visualizer resolves the names against channel_names,
+        # ships only the referenced channels to the renderer subprocesses, and
+        # rewrites the channel lists to index into the stripped tensor.
         cnames = params.channel_names
         plot_list = []
 
@@ -991,7 +991,8 @@ class Driver(metaclass=abc.ABCMeta):
             plot_list.append(
                 {
                     "name": "windspeed_uv10",
-                    "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+                    "op": "magnitude",
+                    "channels": ["u10m", "v10m"],
                     "diverging": False,
                 }
             )
@@ -1000,7 +1001,8 @@ class Driver(metaclass=abc.ABCMeta):
             plot_list.append(
                 {
                     "name": "geopotential_z500",
-                    "functor": "lambda x: x[{z500}, ...]",
+                    "op": "select",
+                    "channels": ["z500"],
                     "diverging": False,
                 }
             )
@@ -1009,7 +1011,8 @@ class Driver(metaclass=abc.ABCMeta):
             plot_list.append(
                 {
                     "name": "specific_humidity_q100",
-                    "functor": "lambda x: x[{q100}, ...]",
+                    "op": "select",
+                    "channels": ["q100"],
                     "diverging": False,
                 }
             )

--- a/makani/utils/visualize.py
+++ b/makani/utils/visualize.py
@@ -15,7 +15,7 @@
 
 import os
 import io
-import re
+from collections import namedtuple
 from typing import Optional
 import multiprocessing as mp
 import numpy as np
@@ -26,24 +26,57 @@ import wandb
 
 import torch
 
-_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+
+def _op_select(x, channels):
+    return x[channels[0], ...]
+
+
+def _op_magnitude(x, channels):
+    return np.sqrt(sum(np.square(x[c, ...]) for c in channels))
+
+
+_PlotOp = namedtuple("_PlotOp", ["func", "min_channels", "max_channels"])
+
+# Registry of the operations a plot list entry may request. Entries name an op
+# from this table rather than carrying lambda source, which keeps plot lists
+# pure data: they are never evaluated as code, wherever they come from.
+PLOT_OPS = {
+    "select": _PlotOp(_op_select, 1, 1),
+    "magnitude": _PlotOp(_op_magnitude, 1, None),
+}
+
+
+def _check_plot_item(item):
+    """Validate a plot list entry against :data:`PLOT_OPS`, returning its channel list."""
+    op = item["op"]
+    if op not in PLOT_OPS:
+        raise ValueError(f"unknown plot op {op!r}, expected one of {sorted(PLOT_OPS)}")
+
+    channels = list(item["channels"])
+    spec = PLOT_OPS[op]
+    if len(channels) < spec.min_channels or (spec.max_channels is not None and len(channels) > spec.max_channels):
+        upper = "any number of" if spec.max_channels is None else spec.max_channels
+        raise ValueError(f"plot op {op!r} takes {spec.min_channels} to {upper} channels, got {len(channels)}")
+
+    return channels
 
 
 def resolve_plot_list(plot_list, channel_names):
     """
-    Resolve symbolic ``{name}`` channel references in functor strings.
+    Resolve symbolic channel references in a plot list.
 
-    Each functor string in ``plot_list`` may reference channels by name using
-    ``{name}`` placeholders (e.g. ``"lambda x: x[{z500}, ...]"``). This walks
-    the list, collects the union of referenced channels in first-seen order,
-    rewrites each functor to index into a stripped tensor of just those
-    channels, and returns the new plot list together with the indices into the
-    original ``channel_names`` layout.
+    Each entry of ``plot_list`` is a dict naming an op from :data:`PLOT_OPS` and
+    the channels it applies to, e.g.
+    ``{"name": "z500", "op": "select", "channels": ["z500"], "diverging": False}``.
+    This walks the list, collects the union of referenced channels in first-seen
+    order, rewrites each entry's channels to indices into a stripped tensor
+    holding just those channels, and returns the new plot list together with the
+    indices into the original ``channel_names`` layout.
     """
     ordered_refs = []
     seen = set()
     for item in plot_list:
-        for name in _PLACEHOLDER_RE.findall(item["functor"]):
+        for name in _check_plot_item(item):
             if name not in seen:
                 seen.add(name)
                 ordered_refs.append(name)
@@ -53,13 +86,13 @@ def resolve_plot_list(plot_list, channel_names):
     channel_indices = []
     for name in ordered_refs:
         if name not in channel_names:
-            raise ValueError(f"functor references channel {name!r} which is not in channel_names")
+            raise ValueError(f"plot list references channel {name!r} which is not in channel_names")
         channel_indices.append(channel_names.index(name))
 
     new_plot_list = []
     for item in plot_list:
         new_item = dict(item)
-        new_item["functor"] = _PLACEHOLDER_RE.sub(lambda m: str(stripped_index[m.group(1)]), item["functor"])
+        new_item["channels"] = [stripped_index[name] for name in item["channels"]]
         new_plot_list.append(new_item)
 
     return new_plot_list, channel_indices
@@ -233,20 +266,28 @@ def _draw_progress_bar(image, progress: float, y_pos: float = 0.5, margin: int =
 
 
 def visualize_field(
-    tag, func_string, prediction, target, lat, lon, scale, bias, diverging, progress: Optional[float] = None
+    tag, op, channels, prediction, target, lat, lon, scale, bias, diverging, progress: Optional[float] = None
 ):
+    """
+    Render a prediction/ground-truth comparison for a single field.
+
+    ``op`` names an entry of :data:`PLOT_OPS` and ``channels`` are the channel
+    indices it is applied to, after ``prediction`` and ``target`` have been
+    unscaled with ``scale`` and ``bias``. Returns ``(tag, image)``.
+    """
     torch.cuda.nvtx.range_push("visualize_field")
 
-    # get func handle:
-    func_handle = eval(func_string)
+    # look the op up in the registry; unknown ops are an error, never code to run
+    channels = _check_plot_item({"op": op, "channels": channels})
+    func_handle = PLOT_OPS[op].func
 
     # unscale:
     pred = scale * prediction + bias
     targ = scale * target + bias
 
-    # apply functor:
-    pred = func_handle(pred)
-    targ = func_handle(targ)
+    # apply op:
+    pred = func_handle(pred, channels)
+    targ = func_handle(targ, channels)
 
     # generate image
     image = plot_comparison(
@@ -269,7 +310,16 @@ def visualize_field(
 
 
 class VisualizationWrapper(object):
-    "Handles visualization during training"
+    """
+    Handles visualization during training.
+
+    ``plot_list`` is a list of dicts, one per rendered field, each with a
+    ``name``, an ``op`` naming an entry of :data:`PLOT_OPS`, the ``channels``
+    that op applies to, and a ``diverging`` flag selecting the colormap. If
+    ``channel_names`` is given, channels are named and resolved against it;
+    otherwise they must already be integer indices into the tensors passed to
+    :meth:`add`.
+    """
 
     def __init__(
         self,
@@ -289,13 +339,17 @@ class VisualizationWrapper(object):
         self.path = path
         self.prefix = prefix
 
-        # If channel_names is provided, resolve {name} placeholders in functor
-        # strings to indices into a stripped tensor that contains only the
+        # If channel_names is provided, resolve the symbolic channel names in the
+        # plot list to indices into a stripped tensor that contains only the
         # referenced channels. This avoids shipping unused channels to the
-        # renderer subprocesses.
+        # renderer subprocesses. Without channel_names the plot list is expected
+        # to index the incoming tensors directly.
         if channel_names is not None:
             self.plot_list, self.channel_indices = resolve_plot_list(plot_list, channel_names)
         else:
+            for item in plot_list:
+                if not all(isinstance(c, (int, np.integer)) for c in _check_plot_item(item)):
+                    raise ValueError("without channel_names, plot list channels must be integer indices")
             self.plot_list = plot_list
             self.channel_indices = None
 
@@ -329,13 +383,13 @@ class VisualizationWrapper(object):
 
         for item in self.plot_list:
             field_name = item["name"]
-            func_string = item["functor"]
             plot_diverge = item["diverging"]
             self.requests.append(
                 self.executor.submit(
                     visualize_field,
                     (tag, field_name),
-                    func_string,
+                    item["op"],
+                    item["channels"],
                     pred,
                     tar,
                     self.lat,

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -85,39 +85,27 @@ class TestPlotComparison(unittest.TestCase):
 class TestVisualizeField(unittest.TestCase):
     def setUp(self):
         rng = np.random.default_rng(1)
-        self.pred = rng.standard_normal((16, 32)).astype(np.float32)
-        self.target = rng.standard_normal((16, 32)).astype(np.float32)
+        self.pred = rng.standard_normal((2, 16, 32)).astype(np.float32)
+        self.target = rng.standard_normal((2, 16, 32)).astype(np.float32)
 
     def test_token_round_trip(self):
         tag = ("epoch_0", "u10m")
-        out_tag, img = visualize_field(tag, "lambda x: x", self.pred, self.target, None, None, 1.0, 0.0, False)
+        out_tag, img = visualize_field(tag, "select", [0], self.pred, self.target, None, None, 1.0, 0.0, False)
         self.assertEqual(out_tag, tag)
         self.assertIsInstance(img, Image.Image)
 
-    def test_functor_is_applied(self):
-        # Use a constant functor; both pred and target collapse to the same value,
-        # so plot_comparison must not raise (vmin == vmax edge case is tolerated by matplotlib).
-        tag = ("t", "f")
-        _, img = visualize_field(
-            tag,
-            "lambda x: np.zeros_like(x)",
-            self.pred,
-            self.target,
-            None,
-            None,
-            1.0,
-            0.0,
-            False,
-        )
+    def test_magnitude_op_is_applied(self):
+        tag = ("t", "windspeed")
+        _, img = visualize_field(tag, "magnitude", [0, 1], self.pred, self.target, None, None, 1.0, 0.0, False)
         self.assertIsInstance(img, Image.Image)
 
     def test_scale_bias_applied(self):
-        # Verify scale*x + bias is computed before the functor by using a functor
-        # whose output depends linearly on the input mean.
+        # Verify scale*x + bias is computed before the op is applied.
         tag = ("t", "f")
         _, img = visualize_field(
             tag,
-            "lambda x: x",
+            "select",
+            [1],
             self.pred,
             self.target,
             None,
@@ -127,6 +115,14 @@ class TestVisualizeField(unittest.TestCase):
             diverging=False,
         )
         self.assertIsInstance(img, Image.Image)
+
+    def test_unknown_op_raises(self):
+        with self.assertRaises(ValueError):
+            visualize_field(("t", "f"), "eval", [0], self.pred, self.target, None, None, 1.0, 0.0, False)
+
+    def test_wrong_channel_count_raises(self):
+        with self.assertRaises(ValueError):
+            visualize_field(("t", "f"), "select", [0, 1], self.pred, self.target, None, None, 1.0, 0.0, False)
 
 
 @unittest.skipUnless(_have_visualize_deps, "matplotlib and/or PIL are not installed")
@@ -166,71 +162,75 @@ class TestResolvePlotList(unittest.TestCase):
     """Unit tests for the symbolic {name}-placeholder resolver."""
 
     def test_single_channel_substituted(self):
-        plot_list = [{"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False}]
+        plot_list = [{"name": "z500", "op": "select", "channels": ["z500"], "diverging": False}]
         new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500", "q100"])
         self.assertEqual(indices, [2])
         # only one referenced channel => it lands at stripped index 0
-        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
-        # non-functor fields are preserved
+        self.assertEqual(new_list[0]["channels"], [0])
+        # remaining fields are preserved
         self.assertEqual(new_list[0]["name"], "z500")
+        self.assertEqual(new_list[0]["op"], "select")
         self.assertEqual(new_list[0]["diverging"], False)
 
-    def test_multiple_placeholders_in_single_functor(self):
+    def test_multiple_channels_in_single_entry(self):
         plot_list = [
             {
                 "name": "wind",
-                "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+                "op": "magnitude",
+                "channels": ["u10m", "v10m"],
                 "diverging": False,
             }
         ]
         new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500"])
         self.assertEqual(indices, [0, 1])
-        self.assertEqual(
-            new_list[0]["functor"],
-            "lambda x: np.sqrt(np.square(x[0, ...]) + np.square(x[1, ...]))",
-        )
+        self.assertEqual(new_list[0]["channels"], [0, 1])
 
     def test_first_seen_ordering(self):
         # channels referenced in a non-source order: stripped indices follow
         # first-appearance order in the plot_list, not the original layout.
         plot_list = [
-            {"name": "a", "functor": "lambda x: x[{q100}, ...]", "diverging": False},
-            {"name": "b", "functor": "lambda x: x[{u10m}, ...]", "diverging": False},
+            {"name": "a", "op": "select", "channels": ["q100"], "diverging": False},
+            {"name": "b", "op": "select", "channels": ["u10m"], "diverging": False},
         ]
         new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m", "z500", "q100"])
         # q100 seen first -> stripped index 0 -> original index 3
         # u10m seen second -> stripped index 1 -> original index 0
         self.assertEqual(indices, [3, 0])
-        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
-        self.assertEqual(new_list[1]["functor"], "lambda x: x[1, ...]")
+        self.assertEqual(new_list[0]["channels"], [0])
+        self.assertEqual(new_list[1]["channels"], [1])
 
     def test_duplicate_references_dedup(self):
         plot_list = [
-            {"name": "a", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
-            {"name": "b", "functor": "lambda x: x[{z500}, ...] * 2", "diverging": False},
+            {"name": "a", "op": "select", "channels": ["z500"], "diverging": False},
+            {"name": "b", "op": "magnitude", "channels": ["z500"], "diverging": False},
         ]
         new_list, indices = resolve_plot_list(plot_list, ["u10m", "z500"])
         self.assertEqual(indices, [1])
-        self.assertEqual(new_list[0]["functor"], "lambda x: x[0, ...]")
-        self.assertEqual(new_list[1]["functor"], "lambda x: x[0, ...] * 2")
-
-    def test_no_placeholders_returns_empty_indices(self):
-        plot_list = [{"name": "raw", "functor": "lambda x: x", "diverging": False}]
-        new_list, indices = resolve_plot_list(plot_list, ["u10m", "v10m"])
-        self.assertEqual(indices, [])
-        self.assertEqual(new_list[0]["functor"], "lambda x: x")
+        self.assertEqual(new_list[0]["channels"], [0])
+        self.assertEqual(new_list[1]["channels"], [0])
 
     def test_unknown_channel_raises(self):
-        plot_list = [{"name": "bad", "functor": "lambda x: x[{nonexistent}, ...]", "diverging": False}]
+        plot_list = [{"name": "bad", "op": "select", "channels": ["nonexistent"], "diverging": False}]
+        with self.assertRaises(ValueError):
+            resolve_plot_list(plot_list, ["u10m", "v10m"])
+
+    def test_unknown_op_raises(self):
+        plot_list = [{"name": "bad", "op": "exec", "channels": ["u10m"], "diverging": False}]
+        with self.assertRaises(ValueError):
+            resolve_plot_list(plot_list, ["u10m", "v10m"])
+
+    def test_wrong_channel_count_raises(self):
+        plot_list = [{"name": "bad", "op": "select", "channels": ["u10m", "v10m"], "diverging": False}]
         with self.assertRaises(ValueError):
             resolve_plot_list(plot_list, ["u10m", "v10m"])
 
     def test_does_not_mutate_input(self):
-        original = "lambda x: x[{z500}, ...]"
-        plot_list = [{"name": "z500", "functor": original, "diverging": False}]
+        original = ["z500"]
+        plot_list = [{"name": "z500", "op": "select", "channels": original, "diverging": False}]
         resolve_plot_list(plot_list, ["z500"])
-        # input dict's functor string should be unchanged
-        self.assertEqual(plot_list[0]["functor"], original)
+        # input dict's channel list should be unchanged
+        self.assertEqual(plot_list[0]["channels"], ["z500"])
+        self.assertEqual(original, ["z500"])
 
 
 @unittest.skipUnless(_have_visualize_deps and _have_moviepy, "matplotlib, PIL, or moviepy is not installed")
@@ -238,9 +238,10 @@ class TestVisualizationWrapper(unittest.TestCase):
     """End-to-end smoke test for the multiprocess visualization pipeline."""
 
     def _make_wrapper(self, num_workers=1):
+        # no channel_names => channels are direct indices into the incoming tensors
         plot_list = [
-            {"name": "u10m", "functor": "lambda x: x", "diverging": False},
-            {"name": "t2m", "functor": "lambda x: x", "diverging": True},
+            {"name": "u10m", "op": "select", "channels": [0], "diverging": False},
+            {"name": "t2m", "op": "select", "channels": [1], "diverging": True},
         ]
         return VisualizationWrapper(
             log_to_wandb=False,
@@ -254,7 +255,7 @@ class TestVisualizationWrapper(unittest.TestCase):
             num_workers=num_workers,
         )
 
-    def _add_frames(self, wrapper, n_frames=3, shape=(16, 32)):
+    def _add_frames(self, wrapper, n_frames=3, shape=(2, 16, 32)):
         rng = np.random.default_rng(2)
         for i in range(n_frames):
             pred = rng.standard_normal(shape).astype(np.float32)
@@ -308,8 +309,8 @@ class TestVisualizationWrapper(unittest.TestCase):
         wrapper = self._make_wrapper()
         try:
             rng = np.random.default_rng(3)
-            pred = rng.standard_normal((8, 16)).astype(np.float32)
-            target = rng.standard_normal((8, 16)).astype(np.float32)
+            pred = rng.standard_normal((2, 8, 16)).astype(np.float32)
+            target = rng.standard_normal((2, 8, 16)).astype(np.float32)
             wrapper.add(tag="0", prediction=pred, target=target)
             # two entries in plot_list => two submitted requests
             self.assertEqual(len(wrapper.requests), 2)
@@ -321,10 +322,11 @@ class TestVisualizationWrapper(unittest.TestCase):
         plot_list = [
             {
                 "name": "wind",
-                "functor": "lambda x: np.sqrt(np.square(x[{u10m}, ...]) + np.square(x[{v10m}, ...]))",
+                "op": "magnitude",
+                "channels": ["u10m", "v10m"],
                 "diverging": False,
             },
-            {"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
+            {"name": "z500", "op": "select", "channels": ["z500"], "diverging": False},
         ]
         scale = np.arange(len(channel_names), dtype=np.float32) + 1.0  # [1, 2, 3, 4, 5]
         bias = np.arange(len(channel_names), dtype=np.float32) * 10.0  # [0, 10, 20, 30, 40]
@@ -340,11 +342,8 @@ class TestVisualizationWrapper(unittest.TestCase):
         )
         try:
             self.assertEqual(wrapper.channel_indices, [0, 1, 2])
-            self.assertEqual(
-                wrapper.plot_list[0]["functor"],
-                "lambda x: np.sqrt(np.square(x[0, ...]) + np.square(x[1, ...]))",
-            )
-            self.assertEqual(wrapper.plot_list[1]["functor"], "lambda x: x[2, ...]")
+            self.assertEqual(wrapper.plot_list[0]["channels"], [0, 1])
+            self.assertEqual(wrapper.plot_list[1]["channels"], [2])
             np.testing.assert_array_equal(wrapper.scale, np.array([1.0, 2.0, 3.0]))
             np.testing.assert_array_equal(wrapper.bias, np.array([0.0, 10.0, 20.0]))
         finally:
@@ -353,8 +352,8 @@ class TestVisualizationWrapper(unittest.TestCase):
     def test_channel_names_path_runs_end_to_end(self):
         channel_names = ["u10m", "v10m", "z500", "q100", "t2m"]
         plot_list = [
-            {"name": "z500", "functor": "lambda x: x[{z500}, ...]", "diverging": False},
-            {"name": "q100", "functor": "lambda x: x[{q100}, ...]", "diverging": True},
+            {"name": "z500", "op": "select", "channels": ["z500"], "diverging": False},
+            {"name": "q100", "op": "select", "channels": ["q100"], "diverging": True},
         ]
         with tempfile.TemporaryDirectory() as tmp:
             cwd = os.getcwd()


### PR DESCRIPTION
Description:
  
  First of a series of fixes from the security review.
  
  visualize_field built its callable by running eval() on a lambda source string carried in the plot list. The strings themselves are hardcoded in driver.py, so nothing user-controlled
  reaches eval today — but visualize_field and VisualizationWrapper are public entry points that execute whatever functor string a caller hands them. Sourcing a plot list from YAML, which
  is a natural thing to want, would have turned that into code injection.
  
  Plot list entries are now pure data. Each names an op from a registry and lists the channels it applies to:
  
  {"name": "windspeed_uv10", "op": "magnitude", "channels": ["u10m", "v10m"], "diverging": False}
  {"name": "geopotential_z500", "op": "select", "channels": ["z500"], "diverging": False}
  
  PLOT_OPS holds the allowed operations with their channel arity — select (exactly one channel) and magnitude (sqrt of the sum of squares over one or more). Those cover every plot the
  driver currently emits; more can be added to the registry as they're needed.
  
  resolve_plot_list keeps doing what it did — collect referenced channels in first-seen order, return their indices in the original layout so only those channels are shipped to the
  renderer subprocesses — but rewrites channel lists rather than substituting indices into source strings. Both the resolver and visualize_field validate the op name and channel count, so
  a bad entry raises ValueError instead of executing. The string form existed because lambdas aren't picklable across the spawn executor; an op name and an index list pickle fine, so
  that constraint is gone.
  
  Compatibility: breaking change to the plot_list format for anyone calling VisualizationWrapper directly. All in-tree callers (the four trainers) go through driver.init_visualizer, which
  is updated. Without channel_names, channels must be integer indices.
  
  Testing: tests/test_visualize.py converted to the new format, with added cases for unknown ops and wrong channel counts in both the resolver and the renderer. Full file passes.